### PR TITLE
Adding support for the ZLEXCOUNT command on sorted set.

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -1701,6 +1701,30 @@ class Redis
     end
   end
 
+  # Count the members, with the same score in a sorted set, within the given lexicographical range.
+  #
+  # @example Count members matching a
+  #   redis.zlexcount("zset", "[a", "[a\xff")
+  #     # => 1
+  # @example Count members matching a-z
+  #   redis.zlexcount("zset", "[a", "[z\xff")
+  #     # => 26
+  #
+  # @param [String] key
+  # @param [String] min
+  #   - inclusive minimum is specified by prefixing `(`
+  #   - exclusive minimum is specified by prefixing `[`
+  # @param [String] max
+  #   - inclusive maximum is specified by prefixing `(`
+  #   - exclusive maximum is specified by prefixing `[`
+  #
+  # @return [Fixnum] number of members within the specified lexicographical range
+  def zlexcount(key, min, max)
+    synchronize do |client|
+      client.call([:zlexcount, key, min, max])
+    end
+  end
+
   # Return a range of members with the same score in a sorted set, by lexicographical ordering
   #
   # @example Retrieve members matching a

--- a/test/commands_on_sorted_sets_test.rb
+++ b/test/commands_on_sorted_sets_test.rb
@@ -8,6 +8,21 @@ class TestCommandsOnSortedSets < Test::Unit::TestCase
   include Helper::Client
   include Lint::SortedSets
 
+  def test_zlexcount
+    target_version "2.8.9" do
+      r.zadd "foo", 0, "aaren"
+      r.zadd "foo", 0, "abagael"
+      r.zadd "foo", 0, "abby"
+      r.zadd "foo", 0, "abbygail"
+
+      assert_equal 4, r.zlexcount("foo", "[a", "[a\xff")
+      assert_equal 4, r.zlexcount("foo", "[aa", "[ab\xff")
+      assert_equal 3, r.zlexcount("foo", "(aaren", "[ab\xff")
+      assert_equal 2, r.zlexcount("foo", "[aba", "(abbygail")
+      assert_equal 1, r.zlexcount("foo", "(aaren", "(abby")
+    end
+  end
+
   def test_zrangebylex
     target_version "2.8.9" do
       r.zadd "foo", 0, "aaren"


### PR DESCRIPTION
Adding support for `ZLEXCOUNT` command. This command has been available since Redis `2.8.9`, along with the other lexicographical commands on sorted set - `ZRANGEBYLEX`, `ZREVRANGEBYLEX` and `ZREMRANGEBYLEX`