### PR TITLE
Back off mechanism for reconnection attempts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,26 @@ end
 
 If no message is received after 5 seconds, the client will unsubscribe.
 
+## Reconnections
+
+The client allows you to configure how many `reconnect_attempts` it should
+complete before declaring a connection as failed. Furthermore, you may
+control the maximum duration between reconnection attempts with
+`reconnect_max_timeout`.
+
+
+```ruby
+Redis.new(
+  :reconnect_attempts => 10,
+  :reconnect_max_timeout => 2
+)
+```
+
+The max timeout value is specified in seconds. With the above configuration, the
+client would attempt 10 reconnections, exponentially increasing the duration
+between each attempt until it reaches the specified 2 second limit. The default
+max timeout is 12.8 seconds.
+
 
 ## SSL/TLS Support
 

--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -369,6 +369,13 @@ class Redis
         disconnect
 
         if attempts <= @options[:reconnect_attempts] && @reconnect
+          wait_time = 2**[attempts, 7].min * 0.1
+
+          if @options[:reconnect_max_timeout]
+            wait_time = [@options[:reconnect_max_timeout], wait_time].min
+          end
+
+          sleep wait_time
           retry
         else
           raise

--- a/test/internals_test.rb
+++ b/test/internals_test.rb
@@ -110,6 +110,12 @@ class TestInternals < Test::Unit::TestCase
     end
   end
 
+  def test_reconnect_max_timeout
+    assert_nothing_raised do
+      Redis.new(OPTIONS.merge(:reconnect_max_timeout => 0))
+    end
+  end
+
   def test_id_inside_multi
     redis = Redis.new(OPTIONS)
     id = nil


### PR DESCRIPTION
This is a first take on a simple back off algorithm for reconnection
attempts. I've previously mentioned this in #598
but didn't get any feedback. Therefore I haven't changed much to the
solution proposed there.
A possible introduction of a back off mechanism has also been mentioned
in #347.

The patch changes the reconnection behaviour to be "less aggressive"
by sleeping for a period of time. The sleep period increases
exponentially, starting at 0.2 seconds and ending at 12.8 seconds
(this maximum can be configured by supplying a `reconnect_max_timeout`
option to the client.)

I've recorded a quick video of how this looks like when
starting/stopping a redis container: https://youtu.be/Z4HuZmwYCZM

Hope I didn't overlook any major points.

Looking forward to your feedback,
thanks for a great library.