### PR TITLE
Allows using a custom HashRing in Redis::Distributed

### DIFF
--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -17,8 +17,8 @@ class Redis
 
     def initialize(node_configs, options = {})
       @tag = options.delete(:tag) || /^\{(.+?)\}/
+      @ring = options.delete(:ring) || HashRing.new
       @default_options = options
-      @ring = HashRing.new
       node_configs.each { |node_config| add_node(node_config) }
       @subscribed_node = nil
     end


### PR DESCRIPTION
We're using Redis::Distributed, but the default sharding algorithm as implemented by Redis::HashRing doesn't cut it for us. So, instead of monkey-patching, I think the constructor should accept an optional :ring parameter.
