### PR TITLE
Include affected command in "operation not permitted" error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /rdsrv
 /redis/*
 /test/db
+/tmp

--- a/test/operation_not_permitted_test.rb
+++ b/test/operation_not_permitted_test.rb
@@ -1,0 +1,84 @@
+# encoding: UTF-8
+
+require File.expand_path("helper", File.dirname(__FILE__))
+
+class TestOperationNotPermitted < Test::Unit::TestCase
+
+  include Helper::Client
+
+  def test_includes_the_affected_command_in_the_error_message
+    redis_mock(:set => lambda { |*_| "-ERR operation not permitted" }) do |redis|
+      begin
+        redis.set :foo, 1
+      rescue Redis::CommandError => e
+      end
+
+      assert_match(/SET foo 1/, e.message)
+    end
+  end
+
+  def test_pipeline_includes_the_first_affected_command_in_the_error_message
+    redis_mock(:get => lambda { |*_| "-ERR operation not permitted" }) do |redis|
+      begin
+        redis.pipelined do
+          redis.set :foo, 1
+          redis.set :bar, 2
+          redis.get :foo
+          redis.set :baz, 3
+        end
+      rescue Redis::CommandError => e
+      end
+
+      assert_match(/GET foo/, e.message)
+    end
+  end
+
+  def test_multi_with_block_includes_the_affected_commands_in_the_error_message
+    commands = {
+      :multi => lambda { |*_| "+OK" },
+      :set   => lambda { |*_| "+QUEUED" },
+      :get   => lambda { |*_| "-ERR operation not permitted" },
+      :exec  => lambda { |*_| "-EXECABORT Transaction discarded because of previous errors." }
+    }
+    redis_mock(commands) do |redis|
+      begin
+        redis.multi do |multi|
+          multi.set :foo, 1
+          multi.set :bar, 2
+          multi.get :foo
+          multi.set :baz, 3
+          multi.get :bar
+        end
+      rescue Redis::CommandError => e
+      end
+
+      assert_match(/GET foo/, e.message)
+      assert_match(/GET bar/, e.message)
+    end
+  end
+
+  def test_pubsub_includes_the_affected_command_in_the_error_message
+    redis_mock(:subscribe => lambda { |*_| "-ERR operation not permitted" }) do |redis|
+      begin
+        redis.subscribe [:foo, :bar] do |on|
+        end
+      rescue Redis::CommandError => e
+      end
+
+      assert_match(/SUBSCRIBE foo bar/, e.message)
+    end
+  end
+
+  def test_limit_the_error_message_length_to_avoid_long_strings
+    items = (1..1000).to_a
+
+    redis_mock(:set => lambda { |*_| "-ERR operation not permitted" }) do |redis|
+      begin
+        redis.set :foo, items
+      rescue Redis::CommandError => e
+      end
+
+      assert_equal 256, e.message.size
+    end
+  end
+end

--- a/test/unknown_commands_test.rb
+++ b/test/unknown_commands_test.rb
@@ -11,4 +11,17 @@ class TestUnknownCommands < Test::Unit::TestCase
       r.not_yet_implemented_command
     end
   end
+
+  def test_multi_with_block_includes_unknown_commands_in_the_error_message
+    begin
+      redis.multi do |multi|
+        multi.unknown1
+        multi.unknown2
+      end
+    rescue => e
+    end
+
+    assert_match(/unknown1/, e.message)
+    assert_match(/unknown2/, e.message)
+  end
 end


### PR DESCRIPTION
(see issue #358)

These are the failures that are produced by these tests (and resolved by this update):

```
  1) Failure:
test_includes_the_affected_command_in_the_error_message(TestOperationNotPermitted) [/Users/jared/Code/redis-rb/test/operation_not_permitted_test.rb:16]:
Expected "ERR operation not permitted" to include "SET foo 1".

  2) Failure:
test_limit_the_error_message_length_to_avoid_long_strings(TestOperationNotPermitted) [/Users/jared/Code/redis-rb/test/operation_not_permitted_test.rb:81]:
<256> expected but was
<27>.

  3) Failure:
test_multi_with_block_includes_the_affected_commands_in_the_error_message(TestOperationNotPermitted) [/Users/jared/Code/redis-rb/test/operation_not_permitted_test.rb:55]:
Expected "EXECABORT Transaction discarded because of previous errors." to include "GET foo".

  4) Failure:
test_pipeline_includes_the_first_affected_command_in_the_error_message(TestOperationNotPermitted) [/Users/jared/Code/redis-rb/test/operation_not_permitted_test.rb:32]:
Expected "ERR operation not permitted" to include "GET foo".

  5) Failure:
test_pubsub_includes_the_affected_command_in_the_error_message(TestOperationNotPermitted) [/Users/jared/Code/redis-rb/test/operation_not_permitted_test.rb:68]:
Expected "ERR operation not permitted" to include "SUBSCRIBE foo bar".

  6) Failure:
test_multi_with_block_includes_unknown_commands_in_the_error_message(TestUnknownCommands) [/Users/jared/Code/redis-rb/test/unknown_commands_test.rb:24]:
Expected "EXECABORT Transaction discarded because of previous errors." to include "unknown1".
```