### PR TITLE
Sentinel: Be more resilient when trying to connect to sentinels

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -461,7 +461,9 @@ class Redis
     end
 
     class Connector
+      attr_reader :logger
       def initialize(options)
+        @logger = options[:logger]
         @options = options
       end
 
@@ -522,6 +524,11 @@ class Redis
                 @sentinels.unshift(sentinel)
 
                 return result
+              end
+            rescue CannotConnectError
+              if logger
+                msg = "[Redis] Could not connect to sentinel #{sentinel[:host]}:#{sentinel[:port]}"
+                logger.debug(msg)
               end
             ensure
               client.disconnect


### PR DESCRIPTION
Ran into this thing the other day.

The issue is that if one of your sentinels is down ( given that the gem tries them in order, say the first one ), or the connection times out or whatever, this will just throw up at that point.

The behavior I would like to see is for it to try all the other sentinels and if it can't connect to any of them, bail.

Doesn't really make sense otherwise, since instead of being more resilient, your setup now relies on all the sentinels needing to be up, which feels slightly strange as a design choice.

Let me know if I'm reading this wrong.

Couldn't find any sentinel tests to update around the test folder, so I'm assuming that'll be a separate issue ( actually writing tests for the sentinel implementation )