### PR TITLE
Distributed: support mget and mapped_mget

### DIFF
--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -277,13 +277,16 @@ class Redis
       node_for(key).get(key)
     end
 
-    # Get the values of all the given keys.
+    # Get the values of all the given keys as an Array.
     def mget(*keys)
-      raise CannotDistribute, :mget
+      mapped_mget(*keys).values_at(*keys)
     end
 
+    # Get the values of all the given keys as a Hash.
     def mapped_mget(*keys)
-      raise CannotDistribute, :mapped_mget
+      keys.group_by { |k| node_for k }.inject({}) do |results, (node, subkeys)|
+        results.merge! node.mapped_mget(*subkeys)
+      end
     end
 
     # Overwrite part of a string at key starting at the specified offset.

--- a/test/distributed_commands_on_strings_test.rb
+++ b/test/distributed_commands_on_strings_test.rb
@@ -9,15 +9,27 @@ class TestDistributedCommandsOnStrings < Test::Unit::TestCase
   include Lint::Strings
 
   def test_mget
-    assert_raise Redis::Distributed::CannotDistribute do
-      r.mget("foo", "bar")
-    end
+    r.set("foo", "s1")
+    r.set("bar", "s2")
+
+    assert_equal ["s1", "s2"]     , r.mget("foo", "bar")
+    assert_equal ["s1", "s2", nil], r.mget("foo", "bar", "baz")
   end
 
   def test_mget_mapped
-    assert_raise Redis::Distributed::CannotDistribute do
-      r.mapped_mget("foo", "bar")
-    end
+    r.set("foo", "s1")
+    r.set("bar", "s2")
+
+    response = r.mapped_mget("foo", "bar")
+
+    assert_equal "s1", response["foo"]
+    assert_equal "s2", response["bar"]
+
+    response = r.mapped_mget("foo", "bar", "baz")
+
+    assert_equal "s1", response["foo"]
+    assert_equal "s2", response["bar"]
+    assert_equal nil , response["baz"]
   end
 
   def test_mset


### PR DESCRIPTION
Upstreaming a patch we use to support distributed cache lookups. Map the keys to their nodes, mget them on each node, and stitch the results together.

Apparently this component is frozen and unmaintained. That's a shame, considering caching is a common use case for Redis, and will become more so with upcoming support for LFU expiry. Sharing for posterity, in any case.

Related: #673, #554, #478, #12.