### PR TITLE
Check inherited socket

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -16,7 +16,8 @@ class Redis
       :db => 0,
       :driver => nil,
       :id => nil,
-      :tcp_keepalive => 0
+      :tcp_keepalive => 0,
+      :enable_inherited_socket => false
     }
 
     def options
@@ -57,6 +58,10 @@ class Redis
 
     def driver
       @options[:driver]
+    end
+
+    def enable_inherited_socket
+      @options[:enable_inherited_socket]
     end
 
     attr_accessor :logger
@@ -300,10 +305,11 @@ class Redis
         tries += 1
 
         if connected?
-          if Process.pid != @pid
+          if !enable_inherited_socket && Process.pid != @pid
             raise InheritedError,
               "Tried to use a connection from a child process without reconnecting. " +
-              "You need to reconnect to Redis after forking."
+              "You need to reconnect to Redis after forking " +
+              "or set :enable_inherited_socket to true."
           end
         else
           connect

--- a/test/fork_safety_test.rb
+++ b/test/fork_safety_test.rb
@@ -30,5 +30,29 @@ class TestForkSafety < Test::Unit::TestCase
       assert_equal "1", redis.get("foo")
 
     end
+
+    def test_fork_safety_with_enabled_inherited_socket
+      redis = Redis.new(OPTIONS.merge(:enable_inherited_socket => true))
+      redis.set "foo", 1
+
+      child_pid = fork {
+        begin
+          # InheritedError triggers a reconnect,
+          # so we need to disable reconnects to force
+          # the exception bubble up
+          redis.without_reconnect {
+            redis.set "foo", 2
+          }
+        rescue Redis::InheritedError
+          exit 127
+        end
+      }
+
+      _, status = Process.wait2(child_pid)
+
+      assert_equal 0, status.exitstatus
+      assert_equal "2", redis.get("foo")
+
+    end
   end
 end


### PR DESCRIPTION
Hello,

This patchset is about adding an extra redis option, `check_inherited_socket`, that allows to control the fd leakage on fork (`Redis::InheritedError`)

There are cases when you want the child to inherit the redis socket to avoid an unnecessary reconnect. In that case you need to handle locking yourself.

```
redis.ping # connect to redis
thousands_of_times do
  fork do
    # share redis socket and avoid reconnecting
    redis.set 'foo', 'bar'
  end
end
```

The `check_inherited_socket` name is probably a bad one, we can change it with something more appropriate.
