### PR TITLE
Redis::Distributed::CannotDistribute error inherited from Redis::Error

### DIFF
--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -2,8 +2,7 @@ require "redis/hash_ring"
 
 class Redis
   class Distributed
-
-    class CannotDistribute < RuntimeError
+    class CannotDistribute < Error
       def initialize(command)
         @command = command
       end


### PR DESCRIPTION
Hi, this is a minimal change that only makes Redis::Distributed::CannotDistribute a subclass of Redis::Error.

I feel that it has a positive value to scope the exception definitions in one file since it makes the rest of the code cleaner, and improves the scalability factor if new custom exceptions needs to be created or if we need to modify the existing once.
## 

Thanks, Ivan
