### PR TITLE
Support sentinels as a string

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -527,8 +527,8 @@ class Redis
         def sentinel_detect
           @sentinels.each do |sentinel|
             client = Client.new(@options.merge({
-              :host => sentinel[:host],
-              :port => sentinel[:port],
+              :host => sentinel[:host] || sentinel["host"],
+              :port => sentinel[:port] || sentinel["port"],
               :reconnect_attempts => 0,
             }))
 

--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -19,7 +19,8 @@ class Redis
       :id => nil,
       :tcp_keepalive => 0,
       :reconnect_attempts => 1,
-      :inherit_socket => false
+      :inherit_socket => false,
+      :sentinels => []
     }
 
     def options
@@ -79,7 +80,7 @@ class Redis
 
       @pending_reads = 0
 
-      if options.include?(:sentinels)
+      if @options.include?(:sentinels) && @options[:sentinels].any?
         @connector = Connector::Sentinel.new(@options)
       else
         @connector = Connector.new(@options)


### PR DESCRIPTION
This allows the `sentinels` option to be passed as a string as well as a
symbol.