### PR TITLE
Check exception message explicitely

### DIFF
--- a/test/commands_on_value_types_test.rb
+++ b/test/commands_on_value_types_test.rb
@@ -101,13 +101,15 @@ class TestCommandsOnValueTypes < Test::Unit::TestCase
     redis_mock(:migrate => lambda { |*args| args }) do |redis|
       options = { :host => "127.0.0.1", :port => 1234 }
 
-      assert_raise(RuntimeError, /host not specified/) do
+      ex = assert_raise(RuntimeError) do
         redis.migrate("foo", options.reject { |key, _| key == :host })
       end
+      assert ex.message =~ /host not specified/
 
-      assert_raise(RuntimeError, /port not specified/) do
+      ex = assert_raise(RuntimeError) do
         redis.migrate("foo", options.reject { |key, _| key == :port })
       end
+      assert ex.message =~ /port not specified/
 
       default_db = redis.client.db.to_i
       default_timeout = redis.client.timeout.to_i


### PR DESCRIPTION
Current minitest only checks if the raised exception is of the same type
or an instance of the given type. It does not compare its message
against the regexp.

As it returns the Exception we simply assert the message manually.

Closes #493