### PR TITLE
Fix and update the method ordering in .order

### DIFF
--- a/.order
+++ b/.order
@@ -22,7 +22,8 @@
     "slaveof",
     "slowlog",
     "sync",
-    "time"
+    "time",
+    "client"
   ],
   "generic": [
     "persist",
@@ -70,7 +71,8 @@
     "append",
     "bitcount",
     "getset",
-    "strlen"
+    "strlen",
+    "bitop"
   ],
   "list": [
     "llen",
@@ -90,8 +92,7 @@
     "lrange",
     "lrem",
     "lset",
-    "ltrim",
-    "bitop"
+    "ltrim"
   ],
   "set": [
     "scard",


### PR DESCRIPTION
This updates the method ordering in .order. Since _bitop_ was categorized into not _string_ but _list_, I have manually removed it, and then rerun _rake commands:order_.
