### PR TITLE
add unsplatted _array form for variadic ZADD/ZREM, SADD/SREM and L/RPUSH for Redis 2.4

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -363,6 +363,13 @@ class Redis
       @client.call [:rpush, key, *values]
     end
   end
+  
+  # Append an array of values to a list.
+  def rpush_array(key, values)
+    synchronize do
+      @client.call [:rpush, key, *values]
+    end
+  end
 
   # Append a value to a list, only if the list exists.
   def rpushx(key, value)
@@ -373,6 +380,13 @@ class Redis
 
   # Prepend one or more values to a list.
   def lpush(key, *values)
+    synchronize do
+      @client.call [:lpush, key, *values]
+    end
+  end
+  
+  # Prepend an array of values to a list.
+  def lpush_array(key, values)
     synchronize do
       @client.call [:lpush, key, *values]
     end
@@ -467,6 +481,20 @@ class Redis
       else
         rv
       end
+    end
+  end
+
+  # Add an array of members to a set.
+  def sadd_array(key, members)
+    synchronize do
+      @client.call [:sadd, key, *members]
+    end
+  end
+
+  # Remove an array of members from a set.
+  def srem_array(key, members)
+    synchronize do
+      @client.call [:srem, key, *members]
     end
   end
 
@@ -565,6 +593,22 @@ class Redis
       else
         rv
       end
+    end
+  end
+
+  # Add an array of members to a sorted set, or update the score for members
+  # that already exist.  args is a list of score, member pairs, [s1, m1, s2, m2, ...]
+  def zadd_array(key, args)
+    raise "wrong number of arguments" unless args.size % 2 == 0
+    synchronize do
+      @client.call [:zadd, key, *args]
+    end
+  end
+  
+  # Remove one or more members from a sorted set.
+  def zrem_array(key, members)
+    synchronize do
+      @client.call [:zrem, key, *members]
     end
   end
 

--- a/test/commands_on_lists_test.rb
+++ b/test/commands_on_lists_test.rb
@@ -8,6 +8,18 @@ end
 
 load './test/lint/lists.rb'
 
+test "RPUSH" do |r|
+  assert r.rpush_array( "foo", ["s1", "s2","s3"] ) == 3
+  assert r.rpush_array( "foo", ["s1", "s2","s3"] ) == 6
+  assert r.lrange( "foo", 0, -1 ) == ["s1", "s2","s3", "s1", "s2","s3"]
+end
+
+test "LPUSH" do |r|
+  assert r.lpush_array( "foo", ["s1", "s2","s3"] ) == 3
+  assert r.lpush_array( "foo", ["s1", "s2","s3"] ) == 6
+  assert r.lrange( "foo", 0, -1 ) == ["s3", "s2","s1", "s3", "s2","s1"]
+end
+
 test "RPUSHX" do |r|
   r.rpushx "foo", "s1"
   r.rpush "foo", "s2"

--- a/test/commands_on_sets_test.rb
+++ b/test/commands_on_sets_test.rb
@@ -8,6 +8,21 @@ end
 
 load './test/lint/sets.rb'
 
+test "SADD" do |r|
+  assert r.sadd_array( "foo", ["s1", "s2","s3"] ) == 3
+  assert r.sadd_array( "foo", ["s1", "s2","s4"] ) == 1
+
+  assert r.smove("foo", "bar", "s2")
+  assert r.sismember("bar", "s2")
+  assert r.smembers("foo").sort == ["s1", "s3", "s4"]
+end
+
+test "SREM" do |r|
+  assert r.sadd_array( "foo", ["s1", "s2","s3"] ) == 3
+  assert r.srem_array( "foo", ["s1", "s2","s4"] ) == 2
+  assert r.smembers("foo") == ["s3"]
+end
+
 test "SMOVE" do |r|
   r.sadd "foo", "s1"
   r.sadd "bar", "s2"

--- a/test/commands_on_sorted_sets_test.rb
+++ b/test/commands_on_sorted_sets_test.rb
@@ -8,6 +8,18 @@ end
 
 load './test/lint/sorted_sets.rb'
 
+test "ZADD" do |r|
+  assert r.zadd_array( "foo", [1, "s1", 2, "s2", 3, "s3"] ) == 3
+  assert r.zadd_array( "foo", [2, "s1", 3, "s2", 1, "s4"] ) == 1
+  assert r.zrange( "foo", 0, -1 ) == ["s4", "s1", "s2", "s3"]
+end
+
+test "ZREM" do |r|
+  assert r.zadd_array( "foo", [1, "s1", 2, "s2", 3, "s3"] ) == 3
+  assert r.zrem_array( "foo", ["s1", "s2","s4"] ) == 2
+  assert r.zrange("foo", 0, -1) == ["s3"]
+end
+
 test "ZCOUNT" do |r|
   r.zadd "foo", 1, "s1"
   r.zadd "foo", 2, "s2"


### PR DESCRIPTION
(cf. #136) Reverted stomped edits and added `zadd_array`, `zrem_array`, `sadd_array`, `srem_array`, `lpush_array` and `rpush_array` which take a single array arg and return the count of operated items per Redis 2.4.

The splatted args for the other calls should still be reviewed. Typically passing arrays of 50-250 elements (your mileage may vary) is sufficient to bonk the ruby stack, whereas these are well within the operating limits of Redis (e.g., merging result set ids.) 
