### PR TITLE
Add support for CLIENT commands

### DIFF
--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -62,6 +62,11 @@ class Redis
       on_each_node :bgsave
     end
 
+    # Manage client connections
+    def client(subcommand=nil, *args)
+      on_each_node :client, subcommand, args
+    end
+
     # Return the number of keys in the selected database.
     def dbsize
       on_each_node :dbsize


### PR DESCRIPTION
This pull request adds support for `CLIENT [LIST | KILL | GETNAME | SETNAME]` commands. 

I think that some of tests might be able to be improved. For example, the current test for `CLIENT KILL` requires Redis 2.6.9 or later because the test depends on `CLIENT SETNAME`. However, the test should not use such newer commands and run on Redis 2.4.0 or later. If you have any ideas for the improvement of tests, please let me know.
