### PR TITLE
Keeps default url even with empty url string

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -398,7 +398,7 @@ class Redis
       url = options[:url] || defaults[:url]
 
       # Override defaults from URL if given
-      if url
+      if url && !url.empty?
         require "uri"
 
         uri = URI(url)

--- a/test/url_param_test.rb
+++ b/test/url_param_test.rb
@@ -135,4 +135,10 @@ class TestUrlParam < Test::Unit::TestCase
 
     assert_equal "127.0.0.1", redis.client.host
   end
+
+  def test_defaults_to_localhost_when_url_is_empty
+    redis = Redis.new(:url => "")
+
+    assert_equal "127.0.0.1", redis.client.host
+  end
 end


### PR DESCRIPTION
When passing a empty url string, it breaks with `ArgumentError: invalid uri scheme ''`. In my case, Sidekiq was passing a empty string, and I took a time to debug to redis-rb to find the problem, since it was a indirect dependency.

Hope it is ok!
