### PR TITLE
Adds a method to silence logging.

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -147,6 +147,14 @@ class Redis
     end
   end
 
+  def silence(&block)
+    tmp = client.logger
+    client.logger = nil
+    block.call
+  ensure
+    client.logger = tmp if tmp
+  end
+
   def debug(*args)
     synchronize do |client|
       client.call([:debug] + args)


### PR DESCRIPTION
I often find myself adding a method like this to silence Redis logs for operations with 10s of thousands records. (And I didn't see any existing methods that do this)

This prevents seeing a log screen that keeps on piling logs, also when using rails (& webrick) this would prevent blocking incoming requests.

Any remarks, I'll be happy to edit this commit to suit your needs? Should I also add any tests?

Usage:

``` ruby
$redis = Redis.new(db: 0, logger: Rails.logger)

$redis.silence do
  $redis.sadd('test', 1)
end
```
