### PR TITLE
Fix version comparison

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -113,7 +113,7 @@ module Helper
 
         return -1 if a.nil?
         return +1 if b.nil?
-        return a <=> b if a != b
+        return a.to_i <=> b.to_i if a != b
       end
 
       0

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -7,16 +7,18 @@ class TestHelper < Test::Unit::TestCase
   include Helper
 
   def test_version_comparison
-    v = Version.new("2.0.0")
+    v = Version.new("2.0.1")
 
-    assert v < "3"
     assert v > "1"
     assert v > "2"
+    assert v < "3"
+    assert v < "10"
 
     assert v < "2.1"
-    assert v < "2.0.1"
-    assert v < "2.0.0.1"
+    assert v < "2.0.2"
+    assert v < "2.0.1.1"
+    assert v < "2.0.10"
 
-    assert v == "2.0.0"
+    assert v == "2.0.1"
   end
 end


### PR DESCRIPTION
This fixes the general comparison operator of class _Helper::Version_ in test/helper.rb.

Since the current implementation cannot compare a one-digit number and a two-digit one correctly, tests for versions greater than or equal to "2.5.10" are run even thought we run a redis instance of version "2.5.7".
