### PR TITLE
implement ZCOUNT for distributed sorted sets

### DIFF
--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -466,6 +466,11 @@ class Redis
       node_for(key).zcard(key)
     end
 
+    # Get the number of members in a particular score range.
+    def zcount(key, min, max)
+      node_for(key).zcount(key, min, max)
+    end
+
     # Get the score associated with the given member in a sorted set.
     def zscore(key, member)
       node_for(key).zscore(key, member)

--- a/test/distributed_commands_on_sorted_sets_test.rb
+++ b/test/distributed_commands_on_sorted_sets_test.rb
@@ -1,0 +1,19 @@
+# encoding: UTF-8
+
+require File.expand_path("./helper", File.dirname(__FILE__))
+require "redis/distributed"
+
+setup do
+  log = StringIO.new
+  init Redis::Distributed.new(NODES, :logger => ::Logger.new(log))
+end
+
+load './test/lint/sorted_sets.rb'
+
+test "ZCOUNT" do |r|
+  r.zadd "foo", 1, "s1"
+  r.zadd "foo", 2, "s2"
+  r.zadd "foo", 3, "s3"
+
+  assert 2 == r.zcount("foo", 2, 3)
+end


### PR DESCRIPTION
also add tests for distributed sorted sets, which look to have been overlooked.
