### PR TITLE
Added zrevrangebyscore method and tests.

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -328,6 +328,15 @@ class Redis
     @client.call(:zrevrange, key, start, stop, *command.to_a)
   end
 
+  def zrevrangebyscore(key, max, min, options = {})
+    command = CommandOptions.new(options) do |c|
+      c.splat :limit
+      c.bool  :with_scores
+    end
+
+    @client.call(:zrevrangebyscore, key, max, min, *command.to_a)
+  end
+
   def zremrangebyscore(key, min, max)
     @client.call(:zremrangebyscore, key, min, max)
   end

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -350,6 +350,10 @@ class Redis
       node_for(key).zrangebyscore(key, min, max, options)
     end
 
+    def zrevrangebyscore(key, max, min, options = {})
+      node_for(key).zrevrangebyscore(key, max, min, options)
+    end
+
     def zcard(key)
       node_for(key).zcard(key)
     end

--- a/test/lint/sorted_sets.rb
+++ b/test/lint/sorted_sets.rb
@@ -72,6 +72,14 @@ test "ZRANGEBYSCORE" do |r|
   assert ["s2", "s3"] == r.zrangebyscore("foo", 2, 3)
 end
 
+test "ZREVRANGEBYSCORE" do |r|
+  r.zadd "foo", 1, "s1"
+  r.zadd "foo", 2, "s2"
+  r.zadd "foo", 3, "s3"
+  
+  assert ["s3", "s2"] == r.zrevrangebyscore("foo", 3, 2)
+end
+
 test "ZRANGEBYSCORE with LIMIT" do |r|
   r.zadd "foo", 1, "s1"
   r.zadd "foo", 2, "s2"
@@ -83,6 +91,17 @@ test "ZRANGEBYSCORE with LIMIT" do |r|
   assert ["s3", "s4"] == r.zrangebyscore("foo", 2, 4, :limit => [1, 2])
 end
 
+test "ZREVRANGEBYSCORE with LIMIT" do |r|
+  r.zadd "foo", 1, "s1"
+  r.zadd "foo", 2, "s2"
+  r.zadd "foo", 3, "s3"
+  r.zadd "foo", 4, "s4"
+
+  assert ["s4"] == r.zrevrangebyscore("foo", 4, 2, :limit => [0, 1])
+  assert ["s3"] == r.zrevrangebyscore("foo", 4, 2, :limit => [1, 1])
+  assert ["s3", "s2"] == r.zrevrangebyscore("foo", 4, 2, :limit => [1, 2])
+end
+
 test "ZRANGEBYSCORE with WITHSCORES" do |r|
   r.zadd "foo", 1, "s1"
   r.zadd "foo", 2, "s2"
@@ -91,6 +110,16 @@ test "ZRANGEBYSCORE with WITHSCORES" do |r|
 
   assert ["s2", "2"] == r.zrangebyscore("foo", 2, 4, :limit => [0, 1], :with_scores => true)
   assert ["s3", "3"] == r.zrangebyscore("foo", 2, 4, :limit => [1, 1], :with_scores => true)
+end
+
+test "ZREVRANGEBYSCORE with WITHSCORES" do |r|
+  r.zadd "foo", 1, "s1"
+  r.zadd "foo", 2, "s2"
+  r.zadd "foo", 3, "s3"
+  r.zadd "foo", 4, "s4"
+
+  assert ["s4", "4"] == r.zrevrangebyscore("foo", 4, 2, :limit => [0, 1], :with_scores => true)
+  assert ["s3", "3"] == r.zrevrangebyscore("foo", 4, 2, :limit => [1, 1], :with_scores => true)
 end
 
 test "ZCARD" do |r|


### PR DESCRIPTION
Hey guys, I'm not sure what your policy is on adding commands that are only available after a certain version of Redis, but I added support for the zrevrangebyscore method and added a bunch of tests for its functionality. According to the new docs on the command, http://redis.io/commands/zrevrangebyscore, it's functionality that exists starting with Redis 2.1.6.

Let me know if there's a specific way that this should be handled and I can work on that. Thanks in advance.
