### PR TITLE
Fixed variable name in the example usage

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -844,7 +844,7 @@ class Redis
   # Get the values of all the given keys.
   #
   # @example
-  #   redis.mapped_mget("key1", "key1")
+  #   redis.mapped_mget("key1", "key2")
   #     # => { "key1" => "v1", "key2" => "v2" }
   #
   # @param [Array<String>] keys array of keys


### PR DESCRIPTION
I think the second variable should be key2 and not key1 but could be wrong.