### PR TITLE
doc: mapped_hmset doesn't accept empty hashes

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -1824,7 +1824,7 @@ class Redis
   #     # => "OK"
   #
   # @param [String] key
-  # @param [Hash] hash fields mapping to values
+  # @param [Hash] a non-empty hash with fields mapping to values
   # @return `"OK"`
   #
   # @see #hmset


### PR DESCRIPTION
Since we elected not to accept [#416](https://github.com/redis/redis-rb/pull/416), update documentation
to explicitly state that the supplied hash must not be empty.
