### PR TITLE
fix lpush so that it accepts multiple value arguments

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -355,9 +355,9 @@ class Redis
   end
 
   # Append one or more values to a list.
-  def rpush(key, value)
+  def rpush(key, *values)
     synchronize do
-      @client.call [:rpush, key, value]
+      @client.call [:rpush, key, *values]
     end
   end
 

--- a/test/commands_on_lists_test.rb
+++ b/test/commands_on_lists_test.rb
@@ -26,12 +26,19 @@ test "LPUSHX" do |r|
   assert ["s3", "s2"] == r.lrange("foo", 0, -1)
 end
 
-test "LPUSH" do |r|
+test "Variadic LPUSH" do |r|
+  next if version(r) < 203090 # 2.4-rc6
   r.lpush "foo", "s1", "s2"
   assert 2 == r.llen("foo")
   assert ["s2", "s1"] == r.lrange("foo", 0, -1)
 end
 
+test "Variadic RPUSH" do |r|
+  next if version(r) < 203090 # 2.4-rc6
+  r.rpush "foo", "s1", "s2"
+  assert 2 == r.llen("foo")
+  assert ["s1", "s2"] == r.lrange("foo", 0, -1)
+end
 
 test "LINSERT" do |r|
   r.rpush "foo", "s1"


### PR DESCRIPTION
In earlier versions (e.g. 2.2.0) it was possible to do

``` ruby
redis.lpush "foo", "s1", "s2"
```

somehow this got lost in the current master
