### PR TITLE
Added subscriptions with timeout

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -1935,7 +1935,14 @@ class Redis
   # Listen for messages published to the given channels.
   def subscribe(*channels, &block)
     synchronize do |client|
-      _subscription(:subscribe, channels, block)
+      _subscription(:subscribe, 0, channels, block)
+    end
+  end
+
+  # Listen for messages published to the given channels. Throw a timeout error if there is no messages for a timeout period.
+  def subscribe_with_timeout(timeout, *channels, &block)
+    synchronize do |client|
+      _subscription(:subscribe_with_timeout, timeout, channels, block)
     end
   end
 
@@ -1950,7 +1957,14 @@ class Redis
   # Listen for messages published to channels matching the given patterns.
   def psubscribe(*channels, &block)
     synchronize do |client|
-      _subscription(:psubscribe, channels, block)
+      _subscription(:psubscribe, 0, channels, block)
+    end
+  end
+
+  # Listen for messages published to channels matching the given patterns. Throw a timeout error if there is no messages for a timeout period.
+  def psubscribe_with_timeout(timeout, *channels, &block)
+    synchronize do |client|
+      _subscription(:psubscribe_with_timeout, timeout, channels, block)
     end
   end
 
@@ -2268,12 +2282,16 @@ private
     end
   end
 
-  def _subscription(method, channels, block)
+  def _subscription(method, timeout, channels, block)
     return @client.call([method] + channels) if subscribed?
 
     begin
       original, @client = @client, SubscribedClient.new(@client)
-      @client.send(method, *channels, &block)
+      if timeout > 0
+        @client.send(method, timeout, *channels, &block)
+      else
+        @client.send(method, *channels, &block)
+      end
     ensure
       @client = original
     end

--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -91,10 +91,10 @@ class Redis
       end
     end
 
-    def call_loop(command)
+    def call_loop(command, timeout = 0)
       error = nil
 
-      result = without_socket_timeout do
+      result = with_socket_timeout(timeout) do
         process([command]) do
           loop do
             reply = read

--- a/test/publish_subscribe_test.rb
+++ b/test/publish_subscribe_test.rb
@@ -148,4 +148,42 @@ class TestPublishSubscribe < Test::Unit::TestCase
       assert received
     end
   end
+
+  def test_subscribe_with_timeout
+    assert_raise Redis::TimeoutError do
+      sleep = %{sleep #{OPTIONS[:timeout] * 2}}
+      publish = %{echo "publish foo bar\r\n" | nc localhost #{OPTIONS[:port]}}
+      cmd = [sleep, publish].join("; ")
+
+      IO.popen(cmd, "r+") do |pipe|
+        received = false
+
+        r.subscribe_with_timeout(OPTIONS[:timeout], "foo")  do |on|
+          on.message do |channel, message|
+            received = true
+            r.unsubscribe
+          end
+        end
+      end
+    end
+  end
+
+  def test_psubscribe_with_timeout
+    assert_raise Redis::TimeoutError do
+      sleep = %{sleep #{OPTIONS[:timeout] * 2}}
+      publish = %{echo "publish foo bar\r\n" | nc localhost #{OPTIONS[:port]}}
+      cmd = [sleep, publish].join("; ")
+
+      IO.popen(cmd, "r+") do |pipe|
+        received = false
+
+        r.psubscribe_with_timeout(OPTIONS[:timeout], "f*")  do |on|
+          on.message do |channel, message|
+            received = true
+            r.unsubscribe
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hi,

I've added subscribe and psubscribe with timeout methods. That is useful when publisher could die for an any reason and subscriber should not hang endlessly waiting. 

So if there is no data published for a timeout period then Redis::Timeout error will be raised.