### PR TITLE
Fix #_write_to_socket in connection

### DIFF
--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -306,9 +306,8 @@ class Redis
         if config[:scheme] == "unix"
           raise ArgumentError, "SSL incompatible with unix sockets" if config[:ssl]
           sock = UNIXSocket.connect(config[:path], config[:connect_timeout])
-        elsif config[:ssl] && RUBY_VERSION < "1.9.3"
-          raise ArgumentError, "This library does not support SSL on Ruby < 1.9"
         elsif config[:scheme] == "rediss" || config[:ssl]
+          raise ArgumentError, "This library does not support SSL on Ruby < 1.9" if RUBY_VERSION < "1.9.3"
           sock = SSLSocket.connect(config[:host], config[:port], config[:connect_timeout], config[:ssl_params])
         else
           sock = TCPSocket.connect(config[:host], config[:port], config[:connect_timeout])

--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -104,14 +104,14 @@ class Redis
         begin
           write_nonblock(data)
 
-        rescue *NBIO_READ_EXCEPTIONS
-          if IO.select([self], nil, nil, @write_timeout)
+        rescue *NBIO_WRITE_EXCEPTIONS
+          if IO.select(nil, [self], nil, @write_timeout)
             retry
           else
             raise Redis::TimeoutError
           end
-        rescue *NBIO_WRITE_EXCEPTIONS
-          if IO.select(nil, [self], nil, @write_timeout)
+        rescue *NBIO_READ_EXCEPTIONS
+          if IO.select([self], nil, nil, @write_timeout)
             retry
           else
             raise Redis::TimeoutError

--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -306,6 +306,8 @@ class Redis
         if config[:scheme] == "unix"
           raise ArgumentError, "SSL incompatible with unix sockets" if config[:ssl]
           sock = UNIXSocket.connect(config[:path], config[:connect_timeout])
+        elsif config[:ssl] && RUBY_VERSION < "1.9.0"
+          raise ArgumentError, "This library does not support SSL on Ruby < 1.9"
         elsif config[:scheme] == "rediss" || config[:ssl]
           sock = SSLSocket.connect(config[:host], config[:port], config[:connect_timeout], config[:ssl_params])
         else


### PR DESCRIPTION
By placing the NBIO_READ_EXCEPTIONS above the NBIO_WRITE_EXCEPTIONS, an
Errno::EWOULDBLOCK or Errno::EAGAIN would trigger a wait for the socket
to be readable. This is causing timeout errors in our testing.

When calling #write_nonblock, the appropriate action is to wait for the
socket to be writable, not readable. Ensuring that we handle the write
exceptions before the read exceptions accomplishes this.

Unless I'm missing something?