### PR TITLE
Minor cleanups and test improvements

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -1072,7 +1072,7 @@ class Redis
 
   def inspect
     synchronize do
-      "#<Redis client v#{Redis::VERSION} connected to #{id} (Redis v#{info["redis_version"]})>"
+      "#<Redis client v#{Redis::VERSION}, driver #{@client.connection.name} connected to #{id} (Redis v#{info["redis_version"]})>"
     end
   end
 

--- a/lib/redis/connection/hiredis.rb
+++ b/lib/redis/connection/hiredis.rb
@@ -5,6 +5,11 @@ require "timeout"
 class Redis
   module Connection
     class Hiredis
+
+      def name
+        "hiredis C Client"
+      end
+
       def initialize
         @connection = ::Hiredis::Connection.new
       end

--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -13,6 +13,10 @@ class Redis
       DOLLAR   = "$".freeze
       ASTERISK = "*".freeze
 
+      def name
+        "Pure Ruby"
+      end
+
       def initialize
         @sock = nil
       end

--- a/lib/redis/connection/synchrony.rb
+++ b/lib/redis/connection/synchrony.rb
@@ -8,6 +8,10 @@ class Redis
     class RedisClient < EventMachine::Connection
       include EventMachine::Deferrable
 
+      def name
+        "EM-Synchrony"
+      end
+
       def post_init
         @req = nil
         @connected = false

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -659,7 +659,7 @@ class Redis
       node_info = nodes.map do |node|
         "#{node.id} (Redis v#{node.info['redis_version']})"
       end
-      "#<Redis client v#{Redis::VERSION} connected to #{node_info.join(', ')}>"
+      "#<Redis client v#{Redis::VERSION}, driver Distributed connected to #{node_info.join(', ')}>"
     end
 
   protected

--- a/test/internals_test.rb
+++ b/test/internals_test.rb
@@ -16,7 +16,7 @@ $TEST_PIPELINING = true
 load File.expand_path("./lint/internals.rb", File.dirname(__FILE__))
 
 test "provides a meaningful inspect" do |r, _|
-  assert "#<Redis client v#{Redis::VERSION} connected to redis://127.0.0.1:6379/15 (Redis v#{r.info["redis_version"]})>" == r.inspect
+  assert "#<Redis client v#{Redis::VERSION}, driver Pure Ruby connected to redis://127.0.0.1:6379/15 (Redis v#{r.info["redis_version"]})>" == r.inspect
 end
 
 test "Redis.current" do
@@ -35,7 +35,7 @@ test "Timeout" do
   end
 end
 
-# Don't use assert_raise because Timeour::Error in 1.8 inherits
+# Don't use assert_raise because Timeout::Error in 1.8 inherits
 # Exception instead of StandardError (on 1.9).
 test "Connection timeout" do
   # EM immediately raises CONNREFUSED
@@ -141,7 +141,7 @@ end
 # Using a mock server in a thread doesn't work here (possibly because blocking
 # socket ops, raw socket timeouts and Ruby's thread scheduling don't mix).
 test "Bubble EAGAIN without retrying" do
-  cmd = %{(sleep 0.3; echo "+PONG\r\n") | nc -l 6380}
+  cmd = %{(sleep 1.5; echo "+PONG\r\n") | nc -l 6380}
   IO.popen(cmd) do |_|
     sleep 0.1 # Give nc a little time to start listening
     redis = Redis.connect(:port => 6380, :timeout => 0.1)
@@ -157,4 +157,3 @@ test "Bubble EAGAIN without retrying" do
     end
   end
 end
-

--- a/test/redis_mock.rb
+++ b/test/redis_mock.rb
@@ -13,6 +13,7 @@ module RedisMock
     # This raises an exception in the thread calling @server.accept which
     # in turn will cause the thread to terminate.
     def shutdown
+      @server.shutdown if @server
       @server.close if @server
     rescue => ex
       $stderr.puts "Error closing mock server: #{ex.message}" if VERBOSE
@@ -73,7 +74,7 @@ module RedisMock
         yield
 
       ensure
-        server.shutdown
+        server.shutdown if server
       end
     end
   end

--- a/test/test.conf
+++ b/test/test.conf
@@ -1,4 +1,5 @@
 dir ./test/db
+unixsocket /tmp/redis.sock
 pidfile ./redis.pid
 port 6379
 timeout 300


### PR DESCRIPTION
Added driver information to client inspect strings for better debugging.  Cleaned up some broken tests, including enabling unix socket testing.  Fixed a documentation spelling error.  NOTE: final netcat based test in the internals suite still not working properly (Ubuntu 11), not raising EAGAIN.  Might be due to timeout not being set properly in clients?
