### PR TITLE
Adding exists_count

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -534,6 +534,16 @@ class Redis
     end
   end
 
+  # Count existing keys.
+  #
+  # @param [Array<String>] key
+  # @return [Fixnum]
+  def exists_count(*keys)
+    synchronize do |client|
+      client.call([:exists + keys])
+    end
+  end
+
   # Find all keys matching the given pattern.
   #
   # @param [String] pattern

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -540,7 +540,7 @@ class Redis
   # @return [Fixnum]
   def exists_count(*keys)
     synchronize do |client|
-      client.call([:exists + keys])
+      client.call([:exists] + keys)
     end
   end
 

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -166,6 +166,14 @@ class Redis
       node_for(key).exists(key)
     end
 
+    # Count existing keys.
+    def exists_count(*args)
+      keys_per_node = args.group_by { |key| node_for(key) }
+      keys_per_node.inject(0) do |sum, (node, keys)|
+        sum + node.exists_count(*keys)
+      end
+    end
+
     # Find all keys matching the given pattern.
     def keys(glob = "*")
       on_each_node(:keys, glob).flatten

--- a/test/commands_on_value_types_test.rb
+++ b/test/commands_on_value_types_test.rb
@@ -8,9 +8,9 @@ class TestCommandsOnValueTypes < Test::Unit::TestCase
 
   def test_exists_count
     target_version "3.0.3" do
-      assert_qual false, r.exists("foo")
-      assert_qual false, r.exists("bar")
-      assert_qual false, r.exists("baz")
+      assert_equal false, r.exists("foo")
+      assert_equal false, r.exists("bar")
+      assert_equal false, r.exists("baz")
 
       r.set "foo", "s1"
       r.set "bar", "s2"

--- a/test/commands_on_value_types_test.rb
+++ b/test/commands_on_value_types_test.rb
@@ -8,7 +8,9 @@ class TestCommandsOnValueTypes < Test::Unit::TestCase
 
   def test_exists_count
     target_version "3.0.3" do
-      assert_qual false, r.exists("foo", "bar", "baz")
+      assert_qual false, r.exists("foo")
+      assert_qual false, r.exists("bar")
+      assert_qual false, r.exists("baz")
 
       r.set "foo", "s1"
       r.set "bar", "s2"

--- a/test/commands_on_value_types_test.rb
+++ b/test/commands_on_value_types_test.rb
@@ -6,6 +6,23 @@ class TestCommandsOnValueTypes < Test::Unit::TestCase
   include Helper::Client
   include Lint::ValueTypes
 
+  def test_exists_count
+    target_version "3.0.3" do
+      assert_qual false, r.exists("foo", "bar", "baz")
+
+      r.set "foo", "s1"
+      r.set "bar", "s2"
+
+      assert_equal 1, r.exists_count("foo")
+
+      assert_equal 2, r.exists_count("foo", "bar")
+
+      assert_equal 0, r.exists_count("baz")
+
+      assert_equal 2, r.exists_count("foo", "bar", "baz")
+    end
+  end
+
   def test_del
     r.set "foo", "s1"
     r.set "bar", "s2"

--- a/test/commands_on_value_types_test.rb
+++ b/test/commands_on_value_types_test.rb
@@ -6,25 +6,6 @@ class TestCommandsOnValueTypes < Test::Unit::TestCase
   include Helper::Client
   include Lint::ValueTypes
 
-  def test_exists_count
-    target_version "3.0.3" do
-      assert_equal false, r.exists("foo")
-      assert_equal false, r.exists("bar")
-      assert_equal false, r.exists("baz")
-
-      r.set "foo", "s1"
-      r.set "bar", "s2"
-
-      assert_equal 1, r.exists_count("foo")
-
-      assert_equal 2, r.exists_count("foo", "bar")
-
-      assert_equal 0, r.exists_count("baz")
-
-      assert_equal 2, r.exists_count("foo", "bar", "baz")
-    end
-  end
-
   def test_del
     r.set "foo", "s1"
     r.set "bar", "s2"

--- a/test/lint/value_types.rb
+++ b/test/lint/value_types.rb
@@ -2,6 +2,25 @@ module Lint
 
   module ValueTypes
 
+    def test_exists_count
+      target_version "3.0.3" do
+        assert_equal false, r.exists("foo")
+        assert_equal false, r.exists("bar")
+        assert_equal false, r.exists("baz")
+
+        r.set "foo", "s1"
+        r.set "bar", "s2"
+
+        assert_equal 1, r.exists_count("foo")
+
+        assert_equal 2, r.exists_count("foo", "bar")
+
+        assert_equal 0, r.exists_count("baz")
+
+        assert_equal 2, r.exists_count("foo", "bar", "baz")
+      end
+    end
+
     def test_exists
       assert_equal false, r.exists("foo")
 


### PR DESCRIPTION
Since Redis 3.0.3 it is possible to specify multiple keys for the command `exists` instead of a single one. In such a case, it returns the total number of keys existing

My work is based on issue #698 comments