### PR TITLE
Cache redis server compilation on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
-
+cache:
+    directories:
+      - tmp/cache
 before_install:
   - gem update --system 2.6.14
   - gem --version

--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,71 @@
+#!/usr/bin/env ruby
+
+TARBALL = ARGV[0]
+
+require 'digest/sha1'
+require 'fileutils'
+
+class Builder
+  def initialize(redis_branch, tmp_dir)
+    @redis_branch = redis_branch
+    @tmp_dir = tmp_dir
+    @build_dir = File.join(@tmp_dir, "cache", "redis-#{redis_branch}")
+  end
+
+  def run
+    download_tarball
+    if old_checkum != checksum
+      build
+      update_checksum
+    end
+    0
+  end
+
+  def download_tarball
+    command!('wget', tarball_url, '-O', tarball_path)
+  end
+
+  def tarball_path
+    File.join(@tmp_dir, "redis-#{@redis_branch}.tar.gz")
+  end
+
+  def tarball_url
+    "https://github.com/antirez/redis/archive/#{@redis_branch}.tar.gz"
+  end
+
+  def build
+    FileUtils.rm_rf(@build_dir)
+    FileUtils.mkdir_p(@build_dir)
+    command!('tar', 'xf', tarball_path, '-C', File.expand_path('../', @build_dir))
+    Dir.chdir(@build_dir) do
+      command!('make')
+    end
+  end
+
+  def update_checksum
+    File.write(checksum_path, checksum)
+  end
+
+  def old_checkum
+    File.read(checksum_path)
+  rescue Errno::ENOENT
+    nil
+  end
+
+  def checksum_path
+    File.join(@build_dir, 'build.checksum')
+  end
+
+  def checksum
+    @checksum ||= Digest::SHA1.file(tarball_path).hexdigest
+  end
+
+  def command!(*args)
+    puts "$ #{args.join(' ')}"
+    unless system(*args)
+      raise "Command failed with status #{$?.exitstatus}"
+    end
+  end
+end
+
+exit Builder.new(ARGV[0], ARGV[1]).run

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 TEST_FILES   := $(shell find test -name *_test.rb -type f)
 REDIS_BRANCH := unstable
 TMP          := tmp
-BUILD_DIR    := ${TMP}/redis-${REDIS_BRANCH}
+BUILD_DIR    := ${TMP}/cache/redis-${REDIS_BRANCH}
 TARBALL      := ${TMP}/redis-${REDIS_BRANCH}.tar.gz
 BINARY       := ${BUILD_DIR}/src/redis-server
 PID_PATH     := ${BUILD_DIR}/redis.pid
@@ -17,19 +17,14 @@ test: ${TEST_FILES}
 ${TMP}:
 	mkdir $@
 
-${TARBALL}: ${TMP}
-	wget https://github.com/antirez/redis/archive/${REDIS_BRANCH}.tar.gz -O $@
-
-${BINARY}: ${TARBALL} ${TMP}
-	rm -rf ${BUILD_DIR}
-	mkdir -p ${BUILD_DIR}
-	tar xf ${TARBALL} -C ${TMP}
-	cd ${BUILD_DIR} && make
+${BINARY}: ${TMP}
+	bin/build ${REDIS_BRANCH} ${TMP}
 
 stop:
 	(test -f ${PID_PATH} && (kill $$(cat ${PID_PATH}) || true) && rm -f ${PID_PATH}) || true
 
 start: ${BINARY}
+	echo ${BINARY}
 	${BINARY}                     \
 		--daemonize  yes            \
 		--pidfile    ${PID_PATH}    \


### PR DESCRIPTION
Fix: https://github.com/redis/redis-rb/issues/610

Or at least most of it.

My Makefile foo isn't great, but from what I've seen it's not easy at all to do checksum based caching with it. So instead I moved the build script to a simple ruby script, and do the conditional build there.

Ultimately there is not much left in the makefile, so this PR is a bit questionable, but let's see if it works first.

The cache should be scoped by branch & by job (each combination of the matrix has it's own cache). The cache should invalidated everytime a Redis server release change.I don't know how often it happens for `unstable`, but for others it should be fairly rare.
