### PR TITLE
Adds IO::WaitWritable to nonblocking exceptions to support use with SSL

### DIFF
--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -28,7 +28,7 @@ class Redis
 
       # Exceptions raised during non-blocking I/O ops that require retrying the op
       NBIO_EXCEPTIONS = [Errno::EWOULDBLOCK, Errno::EAGAIN]
-      NBIO_EXCEPTIONS << IO::WaitReadable if RUBY_VERSION >= "1.9.3"
+      NBIO_EXCEPTIONS += [IO::WaitReadable, IO::WaitWritable] if RUBY_VERSION >= "1.9.3"
 
       def initialize(*args)
         super(*args)


### PR DESCRIPTION
When used with SSL, any read or write can trigger a handshake; this means we need to handle both nonblocking read and write errors.
