### PR TITLE
Add supports for DUMP and RESTORE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 3.0.3 (unreleased)
 
+* Added support for `DUMP` and `RESTORE` (Redis 2.6).
+
 * Added support for `BITCOUNT` and `BITOP` (Redis 2.6).
 
 # 3.0.2

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -359,6 +359,28 @@ class Redis
     end
   end
 
+  # Return a serialized version of the value stored at a key.
+  #
+  # @param [String] key
+  # @return [String] serialized_value
+  def dump(key)
+    synchronize do |client|
+      client.call([:dump, key])
+    end
+  end
+
+  # Create a key using the serialized value, previously obtained using DUMP.
+  #
+  # @param [String] key
+  # @param [String] ttl
+  # @param [String] serialized_value
+  # @return `"OK"`
+  def restore(key, ttl, serialized_value)
+    synchronize do |client|
+      client.call([:restore, key, ttl, serialized_value])
+    end
+  end
+
   # Delete one or more keys.
   #
   # @param [String, Array<String>] keys

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -137,6 +137,16 @@ class Redis
       node_for(key).pttl(key)
     end
 
+    # Return a serialized version of the value stored at a key.
+    def dump(key)
+      node_for(key).dump(key)
+    end
+
+    # Create a key using the serialized value, previously obtained using DUMP.
+    def restore(key, ttl, serialized_value)
+      node_for(key).restore(key, ttl, serialized_value)
+    end
+
     # Delete a key.
     def del(*args)
       keys_per_node = args.group_by { |key| node_for(key) }

--- a/test/lint/value_types.rb
+++ b/test/lint/value_types.rb
@@ -80,6 +80,26 @@ module Lint
       assert_in_range 1..2000, r.pttl("foo")
     end
 
+    def test_dump_and_restore
+      return if version < "2.5.7"
+
+      r.set("foo", "a")
+      v = r.dump("foo")
+      r.del("foo")
+
+      assert r.restore("foo", 1000, v)
+      assert_equal "a", r.get("foo")
+      assert [0, 1].include? r.ttl("foo")
+
+      r.rpush("bar", ["b", "c", "d"])
+      w = r.dump("bar")
+      r.del("bar")
+
+      assert r.restore("bar", 1000, w)
+      assert_equal ["b", "c", "d"], r.lrange("bar", 0, -1)
+      assert [0, 1].include? r.ttl("bar")
+    end
+
     def test_move
       r.select 14
       r.flushdb


### PR DESCRIPTION
This adds supports for DUMP and RESTORE commands for Redis 2.6. I would appreciate it if you could review the code and merge it.
