### PR TITLE
Reduce `Proc` object allocations.

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -161,7 +161,7 @@ class Redis
     synchronize do |client|
       client.call([:config, action] + args) do |reply|
         if reply.kind_of?(Array) && action == :get
-          Hash[_pairify(reply)]
+          Hashify.call(reply)
         else
           reply
         end
@@ -320,7 +320,7 @@ class Redis
   # @return [Boolean] whether the timeout was removed or not
   def persist(key)
     synchronize do |client|
-      client.call([:persist, key], &_boolify)
+      client.call([:persist, key], &Boolify)
     end
   end
 
@@ -331,7 +331,7 @@ class Redis
   # @return [Boolean] whether the timeout was set or not
   def expire(key, seconds)
     synchronize do |client|
-      client.call([:expire, key, seconds], &_boolify)
+      client.call([:expire, key, seconds], &Boolify)
     end
   end
 
@@ -342,7 +342,7 @@ class Redis
   # @return [Boolean] whether the timeout was set or not
   def expireat(key, unix_time)
     synchronize do |client|
-      client.call([:expireat, key, unix_time], &_boolify)
+      client.call([:expireat, key, unix_time], &Boolify)
     end
   end
 
@@ -371,7 +371,7 @@ class Redis
   # @return [Boolean] whether the timeout was set or not
   def pexpire(key, milliseconds)
     synchronize do |client|
-      client.call([:pexpire, key, milliseconds], &_boolify)
+      client.call([:pexpire, key, milliseconds], &Boolify)
     end
   end
 
@@ -382,7 +382,7 @@ class Redis
   # @return [Boolean] whether the timeout was set or not
   def pexpireat(key, ms_unix_time)
     synchronize do |client|
-      client.call([:pexpireat, key, ms_unix_time], &_boolify)
+      client.call([:pexpireat, key, ms_unix_time], &Boolify)
     end
   end
 
@@ -461,7 +461,7 @@ class Redis
   # @return [Boolean]
   def exists(key)
     synchronize do |client|
-      client.call([:exists, key], &_boolify)
+      client.call([:exists, key], &Boolify)
     end
   end
 
@@ -502,7 +502,7 @@ class Redis
   # @return [Boolean] whether the key was moved or not
   def move(key, db)
     synchronize do |client|
-      client.call([:move, key, db], &_boolify)
+      client.call([:move, key, db], &Boolify)
     end
   end
 
@@ -539,7 +539,7 @@ class Redis
   # @return [Boolean] whether the key was renamed or not
   def renamenx(old_name, new_name)
     synchronize do |client|
-      client.call([:renamenx, old_name, new_name], &_boolify)
+      client.call([:renamenx, old_name, new_name], &Boolify)
     end
   end
 
@@ -678,7 +678,7 @@ class Redis
   # @return [Float] value after incrementing it
   def incrbyfloat(key, increment)
     synchronize do |client|
-      client.call([:incrbyfloat, key, increment], &_floatify)
+      client.call([:incrbyfloat, key, increment], &Floatify)
     end
   end
 
@@ -709,7 +709,7 @@ class Redis
 
     synchronize do |client|
       if nx || xx
-        client.call([:set, key, value.to_s] + args, &_boolify_set)
+        client.call([:set, key, value.to_s] + args, &BoolifySet)
       else
         client.call([:set, key, value.to_s] + args)
       end
@@ -749,7 +749,7 @@ class Redis
   # @return [Boolean] whether the key was set or not
   def setnx(key, value)
     synchronize do |client|
-      client.call([:setnx, key, value.to_s], &_boolify)
+      client.call([:setnx, key, value.to_s], &Boolify)
     end
   end
 
@@ -795,7 +795,7 @@ class Redis
   # @see #mapped_msetnx
   def msetnx(*args)
     synchronize do |client|
-      client.call([:msetnx] + args, &_boolify)
+      client.call([:msetnx] + args, &Boolify)
     end
   end
 
@@ -1268,7 +1268,7 @@ class Redis
           reply
         else
           # Single argument: return boolean
-          _boolify.call(reply)
+          Boolify.call(reply)
         end
       end
     end
@@ -1290,7 +1290,7 @@ class Redis
           reply
         else
           # Single argument: return boolean
-          _boolify.call(reply)
+          Boolify.call(reply)
         end
       end
     end
