### PR TITLE
Adding support to named instances

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -1138,6 +1138,12 @@ class Redis
     end
   end
 
+  def name
+    synchronize do
+      @client.name
+    end
+  end
+
   def inspect
     synchronize do
       "#<Redis client v#{Redis::VERSION} connected to #{id} (Redis v#{info["redis_version"]})>"

--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -1,6 +1,6 @@
 class Redis
   class Client
-    attr_accessor :db, :host, :port, :path, :password, :logger
+    attr_accessor :db, :host, :name, :port, :path, :password, :logger
     attr :timeout
     attr :connection
     attr :command_map
@@ -16,6 +16,7 @@ class Redis
       @timeout = (options[:timeout] || 5).to_f
       @password = options[:password]
       @logger = options[:logger]
+      @name = options[:name]
       @reconnect = true
       @connection = Connection.drivers.last.new
       @command_map = {}

--- a/lib/redis/hash_ring.rb
+++ b/lib/redis/hash_ring.rb
@@ -24,7 +24,7 @@ class Redis
     def add_node(node)
       @nodes << node
       @replicas.times do |i|
-        key = Zlib.crc32("#{node.id}:#{i}")
+        key = Zlib.crc32("#{!node.name ? node.id : node.name}:#{i}")
         @ring[key] = node
         @sorted_keys << key
       end
@@ -34,7 +34,7 @@ class Redis
     def remove_node(node)
       @nodes.reject!{|n| n.id == node.id}
       @replicas.times do |i|
-        key = Zlib.crc32("#{node.id}:#{i}")
+        key = Zlib.crc32("#{!node.name ? node.id : node.name}:#{i}")
         @ring.delete(key)
         @sorted_keys.reject! {|k| k == key}
       end

--- a/test/distributed_test.rb
+++ b/test/distributed_test.rb
@@ -43,6 +43,24 @@ test "add nodes" do
   assert logger == @r.nodes[1].client.logger
 end
 
+test "named nodes" do
+  logger = Logger.new("/dev/null")
+
+  @r = Redis::Distributed.new [ { name: "node_1", url: "redis://127.0.0.1:6379/15" } ], :logger => logger, :timeout => 10
+
+  @r.set "key_1", 1
+  @r.set "key_2", 2
+  @r.set "key_3", 3
+  @r.set "key_4", 4
+
+  @r = Redis::Distributed.new [ { name: "node_2", url: "redis://127.0.0.1:6379/15" }, { name: "node_1", url: "redis://127.0.0.1:6380/15" } ], :logger => logger, :timeout => 10
+
+  assert @r.nodes.last == @r.node_for("key_1")
+  assert @r.nodes.last == @r.node_for("key_2")
+  assert @r.nodes.last == @r.node_for("key_3")
+  assert @r.nodes.last == @r.node_for("key_4")
+end
+
 test "Pipelining commands cannot be distributed" do |r|
   assert_raise Redis::Distributed::CannotDistribute do
     r.pipelined do


### PR DESCRIPTION
I needed this since I have to move redis instances from one server to another, so with the original code, it would break the hashing since it used the redis host. With named instances we can make sure you can move them around and still hash the keys correctly.
