### PR TITLE
use random port for tests

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -5,6 +5,8 @@ require "test/unit"
 require "logger"
 require "stringio"
 
+(class Random; def self.rand(*args) super end; end) unless defined?(Random)
+
 begin
   require "ruby-debug"
 rescue LoadError

--- a/test/internals_test.rb
+++ b/test/internals_test.rb
@@ -361,7 +361,7 @@ class TestInternals < Test::Unit::TestCase
         begin
           tries = 5
           begin
-            sa = Socket.pack_sockaddr_in(Random.rand(1024..65000), hosts[af])
+            sa = Socket.pack_sockaddr_in(1024 + Random.rand(63076), hosts[af])
             s.bind(sa)
           rescue Errno::EADDRINUSE => e
             tries -= 1


### PR DESCRIPTION
if port 9999 is in use the tests will fail because the port is hardcoded
I have added a try/catch with Random. It fixes: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=755320
