### PR TITLE
Added Gemfile for anyone wanting to use bundler to manage dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source :rubygems
+
+group :test do
+	gem 'cutest'
+end
+
+# WARNING: using the built-in Timeout class which is known to have issues when used for opening connections. Install the SystemTimer gem if you want to make sure the Redis client will not hang.
+# gem 'SystemTimer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,10 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    cutest (1.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cutest


### PR DESCRIPTION
I left a note in the Gemfile about the SystemTimer gem. I figured this isn't necessarily a requirement for running redis-rb.
