### PR TITLE
Allow to skip SSL verification

### DIFF
--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -267,7 +267,10 @@ class Redis
           ssl_sock = new(tcp_sock, ctx)
           ssl_sock.hostname = host
           ssl_sock.connect
-          ssl_sock.post_connection_check(host)
+
+          unless ctx.verify_mode == OpenSSL::SSL::VERIFY_NONE
+            ssl_sock.post_connection_check(host)
+          end
 
           ssl_sock
         end


### PR DESCRIPTION
This is a redo of #690 and #678. No verification should be done when explicitly asked for it.