### PR TITLE
Parse query string as options

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -66,6 +66,10 @@ class Redis
       @options[:inherit_socket]
     end
 
+    def tcp_keepalive
+      @options[:tcp_keepalive]
+    end
+
     attr_accessor :logger
     attr_reader :connection
     attr_reader :command_map
@@ -391,6 +395,15 @@ class Redis
           defaults[:password] = CGI.unescape(uri.password) if uri.password
           defaults[:db]       = uri.path[1..-1].to_i if uri.path
           defaults[:role] = :master
+
+          # extract options from query string
+          if uri.query
+            params = CGI.parse(uri.query)
+            defaults[:tcp_keepalive]  = params["tcp_keepalive"][0].to_i       unless params["tcp_keepalive"].empty?
+            defaults[:driver]         = params["driver"][0]                   unless params["driver"].empty?
+            defaults[:timeout]        = params["timeout"][0].to_f             unless params["timeout"].empty?
+            defaults[:inherit_socket] = params["inherit_socket"][0] == "true" unless params["inherit_socket"].empty?
+          end
         else
           raise ArgumentError, "invalid uri scheme '#{uri.scheme}'"
         end

--- a/test/url_param_test.rb
+++ b/test/url_param_test.rb
@@ -45,6 +45,28 @@ class TestUrlParam < Test::Unit::TestCase
     assert_equal "secr3t:", redis.client.password
   end
 
+  def test_parses_query_string
+    redis = Redis.new(:url => "redis://:secr3t@foo.com:999/2?tcp_keepalive=100&timeout=999&inherit_socket=true")
+
+    assert_equal({ :time => 80, :intvl => 10, :probes => 2 }, redis.client.tcp_keepalive)
+    assert_equal(999, redis.client.timeout)
+    assert_equal(true, redis.client.inherit_socket?)
+  end
+
+  if RUBY_VERSION.start_with?("1.8")
+    def test_parses_query_string_driver
+      assert_raise RuntimeError do
+        Redis.new(:url => "redis://:secr3t@foo.com:999/2?driver=randomdriver")
+      end
+    end
+  else#if RUBY_VERSION.start_with?("1.9")
+    def test_parses_query_string_driver
+      assert_raise RuntimeError, 'Cannot load driver "randomdriver"' do |e|
+        Redis.new(:url => "redis://:secr3t@foo.com:999/2?driver=randomdriver")
+      end
+    end
+  end
+
   def test_does_not_unescape_password_when_explicitly_passed
     redis = Redis.new :url => "redis://:secr3t%3A@foo.com:999/2", :password => "secr3t%3A"
 


### PR DESCRIPTION
I really only needed this for `tcp_keepalive`, but I added `driver`, `timeout`, and `inherit_socket` as well.
