### PR TITLE
Yield connection instance to pipelined blocks.

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -975,7 +975,7 @@ class Redis
     synchronize do
       begin
         original, @client = @client, Pipeline.new
-        yield
+        yield self
         original.call_pipelined(@client.commands, options) unless @client.commands.empty?
       ensure
         @client = original

--- a/test/pipelining_commands_test.rb
+++ b/test/pipelining_commands_test.rb
@@ -6,6 +6,12 @@ setup do
   init Redis.new(OPTIONS)
 end
 
+test "Yields the connection to pipelined block" do |r|
+  r.pipelined do |yielded|
+    assert r === yielded
+  end
+end
+
 test "BULK commands" do |r|
   r.pipelined do
     r.lpush "foo", "s1"


### PR DESCRIPTION
This patch is against 2.2.2 and will require a 2.2 maintenance branch, which I hope you'll create.

Yielding the connection instance to the pipeline block allows pipelines to be safely used with transparent connection proxies, like the EM-synchrony ConnectionPool class. These proxies assume that any access to connection, such as `redis.pipeline { }` will allocate and the release a connection from the pool.

Bad case:

```
 redis.pipeline do  <--- reservers a connection from the pool
   redis.set 'x', 1    <--- each subsequent access to redis attempts to reserve another connection
   redis.set 'y', 2 
end
```

Good case:

```
redis.pipeline do |p|
  p.set 'x', 1        <---- uses the same reserved connection for each command
  p.set 'y', 2
end
```
