### PR TITLE
added REPLACE modifier for restore command

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -460,12 +460,11 @@ class Redis
   # @param [String] serialized_value
   # @param [Hash] options
   #   - `:replace => Boolean`: if false, raises an error if key already exists
-  # @param [Hash] replace
   # @raise [Redis::CommandError]
   # @return [String] `"OK"`
   def restore(key, ttl, serialized_value, options = {})
     args = [:restore, key, ttl, serialized_value]
-    args << 'REPLACE' if options.fetch(:replace, true)
+    args << 'REPLACE' if options[:replace]
 
     synchronize do |client|
       client.call(args)

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -458,10 +458,17 @@ class Redis
   # @param [String] key
   # @param [String] ttl
   # @param [String] serialized_value
+  # @param [Hash] options
+  #   - `:replace => Boolean`: if false, raises an error if key already exists
+  # @param [Hash] replace
+  # @raise [Redis::CommandError]
   # @return [String] `"OK"`
-  def restore(key, ttl, serialized_value)
+  def restore(key, ttl, serialized_value, options = {})
+    args = [:restore, key, ttl, serialized_value]
+    args << 'REPLACE' if options.fetch(:replace, true)
+
     synchronize do |client|
-      client.call([:restore, key, ttl, serialized_value])
+      client.call(args)
     end
   end
 

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -144,8 +144,9 @@ class Redis
     end
 
     # Create a key using the serialized value, previously obtained using DUMP.
-    def restore(key, ttl, serialized_value)
-      node_for(key).restore(key, ttl, serialized_value)
+    def restore(key, ttl, serialized_value, options = {})
+      options[:replace] = true unless options.key?(:replace)
+      node_for(key).restore(key, ttl, serialized_value, options)
     end
 
     # Transfer a key from the connected instance to another instance.

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -145,7 +145,6 @@ class Redis
 
     # Create a key using the serialized value, previously obtained using DUMP.
     def restore(key, ttl, serialized_value, options = {})
-      options[:replace] = true unless options.key?(:replace)
       node_for(key).restore(key, ttl, serialized_value, options)
     end
 

--- a/test/lint/value_types.rb
+++ b/test/lint/value_types.rb
@@ -95,8 +95,12 @@ module Lint
         assert [0, 1].include? r.ttl("bar")
 
         r.set("bar", "somethingelse")
+        assert_raises(Redis::CommandError) { r.restore("bar", 1000, w) } # ensure by default replace is false
         assert_raises(Redis::CommandError) { r.restore("bar", 1000, w, :replace => false) }
         assert_equal "somethingelse", r.get("bar")
+        assert r.restore("bar", 1000, w, :replace => true)
+        assert_equal ["b", "c", "d"], r.lrange("bar", 0, -1)
+        assert [0, 1].include? r.ttl("bar")
       end
     end
 

--- a/test/lint/value_types.rb
+++ b/test/lint/value_types.rb
@@ -95,7 +95,7 @@ module Lint
         assert [0, 1].include? r.ttl("bar")
 
         r.set("bar", "somethingelse")
-        assert_raises(Redis::CommandError) { r.restore("bar", 1000, w, replace: false) }
+        assert_raises(Redis::CommandError) { r.restore("bar", 1000, w, :replace => false) }
         assert_equal "somethingelse", r.get("bar")
       end
     end

--- a/test/lint/value_types.rb
+++ b/test/lint/value_types.rb
@@ -93,6 +93,10 @@ module Lint
         assert r.restore("bar", 1000, w)
         assert_equal ["b", "c", "d"], r.lrange("bar", 0, -1)
         assert [0, 1].include? r.ttl("bar")
+
+        r.set("bar", "somethingelse")
+        assert_raises(Redis::CommandError) { r.restore("bar", 1000, w, replace: false) }
+        assert_equal "somethingelse", r.get("bar")
       end
     end
 


### PR DESCRIPTION
Added support for REPLACE modifier to the RESTORE command. If :replace option is true, passes along the REPLACE modifier. If the modifier is missing, a Redis::CommandError is raised iff the key already exists. If the modifier is present, the key is overwritten.