### PR TITLE
Add `execute` method to Redis class to execute raw redis commands.

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -282,6 +282,19 @@ class Redis
     end
   end
 
+  # Execute raw redis command
+  #
+  # @param [String] command
+  # @return [String]
+  def execute(command)
+    synchronize do |client|
+      # A whitespace is appended to command because the library
+      # splits commands by whitespaces, so commands like "get :key"
+      # won't work without trailing whitespace.
+      client.call "#{command} ".split
+    end
+  end
+
   # Remove the expiration from a key.
   #
   # @param [String] key


### PR DESCRIPTION
There are certain use-cases when calling a method of `Redis` class is inconvenient, for example when redis-rb is used as a part of wrapper around redis-server and command is received from external source. In such a case it's much more confortable to send this command directly to redis server. For such cases I've added a method called `execute` to `Redis` class and i hope this patch may be useful for anyone else.

Sorry for my bad English, because I'm not a native speaker.
