### PR TITLE
Add support to Redis#clone

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -70,6 +70,10 @@ class Redis
       super()
     end
   end
+  
+  def initialize_copy(redis)
+		@client = redis.client.clone
+	end
 
   # Run code without the client reconnecting
   def without_reconnect(&block)

--- a/test/clone_test.rb
+++ b/test/clone_test.rb
@@ -1,0 +1,20 @@
+# encoding: UTF-8
+
+require File.expand_path("./helper", File.dirname(__FILE__))
+
+setup do
+  init Redis.new(OPTIONS)
+end
+
+test "CLONE" do |r|
+  
+  r2 = r.clone
+  
+  r.select 0
+  r2.select 5
+  
+  assert 0 == r.client.db
+  assert 5 == r2.client.db
+end
+
+# Allow to clone redis configuration into another redis instance


### PR DESCRIPTION
If you try to use Redis#clone, the cloned client instance still referring to the first one.

```
r = Redis.current
r2 = r.clone
r2.select 5
puts r.client.db # => 5
puts r2.client.db # => 5
```

Now it's possible to clone a redis client instance, and make changes on it, without affecting the first instance.

```
r = Redis.current
r2 = r.clone
r2.select 5
puts r.client.db # => 0
puts r2.client.db # => 5
```
