### PR TITLE
Enable warnings and move ruby arguments to a variable

### DIFF
--- a/makefile
+++ b/makefile
@@ -7,11 +7,12 @@ BINARY       := ${BUILD_DIR}/src/redis-server
 PID_PATH     := ${BUILD_DIR}/redis.pid
 SOCKET_PATH  := ${BUILD_DIR}/redis.sock
 PORT         := 6381
+RUBYOPT      := -vw
 
 test: ${TEST_FILES}
 	make start
 	env SOCKET_PATH=${SOCKET_PATH} \
-		ruby -v $$(echo $? | tr ' ' '\n' | awk '{ print "-r./" $$0 }') -e ''
+		ruby ${RUBYOPT} $$(echo $? | tr ' ' '\n' | awk '{ print "-r./" $$0 }') -e ''
 	make stop
 
 ${TMP}:


### PR DESCRIPTION
This PR enables warnings passing `-w` to the Ruby interpreter. In addition to this, it moves the arguments to a new variable. This makes it easier to dynamically change the flags from the command line, e.g: `make RUBYOPT=''` runs Ruby with no arguments being passed.

Enabling warnings is useful to uncover common coding mistakes, as the [manpage states](https://linux.die.net/man/1/ruby): 
> -w' Enables verbose mode without printing version message at the beginning. It sets the $VERBOSE variable to true.