### PR TITLE
Allow multiple arguments for `pfcount`

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -2483,9 +2483,9 @@ class Redis
   #
   # @param [String] key
   # @return [Fixnum]
-  def pfcount(key)
+  def pfcount(*keys)
     synchronize do |client|
-      client.call([:pfcount, key])
+      client.call([:pfcount] + keys.flatten(1))
     end
   end
 

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -792,8 +792,10 @@ class Redis
     end
 
     # Get the approximate cardinality of members added to HyperLogLog structure.
-    def pfcount(key)
-      node_for(key).pfcount(key)
+    def pfcount(*keys)
+      ensure_same_node(:pfcount, keys.flatten(1)) do |node|
+        node.pfcount(keys)
+      end
     end
 
     # Merge multiple HyperLogLog values into an unique value that will approximate the cardinality of the union of

--- a/test/distributed_commands_on_hyper_log_log_test.rb
+++ b/test/distributed_commands_on_hyper_log_log_test.rb
@@ -19,4 +19,15 @@ class TestDistributedCommandsOnHyperLogLog < Test::Unit::TestCase
     end
   end
 
+  def test_pfcount_multiple_keys_diff_nodes
+    target_version "2.8.9" do
+      assert_raise Redis::Distributed::CannotDistribute do
+        r.pfadd "foo", "s1"
+        r.pfadd "bar", "s2"
+
+        assert r.pfcount("res", "foo", "bar")
+      end
+    end
+  end
+
 end

--- a/test/lint/hyper_log_log.rb
+++ b/test/lint/hyper_log_log.rb
@@ -33,13 +33,25 @@ module Lint
 
     def test_variadic_pfcount
       target_version "2.8.9" do
-        assert_equal 0, r.pfcount(["foo", "bar"])
+        assert_equal 0, r.pfcount(["{1}foo", "{1}bar"])
 
-        assert_equal true, r.pfadd("foo", "s1")
-        assert_equal true, r.pfadd("bar", "s1")
-        assert_equal true, r.pfadd("bar", "s2")
+        assert_equal true, r.pfadd("{1}foo", "s1")
+        assert_equal true, r.pfadd("{1}bar", "s1")
+        assert_equal true, r.pfadd("{1}bar", "s2")
 
-        assert_equal 2, r.pfcount(["foo", "bar"])
+        assert_equal 2, r.pfcount(["{1}foo", "{1}bar"])
+      end
+    end
+
+    def test_variadic_pfcount_expanded
+      target_version "2.8.9" do
+        assert_equal 0, r.pfcount("{1}foo", "{1}bar")
+
+        assert_equal true, r.pfadd("{1}foo", "s1")
+        assert_equal true, r.pfadd("{1}bar", "s1")
+        assert_equal true, r.pfadd("{1}bar", "s2")
+
+        assert_equal 2, r.pfcount("{1}foo", "{1}bar")
       end
     end
 


### PR DESCRIPTION
It now supports both an array of keys and multiple arguments.
For distributed access, it will now also ensure that all keys
are on the same node.

The tests were changed to do correctly work both for both scenarios
(keys were extended to use tags, so they land on the same node)
Additionally, a test for this behaviour was added.

Closes #450.
