### PR TITLE
Add support for EAGAINWait{Readable, Writable}

### DIFF
--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -33,6 +33,10 @@ class Redis
         NBIO_READ_EXCEPTIONS << IO::WaitReadable
         NBIO_WRITE_EXCEPTIONS << IO::WaitWritable
       end
+      if RUBY_VERSION >= "2.1.0"
+        NBIO_READ_EXCEPTIONS << IO::EAGAINWaitReadable
+        NBIO_WRITE_EXCEPTIONS << IO::EAGAINWaitWritable
+      end
 
       def initialize(*args)
         super(*args)


### PR DESCRIPTION
Beginning in ruby 2.1.0 there is an `EAGAINWaitReadable` in addition to `WaitReadable` that also needs to be trapped and select+retried.