### PR TITLE
patch srem to support multiple arguments

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -439,7 +439,11 @@ class Redis
   # Remove a member from a set.
   def srem(key, value)
     synchronize do
-      _bool @client.call [:srem, key, value]
+      if value.kind_of?(Array)
+        @client.call [:srem, key, *value]
+      else
+        _bool @client.call [:srem, key, value]
+      end
     end
   end
 

--- a/test/commands_on_sets_test.rb
+++ b/test/commands_on_sets_test.rb
@@ -75,4 +75,15 @@ test "SDIFFSTORE" do |r|
   assert ["s1"] == r.smembers("baz")
 end
 
+test "SREM" do |r|
+  r.sadd "foo", "s1"
+  r.sadd "foo", "s2"
+  r.sadd "bar", "s2"
+  r.sadd "bar", "s3"
+
+  assert r.srem("foo", "s1")
+  assert 2 == r.srem("bar", ['s2', 's3'])
+  assert ["s2"] == r.smembers('foo')
+  assert [] == r.smembers("bar")
+end
 


### PR DESCRIPTION
patch for v2.2.2.  SREM takes multiple arguments in redis >= 2.4.5
