### PR TITLE
Write nonblock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,27 +38,48 @@ matrix:
     # hiredis
     - rvm: jruby-18mode
       gemfile: .travis/Gemfile
-      env: conn=hiredis REDIS_BRANCH=2.8
+      env: conn=hiredis REDIS_BRANCH=3.0
+    - rvm: jruby-18mode
+      gemfile: .travis/Gemfile
+      env: conn=hiredis REDIS_BRANCH=3.2
     - rvm: jruby-19mode
       gemfile: .travis/Gemfile
-      env: conn=hiredis REDIS_BRANCH=2.8
+      env: conn=hiredis REDIS_BRANCH=3.0
+    - rvm: jruby-19mode
+      gemfile: .travis/Gemfile
+      env: conn=hiredis REDIS_BRANCH=3.2
     - rvm: jruby-9.0.5.0
       gemfile: .travis/Gemfile
-      env: conn=hiredis REDIS_BRANCH=2.8
+      env: conn=hiredis REDIS_BRANCH=3.0
+    - rvm: jruby-9.0.5.0
+      gemfile: .travis/Gemfile
+      env: conn=hiredis REDIS_BRANCH=3.2
 
     # synchrony
     - rvm: 1.8.7
       gemfile: .travis/Gemfile
-      env: conn=synchrony REDIS_BRANCH=2.8
+      env: conn=synchrony REDIS_BRANCH=3.0
+    - rvm: 1.8.7
+      gemfile: .travis/Gemfile
+      env: conn=synchrony REDIS_BRANCH=3.2
     - rvm: jruby-18mode
       gemfile: .travis/Gemfile
-      env: conn=synchrony REDIS_BRANCH=2.8
+      env: conn=synchrony REDIS_BRANCH=3.0
+    - rvm: jruby-18mode
+      gemfile: .travis/Gemfile
+      env: conn=synchrony REDIS_BRANCH=3.2
     - rvm: jruby-19mode
       gemfile: .travis/Gemfile
-      env: conn=synchrony REDIS_BRANCH=2.8
+      env: conn=synchrony REDIS_BRANCH=3.0
+    - rvm: jruby-19mode
+      gemfile: .travis/Gemfile
+      env: conn=synchrony REDIS_BRANCH=3.2
     - rvm: jruby-9.0.5.0
       gemfile: .travis/Gemfile
-      env: conn=synchrony REDIS_BRANCH=2.8
+      env: conn=synchrony REDIS_BRANCH=3.0
+    - rvm: jruby-9.0.5.0
+      gemfile: .travis/Gemfile
+      env: conn=synchrony REDIS_BRANCH=3.2
   allow_failures:
     - rvm: rbx-2
 

--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -10,6 +10,16 @@ rescue LoadError
   # Not all systems have OpenSSL support
 end
 
+if RUBY_VERSION < "1.9.3"
+  class String
+    # Ruby 1.8.7 does not have byteslice, but it handles encodings differently anyway.
+    # We can simply slice the string, which is a byte array there.
+    def byteslice(*args)
+      slice(*args)
+    end
+  end
+end
+
 class Redis
   module Connection
     module SocketMixin

--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -85,7 +85,7 @@ class Redis
           write_nonblock(data)
 
         rescue *NBIO_EXCEPTIONS
-          if IO.select([self], nil, nil, @write_timeout)
+          if IO.select(nil, [self], nil, @write_timeout)
             retry
           else
             raise Redis::TimeoutError

--- a/test/internals_test.rb
+++ b/test/internals_test.rb
@@ -5,6 +5,7 @@ require File.expand_path("helper", File.dirname(__FILE__))
 class TestInternals < Test::Unit::TestCase
 
   include Helper::Client
+  include Helper::Skipable
 
   def test_logger
     r.ping
@@ -162,6 +163,8 @@ class TestInternals < Test::Unit::TestCase
 
   driver(:ruby) do
     def test_write_timeout
+      return skip("Relies on buffer sizes, might be unreliable")
+
       server = TCPServer.new("127.0.0.1", 0)
       port   = server.addr[1]
 


### PR DESCRIPTION
This should fix the latest leaks due to the way the timeout module spawns threads.

I used the following test to verify, but I'm not 100% sure it is reliable.
I'm still sure the code is actually correct ([tcp-timeout](https://github.com/lann/tcp-timeout-ruby) uses it as well). It's definitely better than using Timeout.

```ruby
driver(:ruby) do
  def test_write_timeout
    server = TCPServer.new("127.0.0.1", 0)
    port   = server.addr[1]

    # Hacky, but we need the buffer size
    val = TCPSocket.new("127.0.0.1", port).getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).unpack("i")[0]

    assert_raise(Redis::TimeoutError) do
      Timeout.timeout(1) do
        redis = Redis.new(:port => port, :timeout => 5, :write_timeout => 0.1)
        redis.set("foo", "1" * val*2)
      end
    end
  end
end
```