### PR TITLE
Added a note about thread_safe operation to the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -111,6 +111,15 @@ You can use `MULTI/EXEC` to run arbitrary commands in an atomic fashion:
       redis.incr "baz"
     end
 
+## Multithreaded Operation
+
+To use redis safely in a multithreaded environment, be sure to initialize the client with :thread_safe=>true
+
+    Redis.new(:thread_safe=>true)
+
+See the tests and benchmarks for examples.
+
+
 ## More info
 
 Check the [Redis Command Reference](http://code.google.com/p/redis/wiki/CommandReference) or check the tests to find out how to use this client.


### PR DESCRIPTION
It's just a couple lines of documentation, but I think it's important enough to bubble up to the top level README. Getting this wrong can be extremely problematic...

Thanks,
Ben
