### PR TITLE
Improve return values for zscan and hscan

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -2322,9 +2322,11 @@ class Redis
   #   - `:match => String`: only return keys matching the pattern
   #   - `:count => Integer`: return count keys at most per iteration
   #
-  # @return [String, Array<String>] the next cursor and all found keys
+  # @return [String, Array<[String, String]>] the next cursor and all found keys
   def hscan(key, cursor, options={})
-    _scan(:hscan, cursor, options.merge(:key => key))
+    _scan(:hscan, cursor, options.merge(:key => key)) do |reply|
+      [reply[0], reply[1].each_slice(2).to_a]
+    end
   end
 
   # Scan a sorted set

--- a/test/scanning_test.rb
+++ b/test/scanning_test.rb
@@ -98,15 +98,15 @@ class TestScanning < Test::Unit::TestCase
         assert_equal enc.to_s, r.object("encoding", "hash")
 
         cursor = 0
-        all_keys   = []
+        all_key_values   = []
         loop {
-          cursor, keys = r.hscan "hash", cursor
-          all_keys += keys
+          cursor, key_values = r.hscan "hash", cursor
+          all_key_values.concat key_values
           break if cursor == "0"
         }
 
         keys2 = []
-        all_keys.each_slice(2) do |k, v|
+        all_key_values.each do |k, v|
           assert_equal "key:#{v}", k
           keys2 << k
         end


### PR DESCRIPTION
Makes `#zscan` return an array of key/score pairs as its second return value, to more closely match the return value of `#zrange`:

```
r.zscan "scores", 0
# => [7, [["a", 2], ["d", 18.0], ["g", 32.0]]]
```

Makes `#hscan` return an array of key/value  pairs as its second return value:

```
r.hscan "details", 0
# => [0, [["name", "bob"], ["age", "42"]]]
```

As suggested by @federicobond on https://github.com/redis/redis-rb/pull/379
