### PR TITLE
client: make Redis::Client#ensure_connected handle fork reconnects

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -307,7 +307,7 @@ class Redis
         tries += 1
 
         yield
-      rescue ConnectionError
+      rescue ConnectionError, InheritedError
         disconnect
 
         if tries < 2 && @reconnect


### PR DESCRIPTION
If `@reconnect` is enabled and `#ensure_connected` is called in the forked child of
the process that established the connection, a reconnect attempt should be made;
handle this case like any other `ConnectionError`.
