### PR TITLE
Remove the deep dup in Client#options

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -22,9 +22,7 @@ class Redis
       :inherit_socket => false
     }
 
-    def options
-      Marshal.load(Marshal.dump(@options))
-    end
+    attr_reader :options
 
     def scheme
       @options[:scheme]

--- a/test/internals_test.rb
+++ b/test/internals_test.rb
@@ -349,19 +349,6 @@ class TestInternals < Test::Unit::TestCase
     assert_equal "foo", redis.client.options[:scheme]
   end
 
-  def test_does_not_change_self_client_options
-    redis = Redis.new(OPTIONS.merge(:host => "host", :port => 1234, :db => 1, :scheme => "foo"))
-    options = redis.client.options
-
-    options[:host] << "new_host"
-    options[:scheme] << "bar"
-    options.merge!(:db => 0)
-
-    assert_equal "host", redis.client.options[:host]
-    assert_equal 1, redis.client.options[:db]
-    assert_equal "foo", redis.client.options[:scheme]
-  end
-
   def test_resolves_localhost
     assert_nothing_raised do
       Redis.new(OPTIONS.merge(:host => 'localhost')).ping


### PR DESCRIPTION
Replaces https://github.com/redis/redis-rb/pull/512

`redis-rb` itself doesn't use that accessor at all. And the deep dup was simply a precaution.

IMO it's a worthless one.

@djanowski for review please.
