### PR TITLE
Optimize empty transactions

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -150,9 +150,12 @@ class Redis
     end
 
     def call_pipeline(pipeline)
+      commands = pipeline.commands
+      return [] if commands.empty?
+
       with_reconnect pipeline.with_reconnect? do
         begin
-          pipeline.finish(call_pipelined(pipeline.commands)).tap do
+          pipeline.finish(call_pipelined(commands)).tap do
             self.db = pipeline.db if pipeline.db
           end
         rescue ConnectionError => e

--- a/lib/redis/pipeline.rb
+++ b/lib/redis/pipeline.rb
@@ -22,6 +22,10 @@ class Redis
       @shutdown
     end
 
+    def empty?
+      @futures.empty?
+    end
+
     def call(command, &block)
       # A pipeline that contains a shutdown should not raise ECONNRESET when
       # the connection is gone.
@@ -86,7 +90,11 @@ class Redis
       end
 
       def commands
-        [[:multi]] + super + [[:exec]]
+        if empty?
+          []
+        else
+          [[:multi]] + super + [[:exec]]
+        end
       end
     end
   end

--- a/test/transactions_test.rb
+++ b/test/transactions_test.rb
@@ -114,6 +114,16 @@ class TestTransactions < Test::Unit::TestCase
     assert_equal "s1", r.get("foo")
   end
 
+  def test_empty_multi_exec
+    result = nil
+
+    redis_mock(:exec => lambda { |*_| "-ERROR" }) do |redis|
+      result = redis.multi {}
+    end
+
+    assert_equal [], result
+  end
+
   def test_raise_command_errors_when_accessing_futures_after_multi_exec
     begin
       r.multi do |m|


### PR DESCRIPTION
A minor optimization - I run a bunch of logic inside a `multi` block that can conditionally execute commands, but if it doesn't, there's no point in spending time sending the empty transaction to Redis.

I realize the test is a bit silly, but I'm not sure offhand how to improve it - happy to take suggestions.

Thanks!