### PR TITLE
Expose SCAN command as an Enumerator

### DIFF
--- a/test/scanning_test.rb
+++ b/test/scanning_test.rb
@@ -54,6 +54,65 @@ class TestScanning < Test::Unit::TestCase
     end
   end
 
+  def test_scan_each_enumerator
+    target_version "2.7.105" do
+
+      r.debug :populate, 1000
+
+      scan_enumerator = r.scan_each
+      assert_equal true, scan_enumerator.is_a?(::Enumerator)
+
+      keys_from_scan = scan_enumerator.to_a.uniq
+      all_keys = r.keys "*"
+
+      assert_equal all_keys.sort, keys_from_scan.sort
+    end
+  end
+
+  def test_scan_each_enumerator_match
+    target_version "2.7.105" do
+
+      r.debug :populate, 1000
+
+      keys_from_scan = r.scan_each(:match => "key:1??").to_a.uniq
+      all_keys = r.keys "key:1??"
+
+      assert_equal all_keys.sort, keys_from_scan.sort
+    end
+  end
+
+  def test_scan_each_block
+    target_version "2.7.105" do
+
+      r.debug :populate, 100
+
+      keys_from_scan   = []
+      r.scan_each {|key|
+        keys_from_scan << key
+      }
+
+      all_keys = r.keys "*"
+
+      assert_equal all_keys.sort, keys_from_scan.uniq.sort
+    end
+  end
+
+  def test_scan_each_block_match
+    target_version "2.7.105" do
+
+      r.debug :populate, 100
+
+      keys_from_scan   = []
+      r.scan_each(:match => "key:1?") {|key|
+        keys_from_scan << key
+      }
+
+      all_keys = r.keys "key:1?"
+
+      assert_equal all_keys.sort, keys_from_scan.uniq.sort
+    end
+  end
+
   def test_sscan_with_encoding
     target_version "2.7.105" do
       [:intset, :hashtable].each do |enc|
@@ -79,6 +138,70 @@ class TestScanning < Test::Unit::TestCase
 
         assert_equal 100, all_keys.uniq.size
       end
+    end
+  end
+
+  def test_sscan_each_enumerator
+    target_version "2.7.105" do
+      elements = []
+      100.times { |j| elements << "ele:#{j}" }
+      r.sadd "set", elements
+
+      scan_enumerator = r.sscan_each("set")
+      assert_equal true, scan_enumerator.is_a?(::Enumerator)
+
+      keys_from_scan = scan_enumerator.to_a.uniq
+      all_keys = r.smembers("set")
+
+      assert_equal all_keys.sort, keys_from_scan.sort
+    end
+  end
+
+  def test_sscan_each_enumerator_match
+    target_version "2.7.105" do
+      elements = []
+      100.times { |j| elements << "ele:#{j}" }
+      r.sadd "set", elements
+
+      keys_from_scan = r.sscan_each("set", :match => "ele:1?").to_a.uniq
+
+      all_keys = r.smembers("set").grep(/^ele:1.$/)
+
+      assert_equal all_keys.sort, keys_from_scan.sort
+    end
+  end
+
+  def test_sscan_each_enumerator_block
+    target_version "2.7.105" do
+      elements = []
+      100.times { |j| elements << "ele:#{j}" }
+      r.sadd "set", elements
+
+      keys_from_scan = []
+      r.sscan_each("set") do |key|
+        keys_from_scan << key
+      end
+
+      all_keys = r.smembers("set")
+
+      assert_equal all_keys.sort, keys_from_scan.uniq.sort
+    end
+  end
+
+  def test_sscan_each_enumerator_block_match
+    target_version "2.7.105" do
+      elements = []
+      100.times { |j| elements << "ele:#{j}" }
+      r.sadd "set", elements
+
+      keys_from_scan = []
+      r.sscan_each("set", :match => "ele:1?") do |key|
+        keys_from_scan << key
+      end
+
+      all_keys = r.smembers("set").grep(/^ele:1.$/)
+
+      assert_equal all_keys.sort, keys_from_scan.uniq.sort
     end
   end
 
@@ -116,6 +239,71 @@ class TestScanning < Test::Unit::TestCase
     end
   end
 
