### PR TITLE
Add combined watch with multi/exec method for thread safety

### DIFF
--- a/test/thread_safety_test.rb
+++ b/test/thread_safety_test.rb
@@ -30,3 +30,31 @@ test "thread safety" do
   assert_equal ["1"], $foos.uniq
   assert_equal ["2"], $bars.uniq
 end
+
+test "thread safety with multi and watch" do
+  next unless driver == :ruby || driver == :hiredis
+
+  redis = Redis.connect(OPTIONS)
+
+  redis.set "foo", 1
+
+  t1 = Thread.new do
+    sleep 1
+    redis.watch_with_multi "foo" do |r|
+      r.set "foo", 4
+    end
+  end
+
+  t2 = Thread.new do
+    redis.watch_with_multi "bar" do |r|
+      r.set "bar", 2
+      sleep 1
+      redis.set("foo", 2)
+    end
+  end
+
+  t1.join
+  t2.join
+
+  assert_equal "4", redis.get("foo")
+end

--- a/test/transactions_test.rb
+++ b/test/transactions_test.rb
@@ -191,3 +191,11 @@ test "UNWATCH with a modified key" do |r|
 
   assert "s2" == r.get("foo")
 end
+
+test "watch_with_multi" do |r|
+  r.watch_with_multi "foo" do |multi|
+    multi.set "foo", "s1"
+  end
+
+  assert "s1" == r.get("foo")
+end


### PR DESCRIPTION
Addresses issue #228.

My first stab at something that might fix the issue. There were a few different ways I could have gone with this, but in lieu of a connection pool I think this should work pretty well.
