### PR TITLE
Explicitly raise InvalidResponse if commands and responses counts don't match

### DIFF
--- a/lib/redis/connection/hiredis.rb
+++ b/lib/redis/connection/hiredis.rb
@@ -57,7 +57,7 @@ class Redis
       rescue Errno::EAGAIN
         raise TimeoutError
       rescue RuntimeError => err
-        raise ProtocolError.new(err.message)
+        raise ProtocolError.invalid_reply_type(err.message)
       end
     end
   end

--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -375,7 +375,7 @@ class Redis
         when COLON    then format_integer_reply(line)
         when DOLLAR   then format_bulk_reply(line)
         when ASTERISK then format_multi_bulk_reply(line)
-        else raise ProtocolError.new(reply_type)
+        else raise ProtocolError.invalid_reply_type(reply_type)
         end
       end
 

--- a/lib/redis/connection/synchrony.rb
+++ b/lib/redis/connection/synchrony.rb
@@ -33,7 +33,7 @@ class Redis
           begin
             reply = @reader.gets
           rescue RuntimeError => err
-            @req.fail [:error, ProtocolError.new(err.message)]
+            @req.fail [:error, ProtocolError.invalid_reply_type(err.message)]
             break
           end
 

--- a/lib/redis/errors.rb
+++ b/lib/redis/errors.rb
@@ -5,8 +5,8 @@ class Redis
 
   # Raised by the connection when a protocol error occurs.
   class ProtocolError < BaseError
-    def initialize(reply_type)
-      super(<<-EOS.gsub(/(?:^|\n)\s*/, " "))
+    def self.invalid_reply_type(reply_type)
+      new(<<-EOS.gsub(/(?:^|\n)\s*/, " "))
         Got '#{reply_type}' as initial reply byte.
         If you're in a forking environment, such as Unicorn, you need to
         connect to Redis after forking.


### PR DESCRIPTION
As discussed in https://github.com/redis/redis-rb/pull/509

The idea here is to fail loudly if such unlikely race condition happened.

@djanowski is this more acceptable to you?
