### PR TITLE
Stop testing Rubinius

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ rvm:
   - 2.4.1
   - 2.5.0
   - jruby-9.1.15.0
-  - rbx-3
 
 gemfile: ".travis/Gemfile"
 
@@ -69,8 +68,6 @@ matrix:
     - rvm: jruby-9.1.15.0
       gemfile: .travis/Gemfile
       env: DRIVER=synchrony REDIS_BRANCH=3.2
-  allow_failures:
-    - rvm: rbx-3
 
 notifications:
   irc:


### PR DESCRIPTION
Ref: https://github.com/redis/redis-rb/issues/610

I checked in the git history, and they have been in the allowed failure section since forever, I can't find a single build where they pass.

They also take about 7 times 15 minutes (not even sure how) per builds. So the Redis org is then starved out of Travis jobs for a long time.

I'd be happy to re-introduce them if we find a way to make them fast, but for now they are simply making development on this repo a slog.