### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# redis-rb [![Build Status][travis-image]][travis-link]
+# redis-rb [![Build Status][travis-image]][travis-link] [![Inline docs][inchpages-image]][inchpages-link]
 
 [travis-image]: https://secure.travis-ci.org/redis/redis-rb.png?branch=master
 [travis-link]: http://travis-ci.org/redis/redis-rb
 [travis-home]: http://travis-ci.org/
+[inchpages-image]: http://inch-pages.github.io/github/redis/redis-rb.png
+[inchpages-link]: http://inch-pages.github.io/github/redis/redis-rb
 
 A Ruby client library for [Redis][redis-home].
 


### PR DESCRIPTION
Hi there,

this patch adds a docs badge to the README to show off inline-documentation to the casual visitor: [![Inline docs](http://inch-pages.github.io/github/redis/redis-rb.png)](http://inch-pages.github.io/github/redis/redis-rb)

The badge links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of documentation in Ruby projects. The status page for the Redis client is http://inch-pages.github.io/github/redis/redis-rb/

Inch Pages is still in it's infancy, but already used by projects like [Guard](https://github.com/guard/guard) and [Pry](https://github.com/pry/pry).

What do you think?
