### PR TITLE
HashRing iter_nodes is now able to visit all the nodes in the ring.

### DIFF
--- a/lib/redis/hash_ring.rb
+++ b/lib/redis/hash_ring.rb
@@ -55,7 +55,7 @@ class Redis
     def iter_nodes(key)
       return [nil,nil] if @ring.size == 0
       _, pos = get_node_pos(key)
-      (0...@ring.size).each do |n|
+      @ring.size.times do |n|
         yield @ring[@sorted_keys[(pos+n) % @ring.size]]
       end
     end


### PR DESCRIPTION
Before this commit the method was able to return all the nodes from the
first node up to the end of the array sorted_keys, representing the hash
ring.

However while the sorted_keys is an array, it represents a ring, so node
iteration should be able to traverse all the nodes in the ring, and
should always return @ring.size elements.
