### PR TITLE
Yield connection instance to pipelined blocks (master)

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -1776,7 +1776,7 @@ class Redis
     synchronize do
       begin
         original, @client = @client, Pipeline.new
-        yield
+        yield self
         original.call_pipeline(@client)
       ensure
         @client = original

--- a/test/pipelining_commands_test.rb
+++ b/test/pipelining_commands_test.rb
@@ -6,6 +6,12 @@ setup do
   init Redis.new(OPTIONS)
 end
 
+test "Yields the connection to pipelined block" do |r|
+  r.pipelined do |yielded|
+    assert r === yielded
+  end
+end
+
 test "BULK commands" do |r|
   r.pipelined do
     r.lpush "foo", "s1"


### PR DESCRIPTION
This patch is against master and contains the same issue fix described in https://github.com/redis/redis-rb/pull/204
