### PR TITLE
don't try to connect when calling quit on disconnected client

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -99,6 +99,7 @@ class Redis
   #
   # @return [String] `OK`
   def quit
+    return 'OK' unless connected?
     synchronize do |client|
       begin
         client.call([:quit])


### PR DESCRIPTION
Currently if you call `quit` on a redis connection, it'll *try* to
connect to redis before quitting. This seems weird, and can cause
issues in production environments (e.g. because of the current
implementation, `quit` can throw connection exceptions, which doesn't
seem to make sense at all)