### PR TITLE
Update non-distributed `exists` command to accept multiple keys. Fix #698

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -524,13 +524,13 @@ class Redis
     end
   end
 
-  # Determine if a key exists.
+  # Determine if all keys exists.
   #
-  # @param [String] key
+  # @param [String, Array<String>] key
   # @return [Boolean]
-  def exists(key)
+  def exists(*keys)
     synchronize do |client|
-      client.call([:exists, key], &Boolify)
+      client.call([:exists] + keys) == keys.size
     end
   end
 

--- a/test/commands_on_value_types_test.rb
+++ b/test/commands_on_value_types_test.rb
@@ -6,6 +6,17 @@ class TestCommandsOnValueTypes < Test::Unit::TestCase
   include Helper::Client
   include Lint::ValueTypes
 
+  def test_exists
+    assert_equal false, r.exists("foo")
+
+    r.set "foo", "s1"
+    r.set "bar", "s2"
+
+    assert_equal true, r.exists("foo")
+    assert_equal true, r.exists("foo", "bar")
+    assert_equal false, r.exists("foo", "bar", "car")
+  end
+
   def test_del
     r.set "foo", "s1"
     r.set "bar", "s2"


### PR DESCRIPTION
Since Redis 3.0.3 supports EXISTS command may accept multiple keys.