### PR TITLE
Allow subscription to an array of channels

### DIFF
--- a/lib/redis/subscribe.rb
+++ b/lib/redis/subscribe.rb
@@ -42,6 +42,7 @@ class Redis
   protected
 
     def subscription(start, stop, channels, block)
+			channels.flatten!
       sub = Subscription.new(&block)
 
       begin

--- a/test/publish_subscribe_test.rb
+++ b/test/publish_subscribe_test.rb
@@ -6,6 +6,23 @@ setup do
   init Redis.new(OPTIONS)
 end
 
+test "SUBSCRIBE to an array of channels" do |r|
+  listening = false
+	@channels = []
+
+  wire = Wire.new do
+    r.subscribe(['foo', 'bar']) do |on|
+      on.subscribe do |channel, total|
+				@channels << channel
+				r.unsubscribe if channel == 'bar'
+      end
+    end
+  end
+
+  wire.join(1)
+  assert ['foo', 'bar'] == @channels 
+end
+
 test "SUBSCRIBE and UNSUBSCRIBE" do |r|
   listening = false
 


### PR DESCRIPTION
One couldn't subscribe to multiple channels in a array, by flatten the channels array before sending it of it's possible. Test included.
