### PR TITLE
Add support for running sentinel API commands

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -2539,6 +2539,34 @@ class Redis
     end
   end
 
+  # Interact with the sentinel command (masters, master, slaves, failover)
+  #
+  # @param [String] subcommand e.g. `masters`, `master`, `slaves`
+  # @param [Array<String>] args depends on subcommand
+  # @return [Array<String>, Hash<String, String>, String] depends on subcommand
+  def sentinel(subcommand, *args)
+    subcommand = subcommand.to_s.downcase
+    synchronize do |client|
+      if subcommand == 'master'
+        client.call([:sentinel, subcommand] + args, &_hashify)
+      elsif subcommand == 'get-master-addr-by-name'
+        client.call([:sentinel, subcommand] + args)
+      else
+        client.call([:sentinel, subcommand] + args) do |reply|
+          if reply.kind_of?(Array)
+            new_reply = Array.new
+            reply.each do |r|
+              new_reply << _hashify.call(r)
+            end
+            new_reply
+          else
+            reply
+          end
+        end
+      end
+    end
+  end
+
   def id
     @original_client.id
   end

--- a/test/sentinel_command_test.rb
+++ b/test/sentinel_command_test.rb
@@ -1,0 +1,80 @@
+# encoding: UTF-8
+
+require File.expand_path("helper", File.dirname(__FILE__))
+
+class SentinalCommandsTest < Test::Unit::TestCase
+
+  include Helper::Client
+
+  def test_sentinel_command_master
+
+    handler = lambda do |id|
+      {
+        :sentinel => lambda do |command, *args|
+          ["name", "master1", "ip", "127.0.0.1"]
+        end
+      }
+    end
+
+    RedisMock.start(handler.call(:s1), {}, 26381) do
+      redis = Redis.new(:host => "127.0.0.1", :port => 26381)
+
+      result = redis.sentinel('master', 'master1')
+      assert_equal result, { "name" => "master1", "ip" => "127.0.0.1" }
+    end
+  end
+
+  def test_sentinel_command_masters
+
+    handler = lambda do |id|
+      {
+        :sentinel => lambda do |command, *args|
+          [%w[name master1 ip 127.0.0.1 port 6381], %w[name master1 ip 127.0.0.1 port 6382]]
+        end
+      }
+    end
+
+    RedisMock.start(handler.call(:s1), {}, 26381) do
+      redis = Redis.new(:host => "127.0.0.1", :port => 26381)
+
+      result = redis.sentinel('masters')
+      assert_equal result[0], { "name" => "master1", "ip" => "127.0.0.1", "port" => "6381" }
+      assert_equal result[1], { "name" => "master1", "ip" => "127.0.0.1", "port" => "6382" }
+    end
+  end
+
+  def test_sentinel_command_get_master_by_name
+
+    handler = lambda do |id|
+      {
+        :sentinel => lambda do |command, *args|
+          ["127.0.0.1", "6381"]
+        end
+      }
+    end
+
+    RedisMock.start(handler.call(:s1), {}, 26381) do
+      redis = Redis.new(:host => "127.0.0.1", :port => 26381)
+
+      result = redis.sentinel('get-master-addr-by-name', 'master1')
+      assert_equal result, ["127.0.0.1", "6381"]
+    end
+  end
+
+  def test_sentinel_command_ckquorum
+    handler = lambda do |id|
+      {
+        :sentinel => lambda do |command, *args|
+          "+OK 2 usable Sentinels. Quorum and failover authorization can be reached"
+        end
+      }
+    end
+
+    RedisMock.start(handler.call(:s1), {}, 26381) do
+      redis = Redis.new(:host => "127.0.0.1", :port => 26381)
+
+      result = redis.sentinel('ckquorum', 'master1')
+      assert_equal result, "OK 2 usable Sentinels. Quorum and failover authorization can be reached"
+    end
+  end
+end

--- a/test/support/redis_mock.rb
+++ b/test/support/redis_mock.rb
@@ -106,8 +106,16 @@ module RedisMock
           break :close
         elsif response.is_a?(Array)
           session.write("*%d\r\n" % response.size)
-          response.each do |e|
-            session.write("$%d\r\n%s\r\n" % [e.length, e])
+
+          response.each do |resp|
+            if resp.is_a?(Array)
+              session.write("*%d\r\n" % resp.size)
+              resp.each do |r|
+                session.write("$%d\r\n%s\r\n" % [r.length, r])
+              end
+            else
+              session.write("$%d\r\n%s\r\n" % [resp.length, resp])
+            end
           end
         else
           session.write(response)


### PR DESCRIPTION
### What?
This pull request adds support for the redis sentinel API. The redis-rb gem already has support for redis sentinel but it can't be used (afaik) to connect to a redis sentinel and to run any of the sentinel API commands like `sentinel masters`, `sentinel master`, `sentinel monitor`, etc...

### Why? 
I was trying to build some tooling around the redis sentinel API to add new redis instances to a redis sentinel servers and I wanted to use this redis gem. 

### How?
Added a new def for the sentinel command and all it's subcommands. Some subcommands return a single array that gets transformed to a hash, some other subcommands return an array of arrays which get transformed to an array of hashes for ease of use.

I also had to change the redis_mock to be able to handle replies consisting of multiple arrays like the reply you get when you run `sentinel masters` which returns an array with all the redis instances the sentinel is monitoring.

I've also added some basic tests that cover some sentinel commands.

This is my first contribution to the project, if there's anything missing or something is terribly wrong just let me know, I'm just starting with ruby so please forgive my terrible code :)