### PR TITLE
Add support for Redis Multi Transaction. Fix #542

### DIFF
--- a/lib/redis/connection/response_helper.rb
+++ b/lib/redis/connection/response_helper.rb
@@ -1,0 +1,32 @@
+class Redis
+  module Connection
+    module ResponseHelper
+
+      def array_expected_response?(response)
+        response.respond_to?(:each_slice)
+      end
+
+      def string_expected_response?(response)
+        response.respond_to?(:to_str) 
+      end
+
+      # add support for redis multi transaction response
+      # validate if multi command queue a command successufully
+      # all commands reply with the string QUEUED when does not exist an error
+      # according with 
+      # http://redis.io/commands/MULTI
+      # http://redis.io/topics/transactions
+      # redis.multi creates a transaction that is the native multi block implementation of redis.
+      # To execute the commands you should call exec.
+      # 
+      # redis.multi
+      # redis.[command]
+      # redis.[command]
+      # redis.exec
+      #
+      def command_queued_response?(response)
+        response == 'QUEUED'
+      end
+    end
+  end
+end

--- a/test/commands_on_multi_test.rb
+++ b/test/commands_on_multi_test.rb
@@ -1,0 +1,92 @@
+
+# encoding: UTF-8
+
+require File.expand_path("helper", File.dirname(__FILE__))
+
+class TestCommandsOnMulti < Test::Unit::TestCase
+
+  include Helper::Client
+  # Redis multi command enqued all commands in a redis transaction
+  # which means all comands send to redis are going to response with 
+  # the string QUEUED
+  # and execute with command exec
+  # This test pretends to test general commands.Those ones where
+  # response QUEUED response cause an issue because was not expect
+  #
+
+  def test_hgetall
+    r.hset 'test', 'foo', 'bar'
+    r.multi
+    assert_equal 'QUEUED', r.hgetall('test')
+    assert_equal [["foo", "bar"]], r.exec
+  end
+
+  def test_incrbyfloat
+    r.multi
+    assert_equal 'QUEUED', r.incrbyfloat('value', 1.24)
+    assert_equal ["1.24"], r.exec
+  end
+
+  def test_zincrby
+    r.multi
+    assert_equal 'QUEUED', r.zincrby('zset', 32.0, 'a')
+    assert_equal ["32"], r.exec
+  end
+
+  def test_zscore
+    r.zadd('zset', 32.0, 'a')
+    r.multi
+    assert_equal 'QUEUED', r.zscore('zset','a')
+    assert_equal ["32"], r.exec
+  end
+
+  def test_hincrbyfloat
+    r.multi
+    assert_equal 'QUEUED', r.hincrbyfloat('zset', 'a', 32.0)
+    assert_equal ["32"], r.exec
+  end
+
+  def test_zrange
+    r.zadd "foo", 1, "s1"
+    r.zadd "foo", 2, "s2"
+    r.multi
+    assert_equal 'QUEUED', r.zrange('foo', 0, -1)
+    assert_equal [['s1','s2']], r.exec
+  end
+
+  def test_zrevrange
+    r.zadd "foo", 1, "s1"
+    r.zadd "foo", 2, "s2"
+    r.multi
+    assert_equal 'QUEUED', r.zrevrange('foo', 0, -1)
+    assert_equal [['s2','s1']], r.exec
+  end
+
+  def test_zrangebyscore
+    r.zadd "foo", 1, "s1"
+    r.zadd "foo", 2, "s2"
+    r.multi
+    assert_equal 'QUEUED', r.zrangebyscore('foo', '2', '100')
+    assert_equal [['s2']], r.exec
+  end
+
+  def test_zrevrangebyscore
+    r.zadd "foo", 1, "s1"
+    r.zadd "foo", 2, "s2"
+    r.multi
+    assert_equal 'QUEUED', r.zrevrangebyscore('foo', '5', '100')
+    assert_equal [[]], r.exec
+  end
+
+  def test_zscan
+    r.multi
+    r.zscan('zset', '0')
+    assert_equal [['0',[]]], r.exec
+  end
+
+  def test_set
+    r.multi
+    assert_equal 'QUEUED', r.set('foo', 'bar')
+    assert r.exec
+  end
+end


### PR DESCRIPTION
#### what?

This change allows you to call `multi` without a block and queue commands successfully using Redis Transactions. Now we can use `exec` method to execute all commands after a `redis.multi` -> Fix issue https://github.com/redis/redis-rb/issues/542
#### why?
- Use the method `redis.multi` without a block raise an error as you can see in this issue https://github.com/redis/redis-rb/issues/542
- It is a good idea to have `multi` method that supports Redis Transactions
#### Caveats

 A complete Redis Transaction support, will involve a big refactor of redis response handler or method yielders. This fix introduce a Response Helper but we could think a way to know when `multi` was activated and manage responses, errors  and commands discards. 

The goal of this method is add support for Redis Transaction using `multi` method without block however, it does not pretend to deprecated `redis.multi { command; command }` with block. I really prefer to use block syntax in production. 

This fix works better with Redis Server 2.6.5 or greater
#### Changes
- Introduce `Redis::Connection::ResponseHelper`
- add methods that validate expected responses
- add a method that validate if response is equal to `QUEUED` that is the response of command under Redis multi transaction.
