### PR TITLE
Add Errno::EADDRNOTAVAIL to system call errors

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -341,6 +341,7 @@ class Redis
       @pending_reads = 0
     rescue TimeoutError,
            SocketError,
+           Errno::EADDRNOTAVAIL,
            Errno::ECONNREFUSED,
            Errno::EHOSTDOWN,
            Errno::EHOSTUNREACH,


### PR DESCRIPTION
Rescue low-level exception `Errno::EADDRNOTAVAIL` (Address not available) to have a `CannotConnectError` instead

Cheers