### PR TITLE
pass connection objects the original uri so they have more context

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -1,5 +1,6 @@
 require "monitor"
 require "redis/errors"
+require "uri"
 
 class Redis
 
@@ -10,27 +11,6 @@ class Redis
   attr :client
 
   def self.connect(options = {})
-    options = options.dup
-
-    url = options.delete(:url) || ENV["REDIS_URL"]
-    if url
-      require "uri"
-
-      uri = URI(url)
-
-      # Require the URL to have at least a host
-      raise ArgumentError, "invalid url" unless uri.host
-
-      options[:host]     ||= uri.host
-      options[:port]     ||= uri.port
-      options[:password] ||= uri.password
-      options[:db]       ||= uri.path[1..-1].to_i
-
-      # A representation of the full URI object
-      # allowing for connections to have more context
-      options[:uri]      ||= uri
-    end
-
     new(options)
   end
 
@@ -44,7 +24,32 @@ class Redis
 
   include MonitorMixin
 
+  def parse_options(options)
+    options = options.dup
+   
+    if options[:path]
+      uri = URI::Generic.new('unix', nil, nil, nil, nil, options[:path], nil, nil, nil)
+    else
+      url = options.delete(:url) || ENV["REDIS_URL"]
+      if url
+        uri = URI.parse(url)
+      else
+        uri = URI::Generic.new('redis', nil, '127.0.0.1', 6379, nil, '/0', nil, nil, nil)
+      end
+      
+      uri.host     = options.delete(:host)     if options[:host]
+      uri.port     = options.delete(:port)     if options[:port]
+      uri.user     = 'redis'
+      uri.password = options.delete(:password) if options[:password]
+      uri.path     = "/#{options.delete(:db)}" if options[:db]
+    end
+    
+    options[:uri] = uri
+    options
+  end
+
   def initialize(options = {})
+    options = parse_options(options)
     @client = Client.new(options)
 
     if options[:thread_safe] == false

--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -2,22 +2,21 @@ require "redis/errors"
 
 class Redis
   class Client
-    attr_accessor :db, :host, :port, :path, :password, :uri, :logger
+    attr_accessor :uri, :db, :logger
     attr :timeout
     attr :connection
     attr :command_map
 
     def initialize(options = {})
-      @path = options[:path]
-      if @path.nil?
-        @host = options[:host] || "127.0.0.1"
-        @port = (options[:port] || 6379).to_i
+      @uri = options[:uri]
+
+      if scheme == 'unix'
+        @db = 0
+      else
+        @db = uri.path[1..-1].to_i
       end
 
-      @db = (options[:db] || 0).to_i
       @timeout = (options[:timeout] || 5).to_f
-      @password = options[:password]
-      @uri = options[:uri]
       @logger = options[:logger]
       @reconnect = true
       @connection = Connection.drivers.last.new
@@ -26,17 +25,40 @@ class Redis
 
     def connect
       establish_connection
-      call [:auth, @password] if @password
+      call [:auth, password] if password
       call [:select, @db] if @db != 0
       self
     end
 
     def id
-      "redis://#{location}/#{db}"
+      safe_uri
     end
 
-    def location
-      @path || "#{@host}:#{@port}"
+    def safe_uri
+      temp_uri = @uri
+      temp_uri.user = nil
+      temp_uri.password = nil
+      temp_uri
+    end
+
+    def host
+      @uri.host
+    end 
+    
+    def password
+      @uri.password
+    end
+
+    def path
+      @uri.path
+    end
+
+    def port
+      @uri.port
+    end
+
+    def scheme
+      @uri.scheme
     end
 
     def call(command, &block)
@@ -235,10 +257,10 @@ class Redis
       # Need timeout in usecs, like socket timeout.
       timeout = Integer(@timeout * 1_000_000)
 
-      if @path
-        connection.connect_unix(@path, timeout)
+      if @uri.scheme == 'unix'
+        connection.connect_unix(@uri.path, timeout)
       else
-        connection.connect(@host, @port, timeout, @uri)
+        connection.connect(@uri, timeout)
       end
 
       # If the timeout is set we set the low level socket options in order
@@ -247,9 +269,9 @@ class Redis
       self.timeout = @timeout
 
     rescue Timeout::Error
-      raise CannotConnectError, "Timed out connecting to Redis on #{location}"
+      raise CannotConnectError, "Timed out connecting to Redis on #{safe_uri}"
     rescue Errno::ECONNREFUSED
-      raise CannotConnectError, "Error connecting to Redis on #{location} (ECONNREFUSED)"
+      raise CannotConnectError, "Error connecting to Redis on #{safe_uri} (ECONNREFUSED)"
     end
 
     def timeout=(timeout)

--- a/lib/redis/connection/hiredis.rb
+++ b/lib/redis/connection/hiredis.rb
@@ -18,8 +18,8 @@ class Redis
         @connection.timeout = usecs
       end
 
-      def connect(host, port, timeout, uri)
-        @connection.connect(host, port, timeout)
+      def connect(uri, timeout)
+        @connection.connect(uri.host, uri.port, timeout)
       rescue Errno::ETIMEDOUT
         raise Timeout::Error
       end

--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -22,9 +22,9 @@ class Redis
         !! @sock
       end
 
-      def connect(host, port, timeout, uri)
+      def connect(uri, timeout)
         with_timeout(timeout.to_f / 1_000_000) do
-          @sock = TCPSocket.new(host, port)
+          @sock = TCPSocket.new(uri.host, uri.port)
           @sock.setsockopt Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1
         end
       end

--- a/lib/redis/connection/synchrony.rb
+++ b/lib/redis/connection/synchrony.rb
@@ -73,8 +73,8 @@ class Redis
         @timeout = usecs
       end
 
-      def connect(host, port, timeout, uri)
-        conn = EventMachine.connect(host, port, RedisClient) do |c|
+      def connect(uri, timeout)
+        conn = EventMachine.connect(uri.host, uri.port, RedisClient) do |c|
           c.pending_connect_timeout = [Float(timeout / 1_000_000), 0.1].max
         end
 


### PR DESCRIPTION
(perhaps a better way of handling my troubles in issue #189)

Currently, `Redis::Client` establishes a connection by passing `host`, `port` and `timeout`.

This changeset passes in the original `uri` that may or may not have been passed to `Redis`.

The advantage here is that future `Redis::Connection` objects can have a little more context as to why they were called.

I have a multi-transport connection class that needs to be able to inspect the original url and determine whether it should be connecting with the standard method (`redis://`), SSL (`redis+ssl://`) or websockets ('redis+ws://`).  We believe that more transport types are likely to follow as our experiments continue.

Unfortunately, since connections aren't given this context, we can't make this determination.  Our preferred course of action is to only have to change a given environment variable to enable the connection, as well as have a single application be able to connection to multiple redis instances over different transport mechanisms.

The above change should enable all of that, plus make way for others to experiment in a similar fashion.
