### PR TITLE
don't propagate unnecessary delete commands

### DIFF
--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -55,7 +55,11 @@ class Redis
     end
 
     def del(*keys)
-      Array(keys.inject(0) { |acc, key| acc += node_for(key).del(key) })
+      if keys.size > nodes.size
+        on_each_node :del, *keys
+      else
+        Array(keys.inject(0) { |acc, key| acc += node_for(key).del(key) })
+      end
     end
 
     def type(key)

--- a/test/distributed_commands_on_value_types_test.rb
+++ b/test/distributed_commands_on_value_types_test.rb
@@ -14,14 +14,16 @@ test "DEL" do |r|
   r.set "foo", "s1"
   r.set "bar", "s2"
   r.set "baz", "s3"
+  r.set "boo", "s4"
+  r.set "bam", "s5"
 
-  assert ["bar", "baz", "foo"] == r.keys("*").sort
+  assert ["bam", "bar", "baz", "boo", "foo"] == r.keys("*").sort
 
   assert [1] == r.del("foo")
 
-  assert ["bar", "baz"] == r.keys("*").sort
+  assert ["bam", "bar", "baz", "boo"] == r.keys("*").sort
 
-  assert [2] == r.del("bar", "baz")
+  assert [4] == r.del("bam", "bar", "baz", "boo")
 
   assert [] == r.keys("*").sort
 end


### PR DESCRIPTION
This patch makes sure delete commands are only send to the nodes that actually store the respective keys in the distributed client (don't try to delete all keys on all nodes).
