### PR TITLE
enable to set options by query_string

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ redis = Redis.new(:host => "10.0.1.1", :port => 6380, :db => 15)
 You can also specify connection options as an URL:
 
 ```ruby
-redis = Redis.new(:url => "redis://:p4ssw0rd@10.0.1.1:6380/15")
+redis = Redis.new(:url => "redis://:p4ssw0rd@10.0.1.1:6380/15?timeout=3")
 ```
 
 By default, the client will try to read the `REDIS_URL` environment variable
@@ -166,7 +166,7 @@ end
       to redis, AND
     - your own code prevents the parent process from using the redis
       connection while a child is alive
-   
+
    Improper use of `inherit_socket` will result in corrupted and/or incorrect
    responses.
 

--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -374,6 +374,12 @@ class Redis
           defaults[:port]     = uri.port if uri.port
           defaults[:password] = CGI.unescape(uri.password) if uri.password
           defaults[:db]       = uri.path[1..-1].to_i if uri.path
+
+          if uri.query
+            queries = CGI.parse(uri.query)
+            defaults[:timeout]  = queries["timeout"].first if queries.has_key?("timeout")
+            defaults[:inherit_socket] = queries["inherit_socket"].first == "true" if queries.has_key?("inherit_socket")
+          end
         end
       end
 

--- a/test/url_param_test.rb
+++ b/test/url_param_test.rb
@@ -109,6 +109,16 @@ class TestUrlParam < Test::Unit::TestCase
     assert_equal "secr3t", redis.client.password
   end
 
+  def test_override_timeout_by_query_string
+    redis = Redis.new :url => "redis://:secr3t%3A@foo.com:999/2?timeout=10"
+    assert_equal 10, redis.client.timeout
+  end
+
+  def test_override_inherit_socket_by_query_string
+    redis = Redis.new :url => "redis://:secret3t%3A@foo.com:999/2?inherit_socket=true"
+    assert_equal true, redis.client.inherit_socket?
+  end
+
   def test_does_not_modify_the_passed_options
     options = { :url => "redis://:secr3t@foo.com:999/2" }
 


### PR DESCRIPTION
options:
- timeout
- inherit_socket
