### PR TITLE
Travis: Remove rbx-2 from the CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ rvm:
   - jruby-18mode
   - jruby-19mode
   - jruby-9.0.5.0
-  - rbx-2
 
 gemfile: ".travis/Gemfile"
 
@@ -80,8 +79,6 @@ matrix:
     - rvm: jruby-9.0.5.0
       gemfile: .travis/Gemfile
       env: conn=synchrony REDIS_BRANCH=3.2
-  allow_failures:
-    - rvm: rbx-2
 
 notifications:
   irc:


### PR DESCRIPTION
This PR removes rbx-2 from the CI matrix.

Rubinius expressed like that errors on installation:

```
Requested binary installation but no rubies are available to download, consider skipping --binary flag.
Gemset '' does not exist, 'rvm rbx-2 do rvm gemset create ' first, or append '--create'.
The command "rvm use rbx-2 --install --binary --fuzzy" failed and exited with 2 during .
