### PR TITLE
Wrap exceptions for missing socket with CannotConnectError

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -340,6 +340,7 @@ class Redis
            Errno::EHOSTDOWN,
            Errno::EHOSTUNREACH,
            Errno::ENETUNREACH,
+           Errno::ENOENT,
            Errno::ETIMEDOUT
 
       raise CannotConnectError, "Error connecting to Redis on #{location} (#{$!.class})"

--- a/test/internals_test.rb
+++ b/test/internals_test.rb
@@ -158,6 +158,13 @@ class TestInternals < Test::Unit::TestCase
     assert (Time.now - start_time) <= opts[:timeout]
   end
 
+  def test_missing_socket
+    opts = { :path => '/missing.sock' }
+    assert_raise Redis::CannotConnectError do
+      Redis.new(opts).ping
+    end
+  end
+
   def close_on_ping(seq, options = {})
     $request = 0
 


### PR DESCRIPTION
Resolves #656.  Test is added as well, though may not be wanted.  Did not see tests checking the other types of connection errors except for timeout.