@@ -1329,7 +1329,7 @@ class Redis
   # @return [Boolean]
   def smove(source, destination, member)
     synchronize do |client|
-      client.call([:smove, source, destination, member], &_boolify)
+      client.call([:smove, source, destination, member], &Boolify)
     end
   end
 
@@ -1340,7 +1340,7 @@ class Redis
   # @return [Boolean]
   def sismember(key, member)
     synchronize do |client|
-      client.call([:sismember, key, member], &_boolify)
+      client.call([:sismember, key, member], &Boolify)
     end
   end
 
@@ -1483,10 +1483,10 @@ class Redis
     synchronize do |client|
       if args.size == 1 && args[0].is_a?(Array)
         # Variadic: return float if INCR, integer if !INCR
-        client.call([:zadd, key] + zadd_options + args[0], &(incr ? _floatify : _identity))
+        client.call([:zadd, key] + zadd_options + args[0], &(incr ? Floatify : nil))
       elsif args.size == 2
         # Single pair: return float if INCR, boolean if !INCR
-        client.call([:zadd, key] + zadd_options + args, &(incr ? _floatify : _boolify))
+        client.call([:zadd, key] + zadd_options + args, &(incr ? Floatify : Boolify))
       else
         raise ArgumentError, "wrong number of arguments"
       end
@@ -1505,7 +1505,7 @@ class Redis
   # @return [Float] score of the member after incrementing it
   def zincrby(key, increment, member)
     synchronize do |client|
-      client.call([:zincrby, key, increment, member], &_floatify)
+      client.call([:zincrby, key, increment, member], &Floatify)
     end
   end
 
@@ -1534,7 +1534,7 @@ class Redis
           reply
         else
           # Single argument: return boolean
-          _boolify.call(reply)
+          Boolify.call(reply)
         end
       end
     end
@@ -1551,7 +1551,7 @@ class Redis
   # @return [Float] score of the member
   def zscore(key, member)
     synchronize do |client|
-      client.call([:zscore, key, member], &_floatify)
+      client.call([:zscore, key, member], &Floatify)
     end
   end
 
@@ -1580,7 +1580,7 @@ class Redis
 
     if with_scores
       args << "WITHSCORES"
-      block = _floatify_pairs
+      block = FloatifyPairs
     end
 
     synchronize do |client|
@@ -1606,7 +1606,7 @@ class Redis
 
     if with_scores
       args << "WITHSCORES"
-      block = _floatify_pairs
+      block = FloatifyPairs
     end
 
     synchronize do |client|
@@ -1744,7 +1744,7 @@ class Redis
 
     if with_scores
       args << "WITHSCORES"
-      block = _floatify_pairs
+      block = FloatifyPairs
     end
 
     limit = options[:limit]
@@ -1776,7 +1776,7 @@ class Redis
 
     if with_scores
       args << ["WITHSCORES"]
-      block = _floatify_pairs
+      block = FloatifyPairs
     end
 
     limit = options[:limit]
@@ -1906,7 +1906,7 @@ class Redis
   # @return [Boolean] whether or not the field was **added** to the hash
   def hset(key, field, value)
     synchronize do |client|
-      client.call([:hset, key, field, value], &_boolify)
+      client.call([:hset, key, field, value], &Boolify)
     end
   end
 
@@ -1918,7 +1918,7 @@ class Redis
   # @return [Boolean] whether or not the field was **added** to the hash
   def hsetnx(key, field, value)
     synchronize do |client|
-      client.call([:hsetnx, key, field, value], &_boolify)
+      client.call([:hsetnx, key, field, value], &Boolify)
     end
   end
 
@@ -2021,7 +2021,7 @@ class Redis
   # @return [Boolean] whether or not the field exists in the hash
   def hexists(key, field)
     synchronize do |client|
-      client.call([:hexists, key, field], &_boolify)
+      client.call([:hexists, key, field], &Boolify)
     end
   end
 
@@ -2045,7 +2045,7 @@ class Redis
   # @return [Float] value of the field after incrementing it
   def hincrbyfloat(key, field, increment)
     synchronize do |client|
-      client.call([:hincrbyfloat, key, field, increment], &_floatify)
+      client.call([:hincrbyfloat, key, field, increment], &Floatify)
     end
   end
 
@@ -2075,7 +2075,7 @@ class Redis
   # @return [Hash<String, String>]
   def hgetall(key)
     synchronize do |client|
