### PR TITLE
handling SocketError

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -336,6 +336,7 @@ class Redis
       @connection = @options[:driver].connect(@options)
       @pending_reads = 0
     rescue TimeoutError,
+           SocketError,
            Errno::ECONNREFUSED,
            Errno::EHOSTDOWN,
            Errno::EHOSTUNREACH,


### PR DESCRIPTION
When connecting to the Sentinel, the standard socket library may raise `SocketError`.
(e.g. `getaddrinfo: Name or service not known` )
But current redis-rb doesn't rescue it, so the process can not try to connect to the next Sentinel.
This patch will rescue it.
