### PR TITLE
Support for EVALSHA

### DIFF
--- a/benchmarking/scripting.rb
+++ b/benchmarking/scripting.rb
@@ -1,0 +1,65 @@
+# Run with
+#
+#   $ ruby -Ilib benchmarking/scripting.rb
+#
+
+require "benchmark"
+require "redis"
+
+r = Redis.new
+
+shuffle_list = <<LUA
+local type = redis('type',KEYS[1])
+if type.ok ~= 'list' then return {err = "Key is not a list"} end
+local len = redis('llen',KEYS[1])
+for i=0,len-1 do
+local r = (math.random(len))-1
+local a = redis("lindex",KEYS[1],i)
+local b = redis("lindex",KEYS[1],r)
+redis("lset",KEYS[1],i,b)
+redis("lset",KEYS[1],r,a)
+end
+return len
+LUA
+
+
+n = (ARGV.shift || 1000).to_i
+
+Benchmark.bmbm do |x|
+  
+  r.del(:mylist)
+  (0..10).each{|x| r.lpush(:mylist,x)}
+  
+  x.report("eval") do
+    n.times do |i|
+      r.eval(shuffle_list,1,:mylist)
+    end
+  end
+  
+  
+  r.del(:mylist)
+  (0..10).each{|x| r.lpush(:mylist,x)}
+  
+  x.report("evalsha") do
+    n.times do |i|
+      r.evalsha(shuffle_list,1,:mylist)
+    end
+  end
+  
+  
+  r.del(:mylist)
+  (0..10).each{|x| r.lpush(:mylist,x)}
+  
+  x.report("ruby") do
+    n.times do
+      len = r.llen(:mylist)    
+      len.times do |i|
+        ran = rand(len)
+        a = r.lindex(:mylist, i)
+        b = r.lindex(:mylist, ran)
+        r.lset(:mylist, i, b)
+        r.lset(:mylist, ran, a)
+      end
+    end
+  end
+end

--- a/examples/scripting.rb
+++ b/examples/scripting.rb
@@ -1,0 +1,17 @@
+require 'redis'
+
+r = Redis.new
+increx = <<LUA
+if redis("exists",KEYS[1]) == 1
+then
+return redis("incr",KEYS[1])
+else
+return nil
+end
+LUA
+
+r.del(:counter)
+puts r.eval(increx,1,:counter)
+puts r.exists(:counter)
+r.set(:counter,10)
+puts r.eval(increx,1,:counter)

--- a/test/scripting.rb
+++ b/test/scripting.rb
@@ -1,0 +1,30 @@
+# encoding: UTF-8
+
+require File.expand_path("./helper", File.dirname(__FILE__))
+
+INCREX = <<LUA
+  if redis("exists",KEYS[1]) == 1
+  then
+  return redis("incr",KEYS[1])
+  else
+  return nil
+  end
+LUA
+
+
+setup do
+  init Redis.new(OPTIONS)
+end
+
+test "EVALSHA" do |r|
+  assert nil == r.evalsha(INCREX, 1,:counter)
+  r.set(:counter,10)
+  assert 11 == r.evalsha(INCREX, 1,:counter)
+end
+
+test "EVALSHA should raise non related exceptions" do |r|
+  assert_raise RuntimeError do
+    r.evalsha(INCREX, 1)
+  end  
+end
+


### PR DESCRIPTION
This commit adds support for the EVALSHA command, introduced in the scripting branch of redis. Passing the script to the `evalsha` method (of redis-rb) feels a bit wrong, but for fast connections the normal `eval` runs a bit faster - check the supplied benchmark. 
Due to this I did not want to make EVALSHA default for every EVAL call.
