### PR TITLE
added #mapped_hmset, #hmget and #mapped_hmget to the distributed client

### DIFF
--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -406,6 +406,18 @@ class Redis
       node_for(key).hmset(key, *attrs)
     end
 
+    def mapped_hmset(key, hash)
+      node_for(key).hmset(key, *hash.to_a.flatten)
+    end
+
+    def hmget(key, *fields)
+      node_for(key).hmget(key, *fields)
+    end
+
+    def mapped_hmget(key, *fields)
+      Hash[*fields.zip(hmget(key, *fields)).flatten]
+    end
+
     def hincrby(key, field, increment)
       node_for(key).hincrby(key, field, increment)
     end

--- a/test/commands_on_hashes_test.rb
+++ b/test/commands_on_hashes_test.rb
@@ -19,28 +19,3 @@ test "HSETNX" do |r|
 
   assert "s2" == r.hget("foo", "f1")
 end
-
-test "HMGET" do |r|
-  r.hset("foo", "f1", "s1")
-  r.hset("foo", "f2", "s2")
-  r.hset("foo", "f3", "s3")
-
-  assert ["s2", "s3"] == r.hmget("foo", "f2", "f3")
-end
-
-test "HMGET mapped" do |r|
-  r.hset("foo", "f1", "s1")
-  r.hset("foo", "f2", "s2")
-  r.hset("foo", "f3", "s3")
-
-  assert({"f1" => "s1"} == r.mapped_hmget("foo", "f1"))
-  assert({"f1" => "s1", "f2" => "s2"} == r.mapped_hmget("foo", "f1", "f2"))
-end
-
-test "Mapped HMSET" do |r|
-  r.mapped_hmset("foo", :f1 => "s1", :f2 => "s2")
-
-  assert "s1" == r.hget("foo", "f1")
-  assert "s2" == r.hget("foo", "f2")
-end
-

--- a/test/lint/hashes.rb
+++ b/test/lint/hashes.rb
@@ -74,6 +74,30 @@ test "HMSET with invalid arguments" do |r|
   end
 end
 
+test "Mapped HMSET" do |r|
+  r.mapped_hmset("foo", :f1 => "s1", :f2 => "s2")
+
+  assert "s1" == r.hget("foo", "f1")
+  assert "s2" == r.hget("foo", "f2")
+end
+
+test "HMGET" do |r|
+  r.hset("foo", "f1", "s1")
+  r.hset("foo", "f2", "s2")
+  r.hset("foo", "f3", "s3")
+
+  assert ["s2", "s3"] == r.hmget("foo", "f2", "f3")
+end
+
+test "HMGET mapped" do |r|
+  r.hset("foo", "f1", "s1")
+  r.hset("foo", "f2", "s2")
+  r.hset("foo", "f3", "s3")
+
+  assert({"f1" => "s1"} == r.mapped_hmget("foo", "f1"))
+  assert({"f1" => "s1", "f2" => "s2"} == r.mapped_hmget("foo", "f1", "f2"))
+end
+
 test "HINCRBY" do |r|
   r.hincrby("foo", "f1", 1)
 


### PR DESCRIPTION
I assume these were commands just not added to the distributed client when Redis introduced them?
