### PR TITLE
Backport INFO fix to 2.x

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -90,7 +90,9 @@ class Redis
       reply = @client.call [:info, cmd].compact
 
       if reply.kind_of?(String)
-        reply = Hash[*reply.split(/:|\r\n/).grep(/^[^#]/)]
+        reply = Hash[reply.split("\r\n").map do |line|
+          line.split(":", 2) unless line =~ /^(#|$)/
+        end]
 
         if cmd && cmd.to_s == "commandstats"
           # Extract nested hashes for INFO COMMANDSTATS


### PR DESCRIPTION
I just hit this on a project whose dependencies prevent using 3.x, and while I'm looking to resolve that, since a fix was applied to 3.x, I thought I'd backport it.

EDIT: I created a new `support/2.x` branch based off the tag for `v2.2.2`, which I think is the furthest we got on the 2.x series; if anyone knows otherwise, I'd be glad to rebase.