### PR TITLE
Add count param to spop interface

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -1339,10 +1339,15 @@ class Redis
   # Remove and return a random member from a set.
   #
   # @param [String] key
-  # @return [String]
-  def spop(key)
+  # @param [Fixnum] count
+  # @return [String, Array<String>]
+  def spop(key, count = nil)
     synchronize do |client|
-      client.call([:spop, key])
+      if count.nil?
+        client.call([:spop, key])
+      else
+        client.call([:spop, key, count])
+      end
     end
   end
 

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -483,8 +483,8 @@ class Redis
     end
 
     # Remove and return a random member from a set.
-    def spop(key)
-      node_for(key).spop(key)
+    def spop(key, count = nil)
+      node_for(key).spop(key, count)
     end
 
     # Get a random member from a set.

--- a/test/lint/sets.rb
+++ b/test/lint/sets.rb
@@ -52,6 +52,15 @@ module Lint
       assert_equal nil, r.spop("foo")
     end
 
+    def test_multiple_spop
+      r.sadd "foo", "s1"
+      r.sadd "foo", "s2"
+      r.sadd "foo", "s3"
+
+      assert_equal 3, r.spop("foo", 3).length
+      assert_equal nil, r.spop("foo")
+    end
+
     def test_scard
       assert_equal 0, r.scard("foo")
 


### PR DESCRIPTION
The count param was added to SPOP in Redis 3.2.
