### PR TITLE
Downgrade INFO string to ASCII

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -179,6 +179,7 @@ class Redis
     synchronize do |client|
       client.call([:info, cmd].compact) do |reply|
         if reply.kind_of?(String)
+          reply.encode!('US-ASCII', invalid: :replace, replace: '') unless reply.valid_encoding?
           reply = Hash[reply.split("\r\n").map do |line|
             line.split(":", 2) unless line =~ /^(#|$)/
           end.compact]


### PR DESCRIPTION
On rare occasions we have seen Redis v2.4.17 instances with invalid data in the INFO response: `used_memory_peak_human:\x90\f\x83\xFB\x83\u007F`

The 'used_memory_peak_human' key should be a string on the form "12345.67K". For our instance the `used_memory_peak:18446744073706301432` is very big, and looking at redis.c (for both 2.4.17 and 2.6.7) I suspect that `bytesToHuman()` is buggy and doesn't deal with such big values.

This patch simply downgrades the info string to ASCII when the encoding is invalid.
