### PR TITLE
Pin em-synchrony version

### DIFF
--- a/.travis/Gemfile
+++ b/.travis/Gemfile
@@ -7,5 +7,5 @@ when "hiredis"
   gem "hiredis"
 when "synchrony"
   gem "hiredis"
-  gem "em-synchrony"
+  gem "em-synchrony", "1.0.4"
 end


### PR DESCRIPTION
Seems 1.0.5 does not work with Ruby 1.8.7 anymore.