### PR TITLE
foundations for ssl support

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -25,6 +25,7 @@ class Redis
       options[:port]     ||= uri.port
       options[:password] ||= uri.password
       options[:db]       ||= uri.path[1..-1].to_i
+      options[:scheme]   ||= uri.scheme
     end
 
     new(options)

--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -2,7 +2,7 @@ require "redis/errors"
 
 class Redis
   class Client
-    attr_accessor :db, :host, :port, :path, :password, :logger
+    attr_accessor :db, :host, :port, :path, :password, :scheme, :logger
     attr :timeout
     attr :connection
     attr :command_map
@@ -17,6 +17,7 @@ class Redis
       @db = (options[:db] || 0).to_i
       @timeout = (options[:timeout] || 5).to_f
       @password = options[:password]
+      @scheme = (options[:scheme] || 'redis')
       @logger = options[:logger]
       @reconnect = true
       @connection = Connection.drivers.last.new
@@ -237,7 +238,11 @@ class Redis
       if @path
         connection.connect_unix(@path, timeout)
       else
-        connection.connect(@host, @port, timeout)
+        if @scheme == "redis+ssl"
+          connection.connect_ssl(@host, @port, timeout)
+        else
+          connection.connect(@host, @port, timeout)
+        end
       end
 
       # If the timeout is set we set the low level socket options in order


### PR DESCRIPTION
The following adds some very straightforward support for SSL (stunnel) connectivity in the ruby client.

I need this for several internal projects in order to secure communications.  There are two major pros to this approach as I see it:
- setting up an stunnel on both the client and server is messy, especially when a client needs to connect to multiple servers
- this allows redis clients that run in Heroku apps to connect securely to their servers (as long as they are running stunnel on the server side, of course)

I tested with an stunnel.conf that looks like so:

```
pid = /tmp/stunnel.pid
cert = /tmp/stunnel.pem
foreground = yes

[redis]
accept  = 6380
connect = 6379
```

I am able to initialize my redis client like so:

``` ruby
require 'redis'

# use as normal, just make sure that the other end is running stunnel (localhost:6380 in this example)
r = Redis.connect url: 'redis+ssl://localhost:6380'
```

I am not including tests in this PR, as I have a few questions:
- is the proposed change generally acceptable with the vision of the lib?
- if so, can you offer some guidance as to how you'd like me to include the stunnel tests within your framework?
