### PR TITLE
modify hgetall to also yield field and value

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -1929,9 +1929,16 @@ class Redis
   #
   # @param [String] key
   # @return [Hash<String, String>]
-  def hgetall(key)
-    synchronize do |client|
-      client.call([:hgetall, key], &_hashify)
+  # @yield [field, value]
+  def hgetall(key, &block)
+    if block_given? && block.arity == 2
+      synchronize { |client|
+        client.call([:hgetall, key], &_hashify)
+      }.each { |field, value| yield field, value }
+    else
+      synchronize do |client|
+        client.call([:hgetall, key], &_hashify)
+      end
     end
   end
 

--- a/test/commands_on_hashes_test.rb
+++ b/test/commands_on_hashes_test.rb
@@ -18,4 +18,27 @@ class TestCommandsOnHashes < Test::Unit::TestCase
 
     assert_equal result[0], { "f1" => "s1", "f2" => "s2" }
   end
+
+  def test_hgetall
+    r.hset("foo", "f1", "s1")
+    r.hset("foo", "f2", "s2")
+
+    result = r.hgetall("foo")
+
+    assert_equal "s1", result["f1"]
+    assert_equal "s2", result["f2"]
+  end
+
+  def test_hgetall_with_block
+    r.hset("foo", "f1", "s1")
+    r.hset("foo", "f2", "s2")
+
+    result = {}
+    r.hgetall("foo") do |field, value|
+      result[field] = value
+    end
+
+    assert_equal "s1", result["f1"]
+    assert_equal "s2", result["f2"]
+  end
 end


### PR DESCRIPTION
Added a helper to make `hgetall` yield field & value pair, which can be used like this:

```
redis.hgetall('foo') do |field, value|
  puts "field = #{field} : value = #{value}"
end
```
