### PR TITLE
Super splat args for HDEL

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -2102,9 +2102,9 @@ class Redis
   # @param [String] key
   # @param [String, Array<String>] field
   # @return [Fixnum] the number of fields that were removed from the hash
-  def hdel(key, field)
+  def hdel(key, *fields)
     synchronize do |client|
-      client.call([:hdel, key, field])
+      client.call([:hdel, key, *fields])
     end
   end
 

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -692,8 +692,8 @@ class Redis
     end
 
     # Delete one or more hash fields.
-    def hdel(key, field)
-      node_for(key).hdel(key, field)
+    def hdel(key, *fields)
+      node_for(key).hdel(key, *fields)
     end
 
     # Determine if a hash field exists.

--- a/test/lint/hashes.rb
+++ b/test/lint/hashes.rb
@@ -30,6 +30,21 @@ module Lint
       assert_equal nil, r.hget("foo", "f1")
     end
 
+    def test_splat_hdel
+      target_version "2.3.9" do
+        r.hset("foo", "f1", "s1")
+        r.hset("foo", "f2", "s2")
+
+        assert_equal "s1", r.hget("foo", "f1")
+        assert_equal "s2", r.hget("foo", "f2")
+
+        assert_equal 2, r.hdel("foo", "f1", "f2")
+
+        assert_equal nil, r.hget("foo", "f1")
+        assert_equal nil, r.hget("foo", "f2")
+      end
+    end
+
     def test_variadic_hdel
       target_version "2.3.9" do
         r.hset("foo", "f1", "s1")


### PR DESCRIPTION
Fix: https://github.com/redis/redis-rb/issues/626

It already supported passing an array of keys, but splat args are much more consistent with other commands like `del`.