### PR TITLE
Handle InheritedError in Redis#quit

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -96,7 +96,7 @@ class Redis
     synchronize do |client|
       begin
         client.call([:quit])
-      rescue ConnectionError
+      rescue ConnectionError, InheritedError
       ensure
         client.disconnect
       end


### PR DESCRIPTION
I was using `quit` in my Passenger post-fork hook, so this caught me when upgrading. I suspect I'm not alone :smile:
