### PR TITLE
Distributed sscan and sscan_each

### DIFF
--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -509,6 +509,16 @@ class Redis
       node_for(key).smembers(key)
     end
 
+    # Scan a set
+    def sscan(key, cursor, options={})
+      node_for(key).sscan(key, cursor, options)
+    end
+
+    # Scan a set and return an enumerator
+    def sscan_each(key, options={}, &block)
+      node_for(key).sscan_each(key, options, &block)
+    end
+
     # Subtract multiple sets.
     def sdiff(*keys)
       ensure_same_node(:sdiff, keys) do |node|

--- a/test/distributed_commands_on_sets_test.rb
+++ b/test/distributed_commands_on_sets_test.rb
@@ -80,4 +80,29 @@ class TestDistributedCommandsOnSets < Test::Unit::TestCase
       r.sdiffstore("baz", "foo", "bar")
     end
   end
+
+  def test_sscan
+    assert_nothing_raised do
+      r.sadd "foo", "s1"
+      r.sadd "foo", "s2"
+      r.sadd "bar", "s2"
+      r.sadd "bar", "s3"
+
+      cursor, vals = r.sscan "foo", 0
+      assert_equal '0', cursor
+      assert_equal %w(s1 s2), vals.sort
+    end
+  end
+
+  def test_sscan_each
+    assert_nothing_raised do
+      r.sadd "foo", "s1"
+      r.sadd "foo", "s2"
+      r.sadd "bar", "s2"
+      r.sadd "bar", "s3"
+
+      vals = r.sscan_each("foo").to_a
+      assert_equal %w(s1 s2), vals.sort
+    end
+  end
 end


### PR DESCRIPTION
Adds `sscan` and `sscan_each` to `Redis::Distributed`. Just simple proxy methods.
