### PR TITLE
Return 0 when attemping to delete an empty array

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -412,6 +412,8 @@ class Redis
   # @param [String, Array<String>] keys
   # @return [Fixnum] number of keys that were deleted
   def del(*keys)
+    return 0 if keys == [[]]
+
     synchronize do |client|
       client.call([:del] + keys)
     end

--- a/test/commands_on_value_types_test.rb
+++ b/test/commands_on_value_types_test.rb
@@ -38,6 +38,8 @@ class TestCommandsOnValueTypes < Test::Unit::TestCase
     assert_equal 2, r.del(["bar", "baz"])
 
     assert_equal [], r.keys("*").sort
+
+    assert_equal 0, r.del([])
   end
 
   def test_randomkey


### PR DESCRIPTION
When filtering a collection, you sometimes end up with an empty collection. It would be preferred if `#del` returned 0 instead of raising a `CommandError`.

This may be slower, as it's doing more. I also benched a slightly-harder-to-understand-but-maybe-faster version using rescue.

Benchmark code: http://gist.github.com/justincampbell/7a44b9a51b72df47ae84 (ran against `redis-server /dev/null`)

```
$ ruby del_benchmark.rb
                      user     system      total        real
del               5.370000   2.770000   8.140000 ( 11.480241)
del_with_check    6.760000   2.720000   9.480000 ( 12.729899)
del_with_rescue   6.580000   2.710000   9.290000 ( 12.555898)
del               6.630000   2.720000   9.350000 ( 12.605888)
del_with_check    6.840000   2.740000   9.580000 ( 12.847978)
del_with_rescue   6.650000   2.710000   9.360000 ( 12.614382)
del               6.620000   2.720000   9.340000 ( 12.599700)
del_with_check    6.820000   2.730000   9.550000 ( 12.805459)
del_with_rescue   6.650000   2.740000   9.390000 ( 12.663082)
del               6.670000   2.740000   9.410000 ( 12.738317)
del_with_check    6.790000   2.720000   9.510000 ( 12.801144)
del_with_rescue   6.600000   2.710000   9.310000 ( 12.560805)
del               6.720000   2.730000   9.450000 ( 12.726231)
del_with_check    6.830000   2.740000   9.570000 ( 12.856461)
del_with_rescue   6.590000   2.720000   9.310000 ( 12.566463)
```
