### PR TITLE
Sadd Command should return the number of elements present in a set

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -1100,21 +1100,11 @@ class Redis
   #
   # @param [String] key
   # @param [String, Array<String>] member one member, or array of members
-  # @return [Boolean, Fixnum] `Boolean` when a single member is specified,
-  #   holding whether or not adding the member succeeded, or `Fixnum` when an
-  #   array of members is specified, holding the number of members that were
-  #   successfully added
+  # @return [Fixnum] holding the number of members that were
+  #   successfully added to the set, but were not already in the set.
   def sadd(key, member)
     synchronize do |client|
-      client.call([:sadd, key, member]) do |reply|
-        if member.is_a? Array
-          # Variadic: return integer
-          reply
-        else
-          # Single argument: return boolean
-          _boolify.call(reply)
-        end
-      end
+      client.call([:sadd, key, member])
     end
   end
 

--- a/test/lint/sets.rb
+++ b/test/lint/sets.rb
@@ -3,9 +3,9 @@ module Lint
   module Sets
 
     def test_sadd
-      assert_equal true, r.sadd("foo", "s1")
-      assert_equal true, r.sadd("foo", "s2")
-      assert_equal false, r.sadd("foo", "s1")
+      assert_equal 1, r.sadd("foo", "s1")
+      assert_equal 1, r.sadd("foo", "s2")
+      assert_equal 0, r.sadd("foo", "s1")
 
       assert_equal ["s1", "s2"], r.smembers("foo").sort
     end

--- a/test/pipelining_commands_test.rb
+++ b/test/pipelining_commands_test.rb
@@ -82,8 +82,8 @@ class TestPipeliningCommands < Test::Unit::TestCase
       @second = r.sadd("foo", 1)
     end
 
-    assert_equal true, @first.value
-    assert_equal false, @second.value
+    assert_equal 1, @first.value
+    assert_equal 0, @second.value
   end
 
   # Although we could support accessing the values in these futures,
@@ -112,8 +112,8 @@ class TestPipeliningCommands < Test::Unit::TestCase
       end
     end
 
-    assert_equal true, @first.value
-    assert_equal false, @second.value
+    assert_equal 1, @first.value
+    assert_equal 0, @second.value
   end
 
   def test_futures_raise_when_confused_with_something_else

--- a/test/transactions_test.rb
+++ b/test/transactions_test.rb
@@ -42,8 +42,8 @@ class TestTransactions < Test::Unit::TestCase
       @second = m.sadd("foo", 1)
     end
 
-    assert_equal true, @first.value
-    assert_equal false, @second.value
+    assert_equal 1, @first.value
+    assert_equal 0, @second.value
   end
 
   # Although we could support accessing the values in these futures,


### PR DESCRIPTION
From the Redis docs for [sadd](http://redis.io/commands/sadd):

"Integer reply: the number of elements that were added to the set, not including all the elements already present into the set."

This change from the regular sadd response should at least be documented.
