### PR TITLE
Redis::Distributed::CannotDistribute becomes Redis::CannotDistribute and inherites from Redis::Error

### DIFF
--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -2,17 +2,6 @@ require "redis/hash_ring"
 
 class Redis
   class Distributed
-
-    class CannotDistribute < RuntimeError
-      def initialize(command)
-        @command = command
-      end
-
-      def message
-        "#{@command.to_s.upcase} cannot be used in Redis::Distributed because the keys involved need to be on the same server or because we cannot guarantee that the operation will be atomic."
-      end
-    end
-
     attr_reader :ring
 
     def initialize(urls, options = {})

--- a/lib/redis/errors.rb
+++ b/lib/redis/errors.rb
@@ -13,4 +13,14 @@ class Redis
       EOS
     end
   end
+
+  class CannotDistribute < Error
+    def initialize(command)
+      @command = command
+    end
+
+    def message
+      "#{@command.to_s.upcase} cannot be used in Redis::Distributed because the keys involved need to be on the same server or because we cannot guarantee that the operation will be atomic."
+    end
+  end
 end

--- a/test/distributed_commands_on_lists_test.rb
+++ b/test/distributed_commands_on_lists_test.rb
@@ -11,13 +11,13 @@ end
 load './test/lint/lists.rb'
 
 test "RPOPLPUSH" do |r|
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.rpoplpush("foo", "bar")
   end
 end
 
 test "BRPOPLPUSH" do |r|
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.brpoplpush("foo", "bar", 1)
   end
 end

--- a/test/distributed_commands_on_sets_test.rb
+++ b/test/distributed_commands_on_sets_test.rb
@@ -11,7 +11,7 @@ end
 load './test/lint/sets.rb'
 
 test "SMOVE" do |r|
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.sadd "foo", "s1"
     r.sadd "bar", "s2"
 
@@ -20,7 +20,7 @@ test "SMOVE" do |r|
 end
 
 test "SINTER" do |r|
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.sadd "foo", "s1"
     r.sadd "foo", "s2"
     r.sadd "bar", "s2"
@@ -30,7 +30,7 @@ test "SINTER" do |r|
 end
 
 test "SINTERSTORE" do |r|
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.sadd "foo", "s1"
     r.sadd "foo", "s2"
     r.sadd "bar", "s2"
@@ -40,7 +40,7 @@ test "SINTERSTORE" do |r|
 end
 
 test "SUNION" do |r|
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.sadd "foo", "s1"
     r.sadd "foo", "s2"
     r.sadd "bar", "s2"
@@ -51,7 +51,7 @@ test "SUNION" do |r|
 end
 
 test "SUNIONSTORE" do |r|
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.sadd "foo", "s1"
     r.sadd "foo", "s2"
     r.sadd "bar", "s2"
@@ -62,7 +62,7 @@ test "SUNIONSTORE" do |r|
 end
 
 test "SDIFF" do |r|
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.sadd "foo", "s1"
     r.sadd "foo", "s2"
     r.sadd "bar", "s2"
@@ -73,7 +73,7 @@ test "SDIFF" do |r|
 end
 
 test "SDIFFSTORE" do |r|
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.sadd "foo", "s1"
     r.sadd "foo", "s2"
     r.sadd "bar", "s2"

--- a/test/distributed_commands_on_strings_test.rb
+++ b/test/distributed_commands_on_strings_test.rb
@@ -11,38 +11,38 @@ end
 load './test/lint/strings.rb'
 
 test "MGET" do |r|
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.mget("foo", "bar")
   end
 end
 
 test "MGET mapped" do |r|
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.mapped_mget("foo", "bar")
   end
 end
 
 test "MSET" do |r|
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.mset(:foo, "s1", :bar, "s2")
   end
 end
 
 test "MSET mapped" do |r|
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.mapped_mset(:foo => "s1", :bar => "s2")
   end
 end
 
 test "MSETNX" do |r|
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.set("foo", "s1")
     r.msetnx(:foo, "s2", :bar, "s3")
   end
 end
 
 test "MSETNX mapped" do |r|
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.set("foo", "s1")
     r.mapped_msetnx(:foo => "s2", :bar => "s3")
   end

--- a/test/distributed_commands_on_value_types_test.rb
+++ b/test/distributed_commands_on_value_types_test.rb
@@ -27,13 +27,13 @@ test "DEL" do |r|
 end
 
 test "RANDOMKEY" do |r|
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.randomkey
   end
 end
 
 test "RENAME" do |r|
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.set("foo", "s1")
     r.rename "foo", "bar"
   end
@@ -43,7 +43,7 @@ test "RENAME" do |r|
 end
 
 test "RENAMENX" do |r|
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.set("foo", "s1")
     r.rename "foo", "bar"
   end

--- a/test/distributed_publish_subscribe_test.rb
+++ b/test/distributed_publish_subscribe_test.rb
@@ -9,11 +9,11 @@ setup do
 end
 
 test "SUBSCRIBE and UNSUBSCRIBE" do |r|
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.subscribe("foo", "bar") { }
   end
 
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.subscribe("{qux}foo", "bar") { }
   end
 end

--- a/test/distributed_sorting_test.rb
+++ b/test/distributed_sorting_test.rb
@@ -9,7 +9,7 @@ setup do
 end
 
 test "SORT" do |r|
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.set("foo:1", "s1")
     r.set("foo:2", "s2")
 

--- a/test/distributed_test.rb
+++ b/test/distributed_test.rb
@@ -44,7 +44,7 @@ test "add nodes" do
 end
 
 test "Pipelining commands cannot be distributed" do |r|
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.pipelined do
       r.lpush "foo", "s1"
       r.lpush "foo", "s2"

--- a/test/distributed_transactions_test.rb
+++ b/test/distributed_transactions_test.rb
@@ -11,23 +11,23 @@ end
 test "MULTI/DISCARD" do |r|
   @foo = nil
 
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.multi { @foo = 1 }
   end
 
   assert nil == @foo
 
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.discard
   end
 end
 
 test "WATCH/UNWATCH" do |r|
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.watch("foo")
   end
 
-  assert_raise Redis::Distributed::CannotDistribute do
+  assert_raise Redis::CannotDistribute do
     r.unwatch
   end
 end


### PR DESCRIPTION
Hi,

I understand that there is a change in the interface from Redis::Distributed::CannotDistribute to Redis::CannotDistribute and potentially it could be evil for some clients, but IMHO it's worth it.
## 

Thanks