-      client.call([:hgetall, key], &_hashify)
+      client.call([:hgetall, key], &Hashify)
     end
   end
 
@@ -2312,7 +2312,7 @@ class Redis
         arg = args.first
 
         client.call([:script, :exists, arg]) do |reply|
-          reply = reply.map { |r| _boolify.call(r) }
+          reply = reply.map { |r| Boolify.call(r) }
 
           if arg.is_a?(Array)
             reply
@@ -2466,7 +2466,7 @@ class Redis
   # @return [String, Array<[String, String]>] the next cursor and all found keys
   def hscan(key, cursor, options={})
     _scan(:hscan, cursor, [key], options) do |reply|
-      [reply[0], _pairify(reply[1])]
+      [reply[0], reply[1].each_slice(2).to_a]
     end
   end
 
@@ -2505,7 +2505,7 @@ class Redis
   #   members and scores
   def zscan(key, cursor, options={})
     _scan(:zscan, cursor, [key], options) do |reply|
-      [reply[0], _floatify_pairs.call(reply[1])]
+      [reply[0], FloatifyPairs.call(reply[1])]
     end
   end
 
@@ -2573,7 +2573,7 @@ class Redis
   # @return [Boolean] true if at least 1 HyperLogLog internal register was altered. false otherwise.
   def pfadd(key, member)
     synchronize do |client|
-      client.call([:pfadd, key, member], &_boolify)
+      client.call([:pfadd, key, member], &Boolify)
     end
   end
 
@@ -2598,7 +2598,7 @@ class Redis
   # @return [Boolean]
   def pfmerge(dest_key, *source_key)
     synchronize do |client|
-      client.call([:pfmerge, dest_key, *source_key], &_boolify_set)
+      client.call([:pfmerge, dest_key, *source_key], &BoolifySet)
     end
   end
 
@@ -2617,9 +2617,9 @@ class Redis
         else
           if reply.kind_of?(Array)
             if reply[0].kind_of?(Array)
-              reply.map(&_hashify)
+              reply.map(&Hashify)
             else
-              _hashify.call(reply)
+              Hashify.call(reply)
             end
           else
             reply
@@ -2652,13 +2652,12 @@ private
   # Commands returning 1 for true and 0 for false may be executed in a pipeline
   # where the method call will return nil. Propagate the nil instead of falsely
   # returning false.
-  def _boolify
+  Boolify =
     lambda { |value|
       value == 1 if value
     }
-  end
 
-  def _boolify_set
+  BoolifySet =
     lambda { |value|
       if value && "OK" == value
         true
@@ -2666,9 +2665,8 @@ private
         false
       end
     }
-  end
 
-  def _hashify
+  Hashify =
     lambda { |array|
       hash = Hash.new
       array.each_slice(2) do |field, value|
@@ -2676,39 +2674,26 @@ private
       end
       hash
     }
-  end
 
-  def _floatify
+  Floatify =
     lambda { |str|
-      return unless str
-
-      if (inf = str.match(/^(-)?inf/i))
-        (inf[1] ? -1.0 : 1.0) / 0.0
-      else
-        Float(str)
+      if str
+        if (inf = str.match(/^(-)?inf/i))
+          (inf[1] ? -1.0 : 1.0) / 0.0
+        else
+          Float(str)
+        end
       end
     }
-  end
 
-  def _floatify_pairs
+  FloatifyPairs =
     lambda { |array|
-      return unless array
-
-      array.each_slice(2).map do |member, score|
-        [member, _floatify.call(score)]
+      if array
+        array.each_slice(2).map do |member, score|
+          [member, Floatify.call(score)]
+        end
       end
     }
-  end
-
-  def _pairify(array)
-    array.each_slice(2).to_a
-  end
-
-  def _identity
-    lambda { |value|
-      value
-    }
-  end
 
   def _subscription(method, channels, block)
     return @client.call([method] + channels) if subscribed?

--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -109,12 +109,12 @@ class Redis
       path || "#{host}:#{port}"
     end
 
-    def call(command, &block)
+    def call(command)
       reply = process([command]) { read }
       raise reply if reply.is_a?(CommandError)
 
-      if block
-        block.call(reply)
+      if block_given?
+        yield reply
       else
         reply
       end


### PR DESCRIPTION
It's also  a kind of refactoring: it removes private methods that actually are not methods of `Redis` instance since they don't depend on its state.