### PR TITLE
Performance improvement for Redis::Distributed.del

### DIFF
--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -379,7 +379,7 @@ class Redis
     def hset(key, field, value)
       node_for(key).hset(key, field, value)
     end
-
+    
     def hget(key, field)
       node_for(key).hget(key, field)
     end
@@ -404,12 +404,24 @@ class Redis
       node_for(key).hvals(key)
     end
 
+    def hmget(key, *fields)
+      node_for(key).hmget(key, *fields)
+    end
+
+    def mapped_hmget(key, *fields)
+      node_for(key).mapped_hmget(key, *fields)
+    end
+
     def hgetall(key)
       node_for(key).hgetall(key)
     end
 
     def hmset(key, *attrs)
       node_for(key).hmset(key, *attrs)
+    end
+
+    def mapped_hmset(key, hash)
+      node_for(key).hmset(key, *hash.to_a.flatten)
     end
 
     def hincrby(key, field, increment)

--- a/test/lint/hashes.rb
+++ b/test/lint/hashes.rb
@@ -88,3 +88,20 @@ test "HINCRBY" do |r|
   assert "2" == r.hget("foo", "f1")
 end
 
+test "MAPPED_HMSET" do |r|
+  r.mapped_hmset("mhmset", {"f1" => "s1", "f2" => "s2"})
+  
+  assert({"f1" => "s1", "f2" => "s2"} == r.hgetall("mhmset"))
+end
+
+test "HMGET" do |r|
+  r.hmset("hmget", "foo1", "bar1", "foo2", "bar2")
+
+  assert(["bar1", "bar2"] == r.hmget("hmget", "foo1", "foo2"))
+end
+
+test "MAPPED_HMGET" do |r|
+  r.hmset("mhmget", "foo1", "bar1", "foo2", "bar2")
+
+  assert({"foo1"=>"bar1", "foo2"=>"bar2"} == r.mapped_hmget("mhmget", "foo1", "foo2"))
+end


### PR DESCRIPTION
Hello,

We're currently using Redis::Distributed in a production environment and ran into a small performance bug with the current workflow for the del method. Currently del will iterate through all of the nodes and delete the keys, this can slow down performance when running in an environment with many redis nodes and you only need to delete a single key.

I've adjusted the del call to only delete the key from the appropriate node and created a new function, del_each_node, which keeps the existing functionality and will iterate through all of the nodes and delete the keys.

Thank you,
Julian
