### PR TITLE
Change #exist behaviour for multiple keys #698

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -530,6 +530,10 @@ class Redis
   # @return [Boolean]
   def exists(key)
     synchronize do |client|
+      if key.is_a?(Enumerable)
+        return client.call([:exists, key], &BoolifyExistEnum)
+      end
+
       client.call([:exists, key], &Boolify)
     end
   end
@@ -2773,6 +2777,15 @@ private
   Boolify =
     lambda { |value|
       value == 1 if value
+    }
+
+  BoolifyExistEnum =
+    lambda { |value|
+      if value == 0
+        nil
+      else
+        value
+      end
     }
 
   BoolifySet =

--- a/test/lint/value_types.rb
+++ b/test/lint/value_types.rb
@@ -8,6 +8,12 @@ module Lint
       r.set("foo", "s1")
 
       assert_equal true,  r.exists("foo")
+
+      r.set("foo1", "s2")
+
+      assert_equal 2,  r.exists(["foo", "foo1"])
+      assert_equal 1,  r.exists(["foo", "foo5"])
+      assert_equal nil,  r.exists(["foo7", "foo5"])
     end
 
     def test_type


### PR DESCRIPTION
This is attempt to solve #698.

For single key argument method `#exist` works as usual - it returns true or false.

But when it has multiple key arguments then it works almost like it described in [redis documentation](https://redis.io/commands/exists). Except for 0 value then method returns nil. Consider this tests:

``` ruby
assert_equal false, r.exists("foo")

r.set("foo", "s1")

assert_equal true,  r.exists("foo")

r.set("foo1", "s2")

assert_equal 2,  r.exists(["foo", "foo1"])
assert_equal 1,  r.exists(["foo", "foo5"])
assert_equal nil, r.exists(["foo7", "foo5"])
```

0 to nil conversion added just in case of backward compatibility with exist codebases (nil as false comparison and not nil as true).