### PR TITLE
allow for configuration keys with nil values to fall back onto defaults

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -86,7 +86,7 @@ class Redis
 
       @pending_reads = 0
 
-      if options.include?(:sentinels)
+      if options.include?(:sentinels) && options[:sentinels].any? { |conf| !conf[:host].nil? && !conf[:port].nil? }
         @connector = Connector::Sentinel.new(@options)
       else
         @connector = Connector.new(@options)
@@ -331,7 +331,7 @@ class Redis
       server = @connector.resolve.dup
 
       @options[:host] = server[:host]
-      @options[:port] = Integer(server[:port]) if server.include?(:port)
+      @options[:port] = Integer(server[:port]) if server.include?(:port) && !server[:port].nil?
 
       @connection = @options[:driver].connect(@options)
       @pending_reads = 0
@@ -435,7 +435,7 @@ class Redis
         options[:port] = options[:port].to_i
       end
 
-      if options.has_key?(:timeout)
+      if options.has_key?(:timeout) && !options[:timeout].nil?
         options[:connect_timeout] ||= options[:timeout]
         options[:read_timeout]    ||= options[:timeout]
         options[:write_timeout]   ||= options[:timeout]
@@ -508,7 +508,7 @@ class Redis
           @options[:db] = DEFAULTS.fetch(:db)
 
           @sentinels = @options.delete(:sentinels).dup
-          @role = @options.fetch(:role, "master").to_s
+          @role = (@options[:role] || "master").to_s
           @master = @options[:host]
         end
 


### PR DESCRIPTION
In our effort to turn our deployment into something 12-factor-compliant, we tried to base our configuration solely on ENV variables like so:

```
url: <%= ENV['REDIS_URL'].presence || nil %>
sentinels:
  - host: <%= ENV['REDIS_SENTINEL_HOST'].presence || nil %>
    port: <%= ENV['REDIS_SENTINEL_PORT'].presence || nil %>
role: <%= ENV['REDIS_ROLE'].presence || nil %>
timeout: <%= ENV['REDIS_TIMEOUT'].presence || 0.1 %>
db: <%= ENV['REDIS_DB'].presence || 0 %>
host: <%= ENV['REDIS_HOST'].presence || '127.0.0.1' %>
port: <%= ENV['REDIS_PORT'].presence || 6379 %>
```

This however results in the configuration hash holding several unnecessary keys with `nil` values. Thus these changes are needed so in case of a key existing but being nil, the default is still used.

I assume this was intended all along, but did only work for some of the keys, not all.
