### PR TITLE
Add optional message argument to ping

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -143,10 +143,12 @@ class Redis
 
   # Ping the server.
   #
+  # @param [optional, String] message
   # @return [String] `PONG`
-  def ping
+  def ping(message = nil)
+    arguments = [:ping, message].compact
     synchronize do |client|
-      client.call([:ping])
+      client.call(arguments)
     end
   end
 

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -146,9 +146,8 @@ class Redis
   # @param [optional, String] message
   # @return [String] `PONG`
   def ping(message = nil)
-    arguments = [:ping, message].compact
     synchronize do |client|
-      client.call(arguments)
+      client.call([:ping, message].compact)
     end
   end
 


### PR DESCRIPTION
According to Redis, you can pass an optional argument to PING. To be consistent with their API, I've added that optional argument