### PR TITLE
Restore support for Ruby 1.8 in the 3.3.x branch

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -2702,11 +2702,11 @@ class Redis
 
   def connection
     {
-      host:     @original_client.host,
-      port:     @original_client.port,
-      db:       @original_client.db,
-      id:       @original_client.id,
-      location: @original_client.location
+      :host     => @original_client.host,
+      :port     => @original_client.port,
+      :db       => @original_client.db,
+      :id       => @original_client.id,
+      :location => @original_client.location
     }
   end
 


### PR DESCRIPTION
This resolves #719 by changing the Redis#connection backport (07d04dee) to use hashrocket syntax.