### PR TITLE
Prevent Client#options from crashing when it contains objects that can't be dumped

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -23,7 +23,7 @@ class Redis
     }
 
     def options
-      Marshal.load(Marshal.dump(@options))
+      _deep_dup(@options)
     end
 
     def scheme
@@ -362,6 +362,25 @@ class Redis
       rescue Exception
         disconnect
         raise
+      end
+    end
+
+    def _deep_dup(object)
+      case object
+      when Hash
+        object.each_with_object(object.dup) do |(key, value), hash|
+          hash[_deep_dup(key)] = _deep_dup(value)
+        end
+      when Array
+        object.map { |item| _deep_dup(item) }
+      when nil, true, false, Symbol, Numeric
+        object
+      else
+        begin
+          object.dup
+        rescue TypeError
+          object
+        end
       end
     end
 

--- a/test/internals_test.rb
+++ b/test/internals_test.rb
@@ -362,6 +362,14 @@ class TestInternals < Test::Unit::TestCase
     assert_equal "foo", redis.client.options[:scheme]
   end
 
+  def test_client_options_can_contain_unmarshable_data
+    redis = Redis.new(OPTIONS.merge(:logger => Logger.new(STDOUT)))
+    assert_nothing_raised do
+      redis.client.options
+    end
+    assert_instance_of Logger, redis.client.options[:logger]
+  end
+
   def test_resolves_localhost
     assert_nothing_raised do
       Redis.new(OPTIONS.merge(:host => 'localhost')).ping


### PR DESCRIPTION
If the options contains an object that can't be dumped e.g. a File, then the `Marshal.load(Marshal.dump(object))` trick to deep dup will fail.

Since Redis takes a logger as options it is relatively common for the options to contains a file descriptor or sockets.

The `_deep_dup` implementation is heavily inspired from `ActiveSupport`'s.

