### PR TITLE
Remove the option for thread_safe

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -43,16 +43,7 @@ class Redis
   def initialize(options = {})
     @client = Client.new(options)
 
-    if options[:thread_safe] == false
-      @synchronizer = lambda { |&block| block.call }
-    else
-      @synchronizer = lambda { |&block| mon_synchronize { block.call } }
-      super() # Monitor#initialize
-    end
-  end
-
-  def synchronize
-    @synchronizer.call { yield }
+    super() # Monitor#initialize
   end
 
   # Run code without the client reconnecting


### PR DESCRIPTION
I think the @synchronizer is just adding an indirection which isn't useful and
just adds a small performance penalty for 99% of the users doing Redis.connect.
