### PR TITLE
Fix mapped_hmset with empty hash

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -1808,7 +1808,7 @@ class Redis
   #
   # @see #hmset
   def mapped_hmset(key, hash)
-    hmset(key, hash.to_a.flatten)
+    hmset(key, hash.to_a.flatten) unless hash.empty?
   end
 
   # Get the value of a hash field.

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -656,7 +656,7 @@ class Redis
     end
 
     def mapped_hmset(key, hash)
-      node_for(key).hmset(key, *hash.to_a.flatten)
+      node_for(key).hmset(key, *hash.to_a.flatten) unless hash.empty?
     end
 
     # Get the value of a hash field.

--- a/test/lint/hashes.rb
+++ b/test/lint/hashes.rb
@@ -112,6 +112,10 @@ module Lint
       assert_equal "s2", r.hget("foo", "f2")
     end
 
+    def test_mapped_hmset_with_empty_hash
+      r.mapped_hmset("foo", {})
+    end
+
     def test_hmget
       r.hset("foo", "f1", "s1")
       r.hset("foo", "f2", "s2")


### PR DESCRIPTION
If you try to use `mapped_hmset` with an empty hash, like `r.mapped_hmset("foo", {})`, the following exception is raised:

```
Redis::CommandError: ERR wrong number of arguments for 'hmset' command
    /Users/juarez.bochi/projects/redis-rb/lib/redis/client.rb:97:in `call'
    /Users/juarez.bochi/projects/redis-rb/lib/redis.rb:1795:in `block in hmset'
    /Users/juarez.bochi/projects/redis-rb/lib/redis.rb:37:in `block in synchronize'
```
