### PR TITLE
Rescue from all connection-related errors when trying to reconnect (also...

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -327,7 +327,7 @@ class Redis
         end
 
         yield
-      rescue ConnectionError, InheritedError
+      rescue BaseConnectionError
         disconnect
 
         if attempts <= @options[:reconnect_attempts] && @reconnect


### PR DESCRIPTION
... includes TimeoutError and CannotConnectError).

Is there a compelling reason to not rescue from TimeoutError or CannotConnectError.
If there was an existing connection and that dropped the first exception is a ConnectionError from which the retry-logic will recover. But since there's no connection anymore upon the next retry it will be a CannotConnectError, which is not rescued from.  This means, in case the connection drops there is only one retry-attempt possible.
