### PR TITLE
Use pure ruby to send a TCP message

### DIFF
--- a/test/publish_subscribe_test.rb
+++ b/test/publish_subscribe_test.rb
@@ -191,7 +191,7 @@ class TestPublishSubscribe < Test::Unit::TestCase
   def test_subscribe_past_a_timeout
     # For some reason, a thread here doesn't reproduce the issue.
     sleep = %{sleep #{OPTIONS[:timeout] * 2}}
-    publish = %{echo "publish foo bar\r\n" | nc 127.0.0.1 #{OPTIONS[:port]}}
+    publish = %{ruby -rsocket -e 't=TCPSocket.new("127.0.0.1",#{OPTIONS[:port]});t.write("publish foo bar\\r\\n");t.read(4);t.close'}
     cmd = [sleep, publish].join("; ")
 
     IO.popen(cmd, "r+") do |pipe|


### PR DESCRIPTION
No netcat in the new travis env.
