### PR TITLE
Allow hostname checks to be disabled

### DIFF
--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -287,7 +287,7 @@ class Redis
           ssl_sock.hostname = host
           ssl_sock.connect
 
-          unless ssl_params.has_key?(:verify_hostname) && ssl_params[:verify_hostname] == false
+          unless ssl_params && ssl_params[:verify_hostname] == false
             ssl_sock.post_connection_check(host)
           end
 

--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -286,7 +286,10 @@ class Redis
           ssl_sock = new(tcp_sock, ctx)
           ssl_sock.hostname = host
           ssl_sock.connect
-          ssl_sock.post_connection_check(host)
+
+          unless ssl_params.has_key?(:verify_hostname) && ssl_params[:verify_hostname] == false
+            ssl_sock.post_connection_check(host)
+          end
 
           ssl_sock
         end


### PR DESCRIPTION
When using mutual certificate authentication, it is often unnecessary (and a blocker) to have the certificate match the host domain. The security model is provided with the client certificates.

`verify_hostname` is firstly a valid option of [SSLContext](https://docs.ruby-lang.org/en/2.4.0/OpenSSL/SSL/SSLContext.html#method-i-set_params), so this option and intention should be carried through in this client when using TLS certificate authentication.