### PR TITLE
Force a disconnect after fork

### DIFF
--- a/examples/unicorn/unicorn.rb
+++ b/examples/unicorn/unicorn.rb
@@ -16,5 +16,5 @@ worker_processes 3
 # worker processes.
 
 after_fork do |server, worker|
-  Redis.current.quit
+  Redis.current.disconnect!
 end


### PR DESCRIPTION
The previous call to `quit` lead to the weird situation that redis-rb will detect the fork, will reconnect by itself, will then send `QUIT` to the server and will disconnect afterwards. A bit too much trouble for a little disconnect.