### PR TITLE
Fix spelling error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ end
 Replies to commands in a pipeline can be accessed via the *futures* they
 emit (since redis-rb 3.0). All calls inside a pipeline block return a
 `Future` object, which responds to the `#value` method. When the
-pipeline has succesfully executed, all futures are assigned their
+pipeline has successfully executed, all futures are assigned their
 respective replies and can be used.
 
 ```ruby


### PR DESCRIPTION
Changed 'succesfully' to 'successfully' on line 174