### PR TITLE
Support mget, mapped_mget, mset and mapped_mset commands for distribu…

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -2032,7 +2032,7 @@ class Redis
     end
   end
 
-  # Inspect the state of the Pub/Sub subsystem. 
+  # Inspect the state of the Pub/Sub subsystem.
   # Possible subcommands: channels, numsub, numpat.
   def pubsub(subcommand, *args)
     synchronize do |client|

--- a/test/distributed_commands_on_strings_test.rb
+++ b/test/distributed_commands_on_strings_test.rb
@@ -9,27 +9,41 @@ class TestDistributedCommandsOnStrings < Test::Unit::TestCase
   include Lint::Strings
 
   def test_mget
-    assert_raise Redis::Distributed::CannotDistribute do
-      r.mget("foo", "bar")
-    end
+    r.set("foo", "s1")
+    r.set("bar", "s2")
+
+    assert_equal ["s1", "s2"]     , r.mget("foo", "bar")
+    assert_equal ["s1", "s2", nil], r.mget("foo", "bar", "baz")
   end
 
   def test_mget_mapped
-    assert_raise Redis::Distributed::CannotDistribute do
-      r.mapped_mget("foo", "bar")
-    end
+    r.set("foo", "s1")
+    r.set("bar", "s2")
+
+    response = r.mapped_mget("foo", "bar")
+
+    assert_equal "s1", response["foo"]
+    assert_equal "s2", response["bar"]
+
+    response = r.mapped_mget("foo", "bar", "baz")
+
+    assert_equal "s1", response["foo"]
+    assert_equal "s2", response["bar"]
+    assert_equal nil , response["baz"]
   end
 
   def test_mset
-    assert_raise Redis::Distributed::CannotDistribute do
-      r.mset(:foo, "s1", :bar, "s2")
-    end
+    r.mset(:foo, "s1", :bar, "s2")
+
+    assert_equal "s1", r.get("foo")
+    assert_equal "s2", r.get("bar")
   end
 
   def test_mset_mapped
-    assert_raise Redis::Distributed::CannotDistribute do
-      r.mapped_mset(:foo => "s1", :bar => "s2")
-    end
+    r.mapped_mset(:foo => "s1", :bar => "s2")
+
+    assert_equal "s1", r.get("foo")
+    assert_equal "s2", r.get("bar")
   end
 
   def test_msetnx

--- a/test/lint/hashes.rb
+++ b/test/lint/hashes.rb
@@ -151,7 +151,7 @@ module Lint
 
         r.hincrbyfloat("foo", "f1", 0.77)
 
-        assert_equal "2", r.hget("foo", "f1").to_f.round.to_s
+        assert_equal "2", r.hget("foo", "f1").to_f.round(0).to_s
 
         r.hincrbyfloat("foo", "f1", -0.1)
 

--- a/test/lint/hashes.rb
+++ b/test/lint/hashes.rb
@@ -147,15 +147,15 @@ module Lint
       target_version "2.5.4" do
         r.hincrbyfloat("foo", "f1", 1.23)
 
-        assert_equal "1.23", r.hget("foo", "f1")
+        assert_equal "1.23", r.hget("foo", "f1").to_f.round(2).to_s
 
         r.hincrbyfloat("foo", "f1", 0.77)
 
-        assert_equal "2", r.hget("foo", "f1")
+        assert_equal "2", r.hget("foo", "f1").to_f.round.to_s
 
         r.hincrbyfloat("foo", "f1", -0.1)
 
-        assert_equal "1.9", r.hget("foo", "f1")
+        assert_equal "1.9", r.hget("foo", "f1").to_f.round(1).to_s
       end
     end
   end


### PR DESCRIPTION
…ted redis.

It is necessary of multi get and set commands for distributed redis.
It will be slow when calling many commands one by one. Executing many get commands in a batch will be fast.
Commands will be splitted to different groups based on nodes for distributed redis and then execute multiple style command by node. Response will be composed finally.
