### PR TITLE
except nil in redis status info.

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -181,7 +181,7 @@ class Redis
         if reply.kind_of?(String)
           reply = Hash[reply.split("\r\n").map do |line|
             line.split(":", 2) unless line =~ /^(#|$)/
-          end]
+          end.compact]
 
           if cmd && cmd.to_s == "commandstats"
             # Extract nested hashes for INFO COMMANDSTATS


### PR DESCRIPTION
ruby-2.0.0preview1 isn't working with `Hash[[nil, ...]]`. example for:

```
test_transformed_replies_inside_multi_exec_block(TestTransactions):
ArgumentError: wrong element type (expected array)
```

Because ruby-2.0.0 validates wrong argument when use Hash[] now. I fixed it.
