### PR TITLE
Passing multiple args as an array

### DIFF
--- a/lib/redis/connection/pure.rb
+++ b/lib/redis/connection/pure.rb
@@ -59,7 +59,7 @@ class Redis
       command = []
       command << "*#{args.size}"
 
-      args.each do |arg|
+      args.flatten.each do |arg|
         arg = arg.to_s
         command << "$#{string_size arg}"
         command << arg


### PR DESCRIPTION
Hi,
I came across a problem, when trying to perform a set operation specifying the keys as an array, e.g.:
    keys = ['some:key1', 'some:key2']
    Redis.new.sunion keys
won't work, whereas:
    Redis.new.sunion 'some:key1', 'some:key2'
will. This is slightly against the _args semantics and is caused by prepending the command to that array. 
Thus I made a miniscule fix flattening the whole args array in Redis::Connection#build_command (could've been done at a higher level, but I see you guys are modyfing call__ methods quite intensively so I didn't want to mess). 
Please feel free to pull my changes :)
Cheers, 
Maciek
P.S. That's my first Ruby patch so please forgive me if I did something wrong :)
