### PR TITLE
Support single level of array nesting in protocol builder

### DIFF
--- a/lib/redis/connection/command_helper.rb
+++ b/lib/redis/connection/command_helper.rb
@@ -4,19 +4,54 @@ class Redis
 
       COMMAND_DELIMITER = "\r\n"
 
-      def build_command(args)
-        command = []
-        command << "*#{args.size}"
+      if "".respond_to?(:bytesize)
+        def build_command(args)
+          command = [nil]
 
-        args.each do |arg|
-          arg = arg.to_s
-          command << "$#{string_size arg}"
-          command << arg
+          args.each do |i|
+            if i === Array
+              i.each do |j|
+                j = j.to_s
+                command << "$#{j.bytesize}"
+                command << j
+              end
+            else
+              i = i.to_s
+              command << "$#{i.bytesize}"
+              command << i
+            end
+          end
+
+          command[0] = "*#{(command.length - 1) / 2}"
+
+          # Trailing delimiter
+          command << ""
+          command.join(COMMAND_DELIMITER)
         end
+      else
+        def build_command(args)
+          command = [nil]
 
-        # Trailing delimiter
-        command << ""
-        command.join(COMMAND_DELIMITER)
+          args.each do |i|
+            if i === Array
+              i.each do |j|
+                j = j.to_s
+                command << "$#{j.size}"
+                command << j
+              end
+            else
+              i = i.to_s
+              command << "$#{i.size}"
+              command << i
+            end
+          end
+
+          command[0] = "*#{(command.length - 1) / 2}"
+
+          # Trailing delimiter
+          command << ""
+          command.join(COMMAND_DELIMITER)
+        end
       end
 
     protected

--- a/lib/redis/connection/hiredis.rb
+++ b/lib/redis/connection/hiredis.rb
@@ -34,7 +34,7 @@ class Redis
       end
 
       def write(command)
-        @connection.write(command)
+        @connection.write(command.flatten(1))
       end
 
       def read


### PR DESCRIPTION
This patch makes the protocol builder support a single level of array nesting. This needs to be in place to support passing array arguments without copying them.
