### PR TITLE
Add Redis::Distributed#mget

### DIFF
--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -278,8 +278,18 @@ class Redis
     end
 
     # Get the values of all the given keys.
+    #
     def mget(*keys)
-      raise CannotDistribute, :mget
+      m_nodes = keys.group_by { |key| node_for(key) }
+
+      results = Hash[
+        m_nodes.flat_map do |node, key_list|
+          values = node.mget(key_list)
+          key_list.zip(values)
+        end
+      ]
+
+      keys.map { |key| results[key] }
     end
 
     def mapped_mget(*keys)

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -284,7 +284,7 @@ class Redis
 
       results = Hash[
         m_nodes.flat_map do |node, key_list|
-          values = node.mget(key_list)
+          values = node.mget(*key_list)
           key_list.zip(values)
         end
       ]

--- a/test/distributed_commands_on_strings_test.rb
+++ b/test/distributed_commands_on_strings_test.rb
@@ -9,9 +9,11 @@ class TestDistributedCommandsOnStrings < Test::Unit::TestCase
   include Lint::Strings
 
   def test_mget
-    assert_raise Redis::Distributed::CannotDistribute do
-      r.mget("foo", "bar")
-    end
+    r.set("foo", "s1")
+    r.set("bar", "s2")
+
+    assert_equal ["s1", "s2"]     , r.mget("foo", "bar")
+    assert_equal ["s1", "s2", nil], r.mget("foo", "bar", "baz")
   end
 
   def test_mget_mapped


### PR DESCRIPTION
## What

When a distributed Redis receives `mget`, find the nodes the keys should be
stored on and issue `mget` commands to each sub-node with only their matching keys.
Then combine the results and return them in an order that matches the key
list.


## Why

My team is sharding the cache in a Rails application that uses Redis as cache storage.
The setup relies on:
```
redis-rails
  redis-activesupport
    redis-store
      redis
```
It works quite well.

However, we also use `record-cache`. That works too because it only uses the high level interface of the generic ActiveSupport cache. Unfortunately, it seems to be optimized to read records in batches, here:
https://github.com/orslumen/record-cache/blob/9bf4285c0a086f831b4b6e1d3fc292fbe44a14d6/lib/record_cache/multi_read.rb#L35-L43

The `redis-activesupport` cache adapter implementation of `read_multi` relies on `mget`, which currently raises an exception in `Redis::Distributed`.
This causes the cache queries to degenerate from a high number of `mget` to a _very_ large number of single `get` commands.
The result is that we've observed a significant increase of both commands per second and CPU usage, which is what we actually wanted to reduce.