### PR TITLE
Write timeout

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -13,6 +13,7 @@ class Redis
       :path => nil,
       :timeout => 5.0,
       :connect_timeout => 5.0,
+      :write_timeout => nil,
       :password => nil,
       :db => 0,
       :driver => nil,
@@ -426,6 +427,8 @@ class Redis
       else
         options[:timeout]
       end
+
+      options[:write_timeout] = options[:write_timeout] ? options[:write_timeout].to_f : options[:timeout]
 
       options[:db] = options[:db].to_i
       options[:driver] = _parse_driver(options[:driver]) || Connection.drivers.last

--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -12,7 +12,7 @@ class Redis
       def initialize(*args)
         super(*args)
 
-        @timeout = nil
+        @timeout = @write_timeout = nil
         @buffer = ""
       end
 
@@ -21,6 +21,14 @@ class Redis
           @timeout = timeout
         else
           @timeout = nil
+        end
+      end
+
+      def write_timeout=(timeout)
+        if timeout && timeout > 0
+          @write_timeout = timeout
+        else
+          @write_timeout = nil
         end
       end
 
@@ -58,6 +66,11 @@ class Redis
 
       rescue EOFError
         raise Errno::ECONNRESET
+      end
+
+      # UNIXSocket and TCPSocket don't support write timeouts
+      def write(*args)
+        Timeout.timeout(@write_timeout, TimeoutError) { super }
       end
     end
 
@@ -213,6 +226,7 @@ class Redis
 
         instance = new(sock)
         instance.timeout = config[:timeout]
+        instance.write_timeout = config[:write_timeout]
         instance.set_tcp_keepalive config[:tcp_keepalive]
         instance
       end
@@ -263,6 +277,10 @@ class Redis
         if @sock.respond_to?(:timeout=)
           @sock.timeout = timeout
         end
+      end
+
+      def write_timeout=(timeout)
+        @sock.write_timeout = timeout
       end
 
       def write(command)

--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -2,6 +2,7 @@ require "redis/connection/registry"
 require "redis/connection/command_helper"
 require "redis/errors"
 require "socket"
+require "timeout"
 
 class Redis
   module Connection

--- a/test/internals_test.rb
+++ b/test/internals_test.rb
@@ -162,16 +162,7 @@ class TestInternals < Test::Unit::TestCase
 
   driver(:ruby) do
     def test_write_timeout
-      t = Thread.new do
-        TCPServer.new("127.0.0.1", 6383)
-      end
-
-      begin
-        TCPSocket.new("127.0.0.1", 6383)
-      rescue Errno::ECONNREFUSED
-        sleep(0.05)
-        retry
-      end
+      TCPServer.new("127.0.0.1", 6383)
 
       assert_raise(Redis::TimeoutError) do
         Timeout.timeout(1) do
@@ -179,8 +170,6 @@ class TestInternals < Test::Unit::TestCase
           redis.set("foo", "1" * 1048576)
         end
       end
-    ensure
-      t.join if t
     end
   end
 

--- a/test/internals_test.rb
+++ b/test/internals_test.rb
@@ -175,7 +175,7 @@ class TestInternals < Test::Unit::TestCase
 
       assert_raise(Redis::TimeoutError) do
         Timeout.timeout(1) do
-          redis = Redis.new(:port => 6383, timeout: 5, write_timeout: 0.2)
+          redis = Redis.new(:port => 6383, :timeout => 5, :write_timeout => 0.2)
           redis.set("foo", "1" * 1048576)
         end
       end

--- a/test/lint/blocking_commands.rb
+++ b/test/lint/blocking_commands.rb
@@ -35,7 +35,7 @@ module Lint
         :brpoplpush => lambda do |*args|
           sleep options[:delay] if options.has_key?(:delay)
           to_protocol(args.last)
-        end,
+        end
       }
 
       redis_mock(commands, &blk)


### PR DESCRIPTION
Writes will block indefinitely without timeout if the socket's write buffer space is exhausted and the host is unreachable. This happens in EC2 when a connection has been closed and is idle for more than 60 seconds.

I couldn't figure out a way to simulate host unreachable (as that probably requires going into the OS' tcp layer), so I added a kinda disgusting test using monkeypatching. Any suggestions on how to make it less disgusting?