### PR TITLE
Ensure #watch without a block returns "OK"

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -1994,7 +1994,7 @@ class Redis
   # @see #multi
   def watch(*keys)
     synchronize do |client|
-      client.call([:watch] + keys)
+      res = client.call([:watch] + keys)
 
       if block_given?
         begin
@@ -2005,6 +2005,8 @@ class Redis
           unwatch
           raise
         end
+      else
+        res
       end
     end
   end

--- a/test/transactions_test.rb
+++ b/test/transactions_test.rb
@@ -157,6 +157,12 @@ class TestTransactions < Test::Unit::TestCase
     end
   end
 
+  def test_watch
+    res = r.watch "foo"
+
+    assert_equal "OK", res
+  end
+
   def test_watch_with_an_unmodified_key
     r.watch "foo"
     r.multi do |multi|


### PR DESCRIPTION
This regression was spotted during our upgrade from redis-rb 2.2.2 to 3.0.3
