### PR TITLE
Raise EPIPE exception after some inactivity

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -171,7 +171,7 @@ class Redis
               command[0] = command_map[command.first]
             end
 
-            connection.write(command)
+            write(command)
           end
 
           yield if block_given?


### PR DESCRIPTION
I'm using sidekiq. After some time of inactivity, it will raise the EPIPE error. backtrace attached.

Broken pipe

``` ruby
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/redis-3.0.0/lib/redis/connection/ruby.rb:200:in `write'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/redis-3.0.0/lib/redis/connection/ruby.rb:200:in `write'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/redis-3.0.0/lib/redis/client.rb:174:in `block (3 levels) in process'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/redis-3.0.0/lib/redis/client.rb:168:in `each'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/redis-3.0.0/lib/redis/client.rb:168:in `block (2 levels) in process'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/redis-3.0.0/lib/redis/client.rb:281:in `ensure_connected'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/redis-3.0.0/lib/redis/client.rb:167:in `block in process'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/redis-3.0.0/lib/redis/client.rb:242:in `logging'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/redis-3.0.0/lib/redis/client.rb:166:in `process'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/redis-3.0.0/lib/redis/client.rb:141:in `call_pipelined'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/redis-3.0.0/lib/redis/client.rb:115:in `block in call_pipeline'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/redis-3.0.0/lib/redis/client.rb:229:in `with_reconnect'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/redis-3.0.0/lib/redis/client.rb:113:in `call_pipeline'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/redis-3.0.0/lib/redis.rb:2027:in `block in multi'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/redis-3.0.0/lib/redis.rb:36:in `block in synchronize'
/usr/local/rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/monitor.rb:211:in `mon_synchronize'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/redis-3.0.0/lib/redis.rb:36:in `synchronize'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/redis-3.0.0/lib/redis.rb:2019:in `multi'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/sidekiq-1.2.1/lib/sidekiq/client.rb:53:in `block (2 levels) in push'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/connection_pool-0.9.1/lib/connection_pool.rb:47:in `with'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/sidekiq-1.2.1/lib/sidekiq.rb:61:in `redis'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/sidekiq-1.2.1/lib/sidekiq/client.rb:52:in `block in push'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/sidekiq-1.2.1/lib/sidekiq/middleware/chain.rb:75:in `call'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/sidekiq-1.2.1/lib/sidekiq/middleware/chain.rb:75:in `block in invoke'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/sidekiq-1.2.1/lib/sidekiq/middleware/chain.rb:80:in `call'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/sidekiq-1.2.1/lib/sidekiq/middleware/chain.rb:80:in `invoke'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/sidekiq-1.2.1/lib/sidekiq/client.rb:50:in `push'
/releases/1aa0b5d8ea17f3cf9a3862531c6039fec99dca49/vendor/bundle/ruby/1.9.1/gems/sidekiq-1.2.1/lib/sidekiq/worker.rb:33:in `perform_async'
```
