### PR TITLE
Add myself to authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ all contributors)
 * Nick Quaranto
 * Pieter Noordhuis
 * Ilya Grigorik
+* Ryan Biesemeyer
 
 ## Contributing
 

--- a/redis.gemspec
+++ b/redis.gemspec
@@ -30,7 +30,8 @@ Gem::Specification.new do |s|
     "Luca Guidi",
     "Michel Martens",
     "Damian Janowski",
-    "Pieter Noordhuis"
+    "Pieter Noordhuis",
+    "Ryan Biesemeyer"
   ]
 
   s.email = ["redis-db@googlegroups.com"]


### PR DESCRIPTION
Since I intend to stick around & be an active maintainer, add me to the list of authors in the README and in the gemspec for future gem releases:

``` sh
╭─{ yaauie @ beorn in ~/src/redis-rb (✔ add-me-to-authors) }
╰─● git shortlog -sn | grep Biesemeyer
    23  Ryan Biesemeyer
[success.]
```
