### PR TITLE
Don't coerce Redis command errors

### DIFF
--- a/test/transactions_test.rb
+++ b/test/transactions_test.rb
@@ -102,7 +102,7 @@ class TestTransactions < Test::Unit::TestCase
     assert @info.value.kind_of?(Hash)
   end
 
-  def test_raise_command_errors_in_multi_exec
+  def test_raise_command_errors_when_reply_is_not_transformed
     assert_raise(Redis::CommandError) do
       r.multi do |m|
         m.set("foo", "s1")
@@ -122,6 +122,49 @@ class TestTransactions < Test::Unit::TestCase
     end
 
     assert_equal [], result
+  end
+
+  def test_raise_command_errors_when_reply_is_transformed_from_int_to_boolean
+    assert_raise(Redis::CommandError) do
+      r.multi do |m|
+        m.set("foo", 1)
+        m.sadd("foo", 2)
+      end
+    end
+  end
+
+  def test_raise_command_errors_when_reply_is_transformed_from_ok_to_boolean
+    assert_raise(Redis::CommandError) do
+      r.multi do |m|
+        m.set("foo", 1, ex: 0, nx: true)
+      end
+    end
+  end
+
+  def test_raise_command_errors_when_reply_is_transformed_to_float
+    assert_raise(Redis::CommandError) do
+      r.multi do |m|
+        m.set("foo", 1)
+        m.zscore("foo", "b")
+      end
+    end
+  end
+
+  def test_raise_command_errors_when_reply_is_transformed_to_floats
+    assert_raise(Redis::CommandError) do
+      r.multi do |m|
+        m.zrange("a", "b", 5, :with_scores => true)
+      end
+    end
+  end
+
+  def test_raise_command_errors_when_reply_is_transformed_to_hash
+    assert_raise(Redis::CommandError) do
+      r.multi do |m|
+        m.set("foo", 1)
+        m.hgetall("foo")
+      end
+    end
   end
 
   def test_raise_command_errors_when_accessing_futures_after_multi_exec


### PR DESCRIPTION
This PR addresses the following issues:

1. Commands that are executed in a transaction and use the `Boolify` or `BoolifySet` transformations coerce Redis command errors to false instead of raising an exception:

```ruby
redis.multi do |multi|
  multi.set('foo', 'bar')
  multi.hexists('foo', 'x') # foo is not a hash
end
# Returns ["OK", false]
# insread of raising
#   `Redis::CommandError: WRONGTYPE Operation against a key holding the wrong kind of value'
```

2. Commands that are executed in a transaction and use the `Hashify` and `Floatify` transformations don't handle Redis command errors.

```ruby
redis.multi do |multi|
  multi.set('foo', 'bar')
  multi.hgetall('foo') # foo is not a hash
end
# NoMethodError: undefined method `each_slice' for #<Redis::CommandError:0x00007fbc73d8f1d0>
```

Resolves #602