### PR TITLE
Unhandled Errno::EINVAL

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -276,6 +276,8 @@ class Redis
       raise CannotConnectError, "Timed out connecting to Redis on #{location}"
     rescue Errno::ECONNREFUSED
       raise CannotConnectError, "Error connecting to Redis on #{location} (ECONNREFUSED)"
+    rescue Errno::EINVAL
+      raise CannotConnectError, "Error connecting to Redis on #{location} (EINVAL)"
     end
 
     def ensure_connected


### PR DESCRIPTION
Hello,

I've run into a similar issue to the error handling encapsulatation as issue [353](https://github.com/redis/redis-rb/issues/353). When using hiredis-rb and a connection can't be made during the establish_connection call a Errno::EINVAL is not being captured and raised as a Redis::ConnectionError. Would it make sense to go ahead and make this change? If so I can submit a patch for this. 

```
Errno::EINVAL - Invalid argument:
  redis (3.0.4) lib/redis/connection/hiredis.rb:16:in `connect'
  redis (3.0.4) lib/redis/client.rb:271:in `establish_connection
```
