### PR TITLE
Add `Redis#disconnect!` as a public-API way of disconnecting.

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -54,6 +54,11 @@ class Redis
     @original_client.connected?
   end
 
+  # Disconnect the client as quickly and silently as possible.
+  def disconnect!
+    @original_client.disconnect
+  end
+
   # Authenticate to the server.
   #
   # @param [String] password must match the password specified in the

--- a/test/connection_handling_test.rb
+++ b/test/connection_handling_test.rb
@@ -38,6 +38,33 @@ class TestConnectionHandling < Test::Unit::TestCase
     assert !r.client.connected?
   end
 
+  def test_disconnect
+    quit = 0
+
+    commands = {
+      :quit => lambda do
+        quit += 1
+        "+OK"
+      end
+    }
+
+    redis_mock(commands) do |redis|
+      assert_equal 0, quit
+
+      redis.quit
+
+      assert_equal 1, quit
+
+      redis.ping
+
+      redis.disconnect!
+
+      assert_equal 1, quit
+
+      assert !redis.connected?
+    end
+  end
+
   def test_shutdown
     commands = {
       :shutdown => lambda { :exit }


### PR DESCRIPTION
This should address the fact that `Redis::Client` will eventually private and `Redis#client` will represent the `CLIENT` command.