### PR TITLE
Avoid Ruby 2.0 warnings when running tests

### DIFF
--- a/test/distributed_remote_server_control_commands_test.rb
+++ b/test/distributed_remote_server_control_commands_test.rb
@@ -17,9 +17,9 @@ class TestDistributedRemoteServerControlCommands < Test::Unit::TestCase
      "total_commands_processed",
     ]
 
-    info = r.info
+    infos = r.info
 
-    info.each do |info|
+    infos.each do |info|
       keys.each do |k|
         msg = "expected #info to include #{k}"
         assert info.keys.include?(k), msg

--- a/test/publish_subscribe_test.rb
+++ b/test/publish_subscribe_test.rb
@@ -67,8 +67,6 @@ class TestPublishSubscribe < Test::Unit::TestCase
           @unsubscribed = true
           @t2 = total
         end
-
-        listening = true
       end
     end
 


### PR DESCRIPTION
When running the tests with `rake`, the following errors are issued:

``` bash
/Users/hanke/temp/redis-rb/test/distributed_remote_server_control_commands_test.rb:22: warning: shadowing outer local variable - info
/Users/hanke/temp/redis-rb/test/publish_subscribe_test.rb:71: warning: assigned but unused variable - listening
```

I rewrote the tests such that these warnings are not issued anymore. Tests still run: `476 tests, 1782 assertions, 0 failures, 0 errors, 0 skips`.

Cheers!
