### PR TITLE
Fix possible race condition with pipelines

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -2130,13 +2130,14 @@ class Redis
 
   def pipelined
     synchronize do |client|
+      pipeline = Pipeline.new
       begin
-        original, @client = @client, Pipeline.new
+        original, @client = @client, pipeline
         yield(self)
-        original.call_pipeline(@client)
       ensure
         @client = original
       end
+      @client.call_pipeline(pipeline)
     end
   end
 
@@ -2175,14 +2176,14 @@ class Redis
       if !block_given?
         client.call([:multi])
       else
+        pipeline = Pipeline::Multi.new
         begin
-          pipeline = Pipeline::Multi.new
           original, @client = @client, pipeline
           yield(self)
-          original.call_pipeline(pipeline)
         ensure
           @client = original
         end
+        @client.call_pipeline(pipeline)
       end
     end
   end

--- a/lib/redis/pipeline.rb
+++ b/lib/redis/pipeline.rb
@@ -122,7 +122,7 @@ class Redis
     end
 
     def _command
-      @command
+      @command.map(&:to_s)
     end
 
     def value

--- a/test/pipelining_commands_test.rb
+++ b/test/pipelining_commands_test.rb
@@ -239,4 +239,28 @@ class TestPipeliningCommands < Test::Unit::TestCase
 
     assert_equal 3, r.client.db
   end
+
+  class LazyString
+    def initialize(redis)
+      @redis = redis
+    end
+
+    def to_s
+      @redis.hgetall('foo').inspect
+    end
+  end
+
+  def test_pipeline_race_condition
+    ttl = LazyString.new(r)
+    r.pipelined do
+      r.expire('bar', ttl)
+    end
+  end
+
+  def test_multi_race_condition
+    ttl = LazyString.new(r)
+    r.multi do
+      r.expire('bar', ttl)
+    end
+  end
 end


### PR DESCRIPTION
Fixes: https://github.com/redis/redis-rb/issues/507

So the reason behind #507, is that the expiry was passed as `1.month`, and that the evaluation of that expression by the Redis client was actually triggering a call to Redis to fetch the translation data.

It's obviously a huge corner case, but I think it would have been prevented by that PR.

@fw42 @djanowski @badboy for review please.