### PR TITLE
SSL params: allow skipping hostname verification 

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,17 @@ redis = Redis.new(
 )
 ```
 
+Turn off hostname verification using `OpenSSL::SSL::SSLContext#verify_mode`, ie:
+
+```ruby
+redis = Redis.new(
+  :url        => "rediss://:p4ssw0rd@10.0.1.1:6381/15",
+  :ssl_params => {
+    :verify_mode => OpenSSL::SSL::VERIFY_NONE
+  }
+)
+```
+
 [stunnel]: https://www.stunnel.org/
 [hitch]: https://hitch-tls.org/
 [ghostunnel]: https://github.com/square/ghostunnel

--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -286,7 +286,16 @@ class Redis
           ssl_sock = new(tcp_sock, ctx)
           ssl_sock.hostname = host
           ssl_sock.connect
-          ssl_sock.post_connection_check(host)
+          
+          #
+          # Enable skipping hostname verification 
+          # if verify mode is set to OpenSSL::SSL::VERIFY_NONE.
+          #
+          # CAUTION: use at own risk!!!
+          #
+          unless ctx.verify_mode == OpenSSL::SSL::VERIFY_NONE
+            ssl_sock.post_connection_check(host) 
+          end
 
           ssl_sock
         end


### PR DESCRIPTION
**Use case:** 

Using _heroku-redis_, its possible to connect directly to its _stunnel_ port to secure the data transport -- however, the SSL certificate hostname from heroku _(aka AWS)_ is an internal address, not the public DNS record used to initiate the connection to heroku-redis instance. Therefore, it required **skipping hostname checks** to make a successful connect.

Given the unsafe nature of this change, is there merit to adding this feature and allowing others to use _skip hostname verification_ if they need too?

Also, I'm unsure the proper way to test this setting, any suggestion would be appreciated.