### PR TITLE
Check redis connection without Redis::CannotConnectError

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -54,6 +54,14 @@ class Redis
     @original_client.connected?
   end
 
+  # Test whether or not the redis server is up
+  def connection_alive?
+    ping
+    connected?
+  rescue Redis::CannotConnectError
+    false
+  end
+
   # Disconnect the client as quickly and silently as possible.
   def disconnect!
     @original_client.disconnect

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -56,7 +56,7 @@ class Redis
 
   # Test whether or not the redis server is up
   def connection_alive?
-    ping
+    without_reconnect { ping }
     connected?
   rescue Redis::CannotConnectError
     false

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -58,7 +58,7 @@ class Redis
   def connection_alive?
     without_reconnect { ping }
     connected?
-  rescue Redis::CannotConnectError
+  rescue Redis::CannotConnectError, Redis::ConnectionError
     false
   end
 


### PR DESCRIPTION
I've notice an odd behaviour, if you kill redis-server the `connected?` method will continue to respond `true` if you don't make any operation. Example:

```ruby
[START redis-server]
redis = Redis.new
redis.connected? # => false (as expected lazy connection)
redis.get 'some_key'
redis.connected? # => true (as expected)
[KILL redis-server]
redis.connected? # => true (BUT isn't connected)
redis.get 'some_key' # => raise Redis::CannotConnectError
redis.connected? # => false (as expected)
```

Signed-off-by: Ricardo Leitão <rleitao@onliquid.com>