### PR TITLE
Fix Redis#{ttl,pttl} doc when key doesn't exist

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -329,8 +329,15 @@ class Redis
   # Get the time to live (in seconds) for a key.
   #
   # @param [String] key
-  # @return [Fixnum] remaining time to live in seconds, or -1 if the
-  #   key does not exist or does not have a timeout
+  # @return [Fixnum] remaining time to live in seconds.
+  #
+  # In Redis 2.6 or older the command returns -1 if the key does not exist or if
+  # the key exist but has no associated expire.
+  #
+  # Starting with Redis 2.8 the return value in case of error changed:
+  #
+  #     - The command returns -2 if the key does not exist.
+  #     - The command returns -1 if the key exists but has no associated expire.
   def ttl(key)
     synchronize do |client|
       client.call([:ttl, key])
@@ -362,8 +369,14 @@ class Redis
   # Get the time to live (in milliseconds) for a key.
   #
   # @param [String] key
-  # @return [Fixnum] remaining time to live in milliseconds, or -1 if the
-  #   key does not exist or does not have a timeout
+  # @return [Fixnum] remaining time to live in milliseconds
+  # In Redis 2.6 or older the command returns -1 if the key does not exist or if
+  # the key exist but has no associated expire.
+  #
+  # Starting with Redis 2.8 the return value in case of error changed:
+  #
+  #     - The command returns -2 if the key does not exist.
+  #     - The command returns -1 if the key exists but has no associated expire.
   def pttl(key)
     synchronize do |client|
       client.call([:pttl, key])


### PR DESCRIPTION
The doc states that Redis#{ttl,pttl} return -1 if the key does not
exist **or** if the key exists but has no associated expire.

This is incorrect with respect to the Redis' doc [here](http://redis.io/commands/ttl)

The documentation is also incorrent with respect to the current library behavior:

```
irb(main):059:0* conn = Redis.new
=> #<Redis client v3.1.0 for redis://127.0.0.1:6379/0>
irb(main):060:0> conn.ttl 'asdf'
=> -2
irb(main):065:0> conn.set 'asdf', 123
=> "OK"
irb(main):070:0> conn.ttl 'asdf'
=> -1
irb(main):071:0> conn.expire 'asdf', 100
=> true
irb(main):082:0> conn.ttl 'asdf'
=> 99

irb(main):059:0* conn = Redis.new
=> #<Redis client v3.1.0 for redis://127.0.0.1:6379/0>
irb(main):085:0> conn.pttl 'jkl;'
=> -2
irb(main):086:0> conn.set 'jkl;', 123
=> "OK"
irb(main):089:0> conn.pttl 'jkl;'
=> -1
irb(main):090:0> conn.expire 'jkl;', 100
=> true
irb(main):093:0> conn.pttl 'jkl;'
=> 91225
irb(main):097:0>
```

This commit adds the mention to a `-2` return value.