### PR TITLE
Support for Unix domain sockets with Redis 2.2

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -5,8 +5,15 @@ class Redis
     attr :connection
 
     def initialize(options = {})
-      @host = options[:host] || "127.0.0.1"
-      @port = (options[:port] || 6379).to_i
+      if options[:path]
+        @mode = :unix
+        @path = options[:path]
+      else
+        @mode = :tcp
+        @host = options[:host] || "127.0.0.1"
+        @port = (options[:port] || 6379).to_i
+      end
+
       @db = (options[:db] || 0).to_i
       @timeout = (options[:timeout] || 5).to_i
       @password = options[:password]
@@ -15,7 +22,7 @@ class Redis
     end
 
     def connect
-      connect_to(@host, @port)
+      connect_to
       call(:auth, @password) if @password
       call(:select, @db) if @db != 0
       self
@@ -129,9 +136,13 @@ class Redis
       end
     end
 
-    def connect_to(host, port)
+    def connect_to
       with_timeout(@timeout) do
-        connection.connect(host, port)
+        if @mode == :unix
+          connection.connect_unix(@path)
+        else
+          connection.connect(@host, @port)
+        end
       end
 
       # If the timeout is set we set the low level socket options in order
@@ -140,7 +151,8 @@ class Redis
       self.timeout = @timeout
 
     rescue Errno::ECONNREFUSED
-      raise Errno::ECONNREFUSED, "Unable to connect to Redis on #{host}:#{port}"
+      location = @mode == :unix ? @path : "#{host}:#{port}"
+      raise Errno::ECONNREFUSED, "Unable to connect to Redis on #{location}"
     end
 
     def timeout=(timeout)

--- a/lib/redis/connection.rb
+++ b/lib/redis/connection.rb
@@ -19,6 +19,10 @@ class Redis
       @sock.setsockopt Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1
     end
 
+    def connect_unix(path)
+      @sock = UNIXSocket.new("/tmp/redis.sock")
+    end
+
     def disconnect
       @sock.close
     rescue

--- a/test/lint/internals.rb
+++ b/test/lint/internals.rb
@@ -27,6 +27,12 @@ test "Connection timeout" do
   end
 end
 
+test "Connecting to UNIX domain socket" do
+  assert_nothing_raised do
+    Redis.new(OPTIONS.merge(:path => "/tmp/redis.sock")).ping
+  end
+end
+
 test "Recovers from failed commands" do |r, _|
   # See http://github.com/ezmobius/redis-rb/issues#issue/28
 


### PR DESCRIPTION
The upcoming Redis 2.2 adds support for Unix domain sockets. I have implemented redis-rb support for this in the attached patch. 

You can now connect to a Unix domain socket instead of a regular TCP socket by adding a `:path => "/path/to/redis.sock"` to the options argument. In case both address/port and domain socket path are supplied the domain socket gets precedence, because they are supposed to be faster.

I also added a test case for connecting to a domain socket.
