### PR TITLE
Fix various test suite warnings relating to variable ambiguity and unused variables

### DIFF
--- a/test/distributed_internals_test.rb
+++ b/test/distributed_internals_test.rb
@@ -72,7 +72,7 @@ class TestDistributedInternals < Test::Unit::TestCase
     nodes = ["redis://localhost:#{PORT}/15", "redis://localhost:#{PORT}/15", *NODES]
 
     assert_raise(RuntimeError) do
-      redis = Redis::Distributed.new nodes
+      Redis::Distributed.new nodes
     end
   end
 

--- a/test/lint/sorted_sets.rb
+++ b/test/lint/sorted_sets.rb
@@ -39,8 +39,8 @@ module Lint
         # INCR option
         assert_equal 1.0, r.zadd("foo", 1, "s1", :incr => true)
         assert_equal 11.0, r.zadd("foo", 10, "s1", :incr => true)
-        assert_equal -Infinity, r.zadd("bar", "-inf", "s1", :incr => true)
-        assert_equal +Infinity, r.zadd("bar", "+inf", "s2", :incr => true)
+        assert_equal(-Infinity, r.zadd("bar", "-inf", "s1", :incr => true))
+        assert_equal(+Infinity, r.zadd("bar", "+inf", "s2", :incr => true))
         r.del "foo", "bar"
 
         # Incompatible options combination
@@ -101,8 +101,8 @@ module Lint
         # INCR option
         assert_equal 1.0, r.zadd("foo", [1, "s1"], :incr => true)
         assert_equal 11.0, r.zadd("foo", [10, "s1"], :incr => true)
-        assert_equal -Infinity, r.zadd("bar", ["-inf", "s1"], :incr => true)
-        assert_equal +Infinity, r.zadd("bar", ["+inf", "s2"], :incr => true)
+        assert_equal(-Infinity, r.zadd("bar", ["-inf", "s1"], :incr => true))
+        assert_equal(+Infinity, r.zadd("bar", ["+inf", "s2"], :incr => true))
         assert_raise(Redis::CommandError) { r.zadd("foo", [1, "s1", 2, "s2"], :incr => true) }
         r.del "foo", "bar"
 


### PR DESCRIPTION
The following warnings appear between the starting of the Redis server and the loading of the test suite when running `rake`:

```
redis-rb/test/lint/sorted_sets.rb:42: warning: ambiguous first argument; put parentheses or a space even after `-' operator
redis-rb/test/lint/sorted_sets.rb:43: warning: ambiguous first argument; put parentheses or a space even after `+' operator
redis-rb/test/lint/sorted_sets.rb:104: warning: ambiguous first argument; put parentheses or a space even after `-' operator
redis-rb/test/lint/sorted_sets.rb:105: warning: ambiguous first argument; put parentheses or a space even after `+' operator
redis-rb/test/distributed_internals_test.rb:75: warning: assigned but unused variable - redis
```

This commit fixes those warnings and makes the test suite output a little cleaner.