### PR TITLE
Sanitize debug logging

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -276,7 +276,7 @@ class Redis
         commands.each do |name, *args|
           logged_args = args.map do |a|
             str = a.respond_to?(:inspect) ? a.inspect : a.to_s
-            str.truncate(100)
+            str.length > 100 ? str[0..100] + "..." : str
           end
           @logger.debug("[Redis] name=#{name.to_s.upcase} args=#{logged_args.join(" ")}")
         end

--- a/test/internals_test.rb
+++ b/test/internals_test.rb
@@ -9,8 +9,8 @@ class TestInternals < Test::Unit::TestCase
   def test_logger
     r.ping
 
-    assert log.string =~ /Redis >> PING/
-      assert log.string =~ /Redis >> \d+\.\d+ms/
+    assert log.string["[Redis] name=PING"]
+    assert log.string =~ /\[Redis\] call_time=\d+\.\d+ ms/
   end
 
   def test_logger_with_pipelining
@@ -19,8 +19,8 @@ class TestInternals < Test::Unit::TestCase
       r.get "foo"
     end
 
-    assert log.string["SET foo bar"]
-    assert log.string["GET foo"]
+    assert log.string[" name=SET args=\"foo\" \"bar\""]
+    assert log.string[" name=GET args=\"foo\""]
   end
 
   def test_recovers_from_failed_commands


### PR DESCRIPTION
Hey folks,

We're having some issues with really long arguments and/or arguments that can end up with unprintable characters in the terminal. 

This PR adds a bit of sanitizing to the logging.

cc @airhorns
