### PR TITLE
Use :read_timeout instead of :timeout for read timeout

### DIFF
--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -314,7 +314,7 @@ class Redis
         end
 
         instance = new(sock)
-        instance.timeout = config[:timeout]
+        instance.timeout = config[:read_timeout]
         instance.write_timeout = config[:write_timeout]
         instance.set_tcp_keepalive config[:tcp_keepalive]
         instance


### PR DESCRIPTION
This will fix #708. After this fix all the tests still run on my machine and my test script from the issue gives the expected results (run with `bundle exec <scriptname>` with the hiredis bits commented out and see the results). 

I scanned the code but could not see any other renamings that could be done without refactoring lots of code. Also, I thought about writing a separate test for this but decided against it because a. I don't think I know enough about the testing system of this library to make it idiomatic, b. This test might fail on other (faster/slower) machines than mine and c. testing timeouts is inherently messy and I dislike waiting in my test suite.

I welcome comments and/or thoughts for improvements of course :)