### PR TITLE
Redis#mapped_mget should work with arrays

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -816,7 +816,7 @@ class Redis
   def mapped_mget(*keys)
     mget(*keys) do |reply|
       if reply.kind_of?(Array)
-        Hash[keys.zip(reply)]
+        Hash[keys.flatten.zip(reply)]
       else
         reply
       end

--- a/test/commands_on_strings_test.rb
+++ b/test/commands_on_strings_test.rb
@@ -30,6 +30,10 @@ class TestCommandsOnStrings < Test::Unit::TestCase
     assert_equal "s1", response["foo"]
     assert_equal "s2", response["bar"]
     assert_equal nil , response["baz"]
+
+    response = r.mapped_mget %w(foo bar)
+    assert_equal "s1", response["foo"]
+    assert_equal "s2", response["bar"]
   end
 
   def test_mapped_mget_in_a_pipeline_returns_hash


### PR DESCRIPTION
Currently, the response is not mapped correctly if you supply an array as an
argument to #mget_mapped. Instead of what you'd expect, you get the array you
provided as a single key, with the first return value as the key's value.

This patch fixes that and adds a test.
