### PR TITLE
Add Errno::EHOSTUNREACH to possible CannotConnectError failures

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -307,6 +307,8 @@ class Redis
       raise CannotConnectError, "Timed out connecting to Redis on #{location}"
     rescue Errno::ECONNREFUSED
       raise CannotConnectError, "Error connecting to Redis on #{location} (ECONNREFUSED)"
+    rescue Errno::EHOSTUNREACH
+      raise CannotConnectError, "Error connecting to Redis on #{location} (EHOSTUNREACH)"
     end
 
     def ensure_connected


### PR DESCRIPTION
Hello,

I'm using the redis-sentinel gem to handle possible server failures, but have hit an issue when a server goes down.
When a server experiences a power failure or reboots, the next request will raise Errno::EHOSTUNREACH, which is not expected.
This looks like a logical candidate to be converted into a CannotConnectError.

A way to reproduce this exception is to initialize a Redis client to a closed port or a non-existant IP on your local network and then make any request on it.
