### PR TITLE
Get tests passing with frozen-string-literals enabled.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.0
+  - 2.4.1
   - jruby-18mode
   - jruby-19mode
   - jruby-9.0.5.0
@@ -15,6 +16,9 @@ rvm:
 gemfile: ".travis/Gemfile"
 
 sudo: false
+
+before_script:
+- if (ruby -e "exit RUBY_VERSION.to_f >= 2.4"); then export RUBYOPT="--enable-frozen-string-literal"; fi; echo $RUBYOPT
 
 env:
   global:

--- a/.travis/Gemfile
+++ b/.travis/Gemfile
@@ -9,3 +9,9 @@ when "synchrony"
   gem "hiredis"
   gem "em-synchrony"
 end
+
+if RUBY_VERSION.to_f < 1.9
+  gem 'test-unit', '3.1.5'
+else
+  gem 'test-unit', '>= 3.2.5'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,9 @@
 source 'https://rubygems.org'
 
 gemspec
+
+if RUBY_VERSION.to_f < 1.9
+  gem 'test-unit', '3.1.5'
+else
+  gem 'test-unit', '>= 3.2.5'
+end

--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -39,7 +39,7 @@ class Redis
         super(*args)
 
         @timeout = @write_timeout = nil
-        @buffer = ""
+        @buffer = "".dup
       end
 
       def timeout=(timeout)

--- a/redis.gemspec
+++ b/redis.gemspec
@@ -40,5 +40,5 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
 
   s.add_development_dependency("rake", "<11.0.0")
-  s.add_development_dependency("test-unit", "3.1.5")
+  s.add_development_dependency("test-unit", ">= 3.1.5")
 end


### PR DESCRIPTION
This one simple change ensure that all string literals can be frozen (as per the optional feature in MRI 2.3 and onwards). @twalpole has (again) beaten me to such a patch (in #590), though mine (again) does not add the pragma comment to all files. Getting their or my PRs merged in would be excellent :)

As an alternative to the pragma comment, I would recommend adding the following to your .travis.yml file to ensure regressions aren't introduced:

```yml
before_script:
- if (ruby -e "exit RUBY_VERSION.to_f >= 2.4"); then export RUBYOPT="--enable-frozen-string-literal"; fi; echo $RUBYOPT
```

This will add the flag when the tests are run on MRI 2.4 or newer (while the feature was introduced in 2.3, it doesn't seem to work reliably until 2.4). Please note: tests will currently fail when this flag is set unless test-unit is also updated (as noted in https://github.com/test-unit/test-unit/pull/149).