### PR TITLE
_hashify result of hgetall (#201, #202)

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -254,11 +254,7 @@ class Redis
     synchronize do
       @client.call [:hgetall, key] do |reply|
         if reply.kind_of?(Array)
-          hash = Hash.new
-          reply.each_slice(2) do |field, value|
-            hash[field] = value
-          end
-          hash
+          _hashify(reply)
         else
           reply
         end
@@ -1958,6 +1954,14 @@ private
     }
   end
 
+  def _hashify(array)
+    hash = Hash.new
+    array.each_slice(2) do |field, value|
+      hash[field] = value
+    end
+    hash  
+  end
+  
   def subscription(method, channels, block)
     return @client.call [method, *channels] if subscribed?
 

--- a/lib/redis/version.rb
+++ b/lib/redis/version.rb
@@ -1,3 +1,3 @@
 class Redis
-  VERSION = "3.0.0.rc1"
+  VERSION = "3.0.0.rc2"
 end


### PR DESCRIPTION
@djanowski scratching around on this some more, only `#hgetall` needs this hook as `#mapped_hmget` has the client pass in the fields. I've rebased this and added the hook which as you suggest is the tersest option for 3.0 final. In the future you might look at whether passing in a block to the protocol handler is a more general way to collapse processing across layers rather than adding a lot of hooks like this.

Thanks,
.tv/
(ref #201, #202)
