### PR TITLE
Symbolize sentinels option to align with other options

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -87,7 +87,7 @@ class Redis
 
       @pending_reads = 0
 
-      if options.include?(:sentinels) && options[:sentinels].any?
+      if @options.include?(:sentinels) && @options[:sentinels].any?
         @connector = Connector::Sentinel.new(@options)
       else
         @connector = Connector.new(@options)


### PR DESCRIPTION
Fixes: #570 

If we can indifferently use `"url"` or `:url` as an option, we should be able to do the same with `:sentinels` option.
