### PR TITLE
Ability to access complete set of client options.

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -19,6 +19,10 @@ class Redis
       :tcp_keepalive => 0
     }
 
+    def options
+      Marshal.load(Marshal.dump(@options))
+    end
+
     def scheme
       @options[:scheme]
     end

--- a/test/internals_test.rb
+++ b/test/internals_test.rb
@@ -320,4 +320,26 @@ class TestInternals < Test::Unit::TestCase
       serv.close if serv
     end
   end
+
+  def test_client_options
+    redis = Redis.new(OPTIONS.merge(:host => "host", :port => 1234, :db => 1, :scheme => "foo"))
+
+    assert_equal "host", redis.client.options[:host]
+    assert_equal 1234, redis.client.options[:port]
+    assert_equal 1, redis.client.options[:db]
+    assert_equal "foo", redis.client.options[:scheme]
+  end
+
+  def test_does_not_change_self_client_options
+    redis = Redis.new(OPTIONS.merge(:host => "host", :port => 1234, :db => 1, :scheme => "foo"))
+    options = redis.client.options
+
+    options[:host] << "new_host"
+    options[:scheme] << "bar"
+    options.merge!(:db => 0)
+
+    assert_equal "host", redis.client.options[:host]
+    assert_equal 1, redis.client.options[:db]
+    assert_equal "foo", redis.client.options[:scheme]
+  end
 end


### PR DESCRIPTION
Hello!

Often there is the need to create a new connection to Redis on the basis of existing.
For example, to create a writing session and maintain the ability to read at the time of the transaction.

Because there is no such possibility, it is necessary to use the following method:

``` ruby
def write_session
  @write_session ||= ::Redis.new(
    :host    => main_redis.client.host,
    :port    => main_redis.client.port,
    :db      => main_redis.client.db,
    :timeout => main_redis.client.timeout
  )
end
```

But this method does not copy all properties, since they are not available.
For example you can not copy the property "driver."

I would like to have a method of making a copy of connection or (and) to be able to access all the properties of the connection.

Then I could write the following code:

``` ruby
  def write_session
    @write_session ||= ::Redis.new(main_redis.client.options)
  end
```

or even:

``` ruby
def write_session
  @write_session ||= main_redis.client.clone_connection
end
```

This pull request makes available a a complete set of client options.
