### PR TITLE
add note about timeouts and connection integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,9 @@ end
 
 If no message is received after 5 seconds, the client will unsubscribe.
 
+**NOTE:** while this library is thread-safe, ruby's Timeout::timeout is NOT
+* **DO NOT** wrap redis calls in a Timeout::timeout -- this will corrupt the connection
+* Practical example can be found [here](http://www.mikeperham.com/2015/05/08/timeout-rubys-most-dangerous-api/)
 
 ## SSL/TLS Support
 

--- a/README.md
+++ b/README.md
@@ -255,8 +255,7 @@ end
 
 If no message is received after 5 seconds, the client will unsubscribe.
 
-**NOTE:** while this library is thread-safe, ruby's Timeout::timeout is NOT
-* **DO NOT** wrap redis calls in a Timeout::timeout -- this will corrupt the connection
+**NOTE:** **DO NOT** wrap redis calls in a Timeout::timeout -- this will corrupt the connection
 * Practical example can be found [here](http://www.mikeperham.com/2015/05/08/timeout-rubys-most-dangerous-api/)
 
 ## SSL/TLS Support


### PR DESCRIPTION
After a long time of investigating difficult to reproduce errors and suspecting that there is some thread safety issue, we found a note at the bottom of the connection pool gem (which we don't use):
https://github.com/mperham/connection_pool
which indicates that `Timeout::timeout` may cause strange errors
Then, we wrapped our redis calls in small timeouts and were quickly able to reproduce the errors