### PR TITLE
FIXBUILD: Test server configuration needs test/db directory

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,15 +7,18 @@ require 'redis/version'
 
 REDIS_DIR = File.expand_path(File.join("..", "test"), __FILE__)
 REDIS_CNF = File.join(REDIS_DIR, "test.conf")
-REDIS_PID = File.join(REDIS_DIR, "db", "redis.pid")
+REDIS_DB_DIR = File.join(REDIS_DIR, "db")
+REDIS_PID = File.join(REDIS_DB_DIR, "redis.pid")
 
 task :default => :run
 
 desc "Run tests and manage server start/stop"
 task :run => [:start, :test, :stop]
 
+directory REDIS_DB_DIR
+
 desc "Start the Redis server"
-task :start do
+task :start => REDIS_DB_DIR do
   redis_running = \
   begin
     File.exists?(REDIS_PID) && Process.kill(0, File.read(REDIS_PID).to_i)


### PR DESCRIPTION
A [recent cleanup commit](https://github.com/redis/redis-rb/commit/0c76a9f72f9617b0549a67a0f2c9602db1bef704) removed the last file in the `test/db` directory. `test.conf` references that directory, so we'll ensure it exists before attempting to start the server.
