### PR TITLE
Always return integer from ZADD

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -1485,8 +1485,8 @@ class Redis
         # Variadic: return float if INCR, integer if !INCR
         client.call([:zadd, key] + zadd_options + args[0], &(incr ? _floatify : _identity))
       elsif args.size == 2
-        # Single pair: return float if INCR, boolean if !INCR
-        client.call([:zadd, key] + zadd_options + args, &(incr ? _floatify : _boolify))
+        # Single pair: return float if INCR, integer if !INCR
+        client.call([:zadd, key] + zadd_options + args, &(incr ? _floatify : _identity))
       else
         raise ArgumentError, "wrong number of arguments"
       end

--- a/test/lint/sorted_sets.rb
+++ b/test/lint/sorted_sets.rb
@@ -6,33 +6,33 @@ module Lint
 
     def test_zadd
       assert_equal 0, r.zcard("foo")
-      assert_equal true, r.zadd("foo", 1, "s1")
-      assert_equal false, r.zadd("foo", 1, "s1")
+      assert_equal 1, r.zadd("foo", 1, "s1")
+      assert_equal 0, r.zadd("foo", 1, "s1")
       assert_equal 1, r.zcard("foo")
       r.del "foo"
 
       target_version "3.0.2" do
         # XX option
         assert_equal 0, r.zcard("foo")
-        assert_equal false, r.zadd("foo", 1, "s1", :xx => true)
+        assert_equal 0, r.zadd("foo", 1, "s1", :xx => true)
         r.zadd("foo", 1, "s1")
-        assert_equal false, r.zadd("foo", 2, "s1", :xx => true)
+        assert_equal 0, r.zadd("foo", 2, "s1", :xx => true)
         assert_equal 2, r.zscore("foo", "s1")
         r.del "foo"
 
         # NX option
         assert_equal 0, r.zcard("foo")
-        assert_equal true, r.zadd("foo", 1, "s1", :nx => true)
-        assert_equal false, r.zadd("foo", 2, "s1", :nx => true)
+        assert_equal 1, r.zadd("foo", 1, "s1", :nx => true)
+        assert_equal 0, r.zadd("foo", 2, "s1", :nx => true)
         assert_equal 1, r.zscore("foo", "s1")
         assert_equal 1, r.zcard("foo")
         r.del "foo"
 
         # CH option
         assert_equal 0, r.zcard("foo")
-        assert_equal true, r.zadd("foo", 1, "s1", :ch => true)
-        assert_equal false, r.zadd("foo", 1, "s1", :ch => true)
-        assert_equal true, r.zadd("foo", 2, "s1", :ch => true)
+        assert_equal 1, r.zadd("foo", 1, "s1", :ch => true)
+        assert_equal 0, r.zadd("foo", 1, "s1", :ch => true)
+        assert_equal 1, r.zadd("foo", 2, "s1", :ch => true)
         assert_equal 1, r.zcard("foo")
         r.del "foo"
 


### PR DESCRIPTION
Hello, I can't find an explanation in the commit-message for why this line is here - but I believe the current use of _boolify disagrees with the Redis documentation: http://redis.io/commands/zadd

For example: `cli.zadd('foo', [2, 'bar'], [3, 'delta'])` will return true or false, even though 0, 1, 2 are all possible return values. 
