### PR TITLE
Redis::Connector#write fails with Errno::EINVAL

### DIFF
--- a/lib/redis/connection.rb
+++ b/lib/redis/connection.rb
@@ -42,8 +42,7 @@ class Redis
     COMMAND_DELIMITER = "\r\n"
 
     def write(command)
-      @sock.write(build_command(*command).join(COMMAND_DELIMITER))
-      @sock.write(COMMAND_DELIMITER)
+      @sock.write(build_command(*command).join(COMMAND_DELIMITER) + COMMAND_DELIMITER)
     end
 
     def build_command(name, *args)


### PR DESCRIPTION
Using redis-rb v2.1.1, redis-namespace v0.8.0 and resque v1.10.0 on FreeBSD, we often get an Errno::EINVAL
 when trying to have Resque enqueue something. I have not been able to debug any lower than what you see in this stacktrace: https://gist.github.com/794778

Since Redis::Connector#write always failed on the 2nd write to @sock, I chose to merge the strings together and write everything just once. It seems to work :-)