+  def test_hscan_each_enumerator
+    target_version "2.7.105" do
+      count = 1000
+      elements = []
+      count.times { |j| elements << "key:#{j}" << j.to_s }
+      r.hmset "hash", *elements
+
+      scan_enumerator = r.hscan_each("hash")
+      assert_equal true, scan_enumerator.is_a?(::Enumerator)
+
+      keys_from_scan = scan_enumerator.to_a.uniq
+      all_keys = r.hgetall("hash").to_a
+
+      assert_equal all_keys.sort, keys_from_scan.sort
+    end
+  end
+
+  def test_hscan_each_enumerator_match
+    target_version "2.7.105" do
+      count = 100
+      elements = []
+      count.times { |j| elements << "key:#{j}" << j.to_s }
+      r.hmset "hash", *elements
+
+      keys_from_scan = r.hscan_each("hash", :match => "key:1?").to_a.uniq
+      all_keys = r.hgetall("hash").to_a.select{|k,v| k =~ /^key:1.$/}
+
+      assert_equal all_keys.sort, keys_from_scan.sort
+    end
+  end
+
+  def test_hscan_each_block
+    target_version "2.7.105" do
+      count = 1000
+      elements = []
+      count.times { |j| elements << "key:#{j}" << j.to_s }
+      r.hmset "hash", *elements
+
+      keys_from_scan = []
+      r.hscan_each("hash") do |*key_value|
+        keys_from_scan << key_value
+      end
+      all_keys = r.hgetall("hash").to_a
+
+      assert_equal all_keys.sort, keys_from_scan.uniq.sort
+    end
+  end
+
+  def test_hscan_each_block_match
+    target_version "2.7.105" do
+      count = 1000
+      elements = []
+      count.times { |j| elements << "key:#{j}" << j.to_s }
+      r.hmset "hash", *elements
+
+      keys_from_scan = []
+      r.hscan_each("hash", :match => "key:1?") do |*key_value|
+        keys_from_scan << key_value
+      end
+      all_keys = r.hgetall("hash").to_a.select{|k,v| k =~ /^key:1.$/}
+
+      assert_equal all_keys.sort, keys_from_scan.uniq.sort
+    end
+  end
+
   def test_zscan_with_encoding
     target_version "2.7.105" do
       [:ziplist, :skiplist].each do |enc|
@@ -150,4 +338,72 @@ class TestScanning < Test::Unit::TestCase
       end
     end
   end
+
+  def test_zscan_each_enumerator
+    target_version "2.7.105" do
+      count = 1000
+      elements = []
+      count.times { |j| elements << j << "key:#{j}" }
+      r.zadd "zset", elements
+
+      scan_enumerator = r.zscan_each "zset"
+      assert_equal true, scan_enumerator.is_a?(::Enumerator)
+
+      scores_from_scan = scan_enumerator.to_a.uniq
+      member_scores = r.zrange("zset", 0, -1, :with_scores => true)
+
+      assert_equal member_scores.sort, scores_from_scan.sort
+    end
+  end
+
+  def test_zscan_each_enumerator_match
+    target_version "2.7.105" do
+      count = 1000
+      elements = []
+      count.times { |j| elements << j << "key:#{j}" }
+      r.zadd "zset", elements
+
+      scores_from_scan = r.zscan_each("zset", :match => "key:1??").to_a.uniq
+      member_scores = r.zrange("zset", 0, -1, :with_scores => true)
+      filtered_members = member_scores.select{|k,s| k =~ /^key:1..$/}
+
+      assert_equal filtered_members.sort, scores_from_scan.sort
+    end
+  end
+
+  def test_zscan_each_block
+    target_version "2.7.105" do
+      count = 1000
+      elements = []
+      count.times { |j| elements << j << "key:#{j}" }
+      r.zadd "zset", elements
+
+      scores_from_scan = []
+      r.zscan_each("zset") do |*key_score|
+        scores_from_scan << key_score
+      end
+      member_scores = r.zrange("zset", 0, -1, :with_scores => true)
+
+      assert_equal member_scores.sort, scores_from_scan.sort
+    end
+  end
+
+  def test_zscan_each_block_match
+    target_version "2.7.105" do
+      count = 1000
+      elements = []
+      count.times { |j| elements << j << "key:#{j}" }
+      r.zadd "zset", elements
+
+      scores_from_scan = []
+      r.zscan_each("zset", :match => "key:1??") do |*key_score|
+        scores_from_scan << key_score
+      end
+      member_scores = r.zrange("zset", 0, -1, :with_scores => true)
+      filtered_members = member_scores.select{|k,s| k =~ /^key:1..$/}
+
+      assert_equal filtered_members.sort, scores_from_scan.sort
+    end
+  end
+
 end


### PR DESCRIPTION
I believe the new SCAN commands lend themselves naturally to Enumerator behavior. There are very few cases where the consuming code will care about the `cursor` value that is returned - most will just want to iterate through all of the values that get returned.

I understand this library is intended to provide a very thin wrapper over the Redis API, but this seems to be one of the few cases where adding a little language sugar would be valuable.

I named the method `scan_each` just to demonstrate it, but I think it makes sense to make this the default implementation of the `scan` method, and possibly expose the lower-level method (the existing implementation) via another name.

I only implemented the one method for now, but can implement the rest if it is agreed that this approach is valuable.
- [x] update to be compatible with new `#hscan` and `#zscan` return values
