### PR TITLE
make number of retries in ensure_connected configurable

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -16,7 +16,8 @@ class Redis
       :db => 0,
       :driver => nil,
       :id => nil,
-      :tcp_keepalive => 0
+      :tcp_keepalive => 0,
+      :reconnect_attempts => 1
     }
 
     def scheme
@@ -279,7 +280,7 @@ class Redis
     end
 
     def ensure_connected
-      tries = 0
+      attempts = 0
 
       begin
         if connected?
@@ -292,13 +293,13 @@ class Redis
           connect
         end
 
-        tries += 1
+        attempts += 1
 
         yield
       rescue ConnectionError
         disconnect
 
-        if tries < 2 && @reconnect
+        if attempts <= @options[:reconnect_attempts] && @reconnect
           retry
         else
           raise

--- a/test/internals_test.rb
+++ b/test/internals_test.rb
@@ -146,7 +146,7 @@ class TestInternals < Test::Unit::TestCase
     end
   end
 
-  def close_on_ping(seq)
+  def close_on_ping(seq, options = {})
     $request = 0
 
     command = lambda do
@@ -158,7 +158,7 @@ class TestInternals < Test::Unit::TestCase
       rv
     end
 
-    redis_mock(:ping => command, :timeout => 0.1) do |redis|
+    redis_mock({:ping => command}, {:timeout => 0.1}.merge(options)) do |redis|
       yield(redis)
     end
   end
@@ -199,6 +199,22 @@ class TestInternals < Test::Unit::TestCase
 
   def test_retry_only_once_when_read_raises_econnreset
     close_on_ping([0, 1]) do |redis|
+      assert_raise Redis::ConnectionError do
+        redis.ping
+      end
+
+      assert !redis.client.connected?
+    end
+  end
+
+  def test_retry_with_custom_reconnect_attempts
+    close_on_ping([0, 1], :reconnect_attempts => 2) do |redis|
+      assert_equal "2", redis.ping
+    end
+  end
+
+  def test_retry_with_custom_reconnect_attempts_can_still_fail
+    close_on_ping([0, 1, 2], :reconnect_attempts => 2) do |redis|
       assert_raise Redis::ConnectionError do
         redis.ping
       end


### PR DESCRIPTION
Instead of retrying only once on connection failures,
have a config option in the client to specify how
many attempts should be made.
