### PR TITLE
Rename timeout option to read_timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ listening on `localhost`, port 6379. If you need to connect to a remote
 server or a different port, try:
 
 ```ruby
-redis = Redis.new(:host => "10.0.1.1", :port => 6380, :db => 15)
+redis = Redis.new(:host => "10.0.1.1", :port => 6380, :db => 15,
+                  :read_timeout => 1, :connect_timeout => 1)
 ```
 
 You can also specify connection options as an URL:

--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -11,7 +11,7 @@ class Redis
       :host => "127.0.0.1",
       :port => 6379,
       :path => nil,
-      :timeout => 5.0,
+      :read_timeout => 5.0,
       :connect_timeout => 5.0,
       :password => nil,
       :db => 0,
@@ -42,8 +42,16 @@ class Redis
       @options[:path]
     end
 
+    def read_timeout
+      @options[:read_timeout]
+    end
+
+    def connect_timeout
+      @options[:connect_timeout]
+    end
+
     def timeout
-      @options[:timeout]
+      @options[:read_timeout]
     end
 
     def password
@@ -422,11 +430,16 @@ class Redis
         options[:port] = options[:port].to_i
       end
 
-      options[:timeout] = options[:timeout].to_f
+      if options.has_key?(:timeout)
+        options[:read_timeout] ||= options[:timeout]
+        options[:connect_timeout] ||= options[:timeout]
+      end
+
+      options[:read_timeout] = options[:read_timeout].to_f
       options[:connect_timeout] = if options[:connect_timeout]
         options[:connect_timeout].to_f
       else
-        options[:timeout]
+        options[:read_timeout]
       end
 
       options[:db] = options[:db].to_i

--- a/lib/redis/connection/hiredis.rb
+++ b/lib/redis/connection/hiredis.rb
@@ -18,7 +18,7 @@ class Redis
         end
 
         instance = new(connection)
-        instance.timeout = config[:timeout]
+        instance.timeout = config[:read_timeout]
         instance
       rescue Errno::ETIMEDOUT
         raise TimeoutError

--- a/lib/redis/connection/synchrony.rb
+++ b/lib/redis/connection/synchrony.rb
@@ -81,7 +81,7 @@ class Redis
         raise Errno::ECONNREFUSED if Fiber.yield == :refused
 
         instance = new(conn)
-        instance.timeout = config[:timeout]
+        instance.timeout = config[:read_timeout]
         instance
       end
 

--- a/redis.gemspec
+++ b/redis.gemspec
@@ -40,4 +40,5 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
 
   s.add_development_dependency("rake")
+  s.add_development_dependency("test-unit")
 end


### PR DESCRIPTION
Associated with issue #437, this renames the `timeout` option and adds to README so the options are documented.  Existing usage of `timeout` is supported for backwards compatibility.

There's a few test failures, I'm unclear how to fix them.