### PR TITLE
Make Futures identifiable

### DIFF
--- a/lib/redis/pipeline.rb
+++ b/lib/redis/pipeline.rb
@@ -126,5 +126,13 @@ class Redis
       ::Kernel.raise(@object) if @object.kind_of?(::RuntimeError)
       @object
     end
+
+    def is_a?(other)
+      self.class.ancestors.include?(other)
+    end
+
+    def class
+      Future
+    end
   end
 end

--- a/test/pipelining_commands_test.rb
+++ b/test/pipelining_commands_test.rb
@@ -132,6 +132,18 @@ class TestPipeliningCommands < Test::Unit::TestCase
     end
   end
 
+  def test_futures_can_be_identified
+    r.pipelined do
+      @result = r.sadd("foo", 1)
+    end
+
+    assert_equal true, @result.is_a?(Redis::Future)
+    if defined?(::BasicObject)
+      assert_equal true, @result.is_a?(::BasicObject)
+    end
+    assert_equal Redis::Future, @result.class
+  end
+
   def test_returning_the_result_of_an_empty_pipeline
     result = r.pipelined do
     end


### PR DESCRIPTION
I want code who gets given a value from Redis to be able to know if it need to call `value` or not on the thing to get the real value. This defines the `class` and `is_a?(other_class)` methods on `Future` so that calling code can figure out if it is a Future or not. Other ways I considered doing this:
- adding a `redis_future?` predicate method to the object, but I figure existing Ruby paradigms exist for asking objects what they are, so it makes more sense to just use the usual Ruby way.
- changing the superclass of `Future` to `Object` instead of `BasicObject`, but there is a test which assets `Future` doesn't respond to `to_s`, which `Object` definitely does. Is the superclass `BasicObject` because its easy to get confused if a value is a future or not and developers often call methods like `to_s` on futures by accident? Or is it for performance?

Thoughts? Thanks for any and all feedback!
