### PR TITLE
Fix testing of redis branches

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 TEST_FILES   := $(shell find test -name *_test.rb -type f)
-REDIS_BRANCH := unstable
+REDIS_BRANCH ?= unstable
 TMP          := tmp
 BUILD_DIR    := ${TMP}/cache/redis-${REDIS_BRANCH}
 TARBALL      := ${TMP}/redis-${REDIS_BRANCH}.tar.gz
@@ -24,7 +24,6 @@ stop:
 	(test -f ${PID_PATH} && (kill $$(cat ${PID_PATH}) || true) && rm -f ${PID_PATH}) || true
 
 start: ${BINARY}
-	echo ${BINARY}
 	${BINARY}                     \
 		--daemonize  yes            \
 		--pidfile    ${PID_PATH}    \

--- a/test/commands_on_geo_test.rb
+++ b/test/commands_on_geo_test.rb
@@ -6,85 +6,111 @@ class TestCommandsGeo < Test::Unit::TestCase
   def setup
     super
 
-    added_items_count = r.geoadd("Sicily", 13.361389, 38.115556, "Palermo", 15.087269, 37.502669, "Catania")
-    assert_equal 2, added_items_count
+    target_version "3.2.0" do
+      added_items_count = r.geoadd("Sicily", 13.361389, 38.115556, "Palermo", 15.087269, 37.502669, "Catania")
+      assert_equal 2, added_items_count
+    end
   end
 
   def test_georadius_with_sort
-    nearest_cities = r.georadius("Sicily", 15, 37, 200, 'km', sort: 'asc')
-    assert_equal %w(Catania Palermo), nearest_cities
+    target_version "3.2.0" do
+      nearest_cities = r.georadius("Sicily", 15, 37, 200, 'km', sort: 'asc')
+      assert_equal %w(Catania Palermo), nearest_cities
 
-    farthest_cities = r.georadius("Sicily", 15, 37, 200, 'km', sort: 'desc')
-    assert_equal %w(Palermo Catania), farthest_cities
+      farthest_cities = r.georadius("Sicily", 15, 37, 200, 'km', sort: 'desc')
+      assert_equal %w(Palermo Catania), farthest_cities
+    end
   end
 
   def test_georadius_with_count
-    city = r.georadius("Sicily", 15, 37, 200, 'km', count: 1)
-    assert_equal %w(Catania), city
+    target_version "3.2.0" do
+      city = r.georadius("Sicily", 15, 37, 200, 'km', count: 1)
+      assert_equal %w(Catania), city
+    end
   end
 
   def test_georadius_with_options_count_sort
-    city = r.georadius("Sicily", 15, 37, 200, 'km', sort: :desc, options: :WITHDIST, count: 1)
-    assert_equal [["Palermo", "190.4424"]], city
+    target_version "3.2.0" do
+      city = r.georadius("Sicily", 15, 37, 200, 'km', sort: :desc, options: :WITHDIST, count: 1)
+      assert_equal [["Palermo", "190.4424"]], city
+    end
   end
 
   def test_georadiusbymember_with_sort
-    nearest_cities = r.georadiusbymember("Sicily", "Catania", 200, 'km', sort: 'asc')
-    assert_equal %w(Catania Palermo), nearest_cities
+    target_version "3.2.0" do
+      nearest_cities = r.georadiusbymember("Sicily", "Catania", 200, 'km', sort: 'asc')
+      assert_equal %w(Catania Palermo), nearest_cities
 
-    farthest_cities = r.georadiusbymember("Sicily", "Catania", 200, 'km', sort: 'desc')
-    assert_equal %w(Palermo Catania), farthest_cities
+      farthest_cities = r.georadiusbymember("Sicily", "Catania", 200, 'km', sort: 'desc')
+      assert_equal %w(Palermo Catania), farthest_cities
+    end
   end
 
   def test_georadiusbymember_with_count
-    city = r.georadiusbymember("Sicily", "Catania", 200, 'km', count: 1)
-    assert_equal %w(Catania), city
+    target_version "3.2.0" do
+      city = r.georadiusbymember("Sicily", "Catania", 200, 'km', count: 1)
+      assert_equal %w(Catania), city
+    end
   end
 
   def test_georadiusbymember_with_options_count_sort
-    city = r.georadiusbymember("Sicily", "Catania", 200, 'km', sort: :desc, options: :WITHDIST, count: 1)
-    assert_equal [["Palermo", "166.2742"]], city
+    target_version "3.2.0" do
+      city = r.georadiusbymember("Sicily", "Catania", 200, 'km', sort: :desc, options: :WITHDIST, count: 1)
+      assert_equal [["Palermo", "166.2742"]], city
+    end
   end
 
   def test_geopos
-    location = r.geopos("Sicily", "Catania")
-    assert_equal [["15.08726745843887329", "37.50266842333162032"]], location
+    target_version "3.2.0" do
+      location = r.geopos("Sicily", "Catania")
+      assert_equal [["15.08726745843887329", "37.50266842333162032"]], location
 
-    locations = r.geopos("Sicily", ["Palermo", "Catania"])
-    assert_equal [["13.36138933897018433", "38.11555639549629859"], ["15.08726745843887329", "37.50266842333162032"]], locations
+      locations = r.geopos("Sicily", ["Palermo", "Catania"])
+      assert_equal [["13.36138933897018433", "38.11555639549629859"], ["15.08726745843887329", "37.50266842333162032"]], locations
+    end
   end
 
   def test_geopos_nonexistant_location
-    location = r.geopos("Sicily", "Rome")
-    assert_equal [nil], location
+    target_version "3.2.0" do
+      location = r.geopos("Sicily", "Rome")
+      assert_equal [nil], location
 
-    locations = r.geopos("Sicily", ["Rome", "Catania"])
-    assert_equal [nil, ["15.08726745843887329", "37.50266842333162032"]], locations
+      locations = r.geopos("Sicily", ["Rome", "Catania"])
+      assert_equal [nil, ["15.08726745843887329", "37.50266842333162032"]], locations
+    end
   end
 
   def test_geodist
-    distination_in_meters = r.geodist("Sicily", "Palermo", "Catania")
-    assert_equal "166274.1516", distination_in_meters
+    target_version "3.2.0" do
+      distination_in_meters = r.geodist("Sicily", "Palermo", "Catania")
+      assert_equal "166274.1516", distination_in_meters
 
-    distination_in_feet = r.geodist("Sicily", "Palermo", "Catania", 'ft')
-    assert_equal "545518.8700", distination_in_feet
+      distination_in_feet = r.geodist("Sicily", "Palermo", "Catania", 'ft')
+      assert_equal "545518.8700", distination_in_feet
+    end
   end
 
   def test_geodist_with_nonexistant_location
-    distination = r.geodist("Sicily", "Palermo", "Rome")
-    assert_equal nil, distination
+    target_version "3.2.0" do
+      distination = r.geodist("Sicily", "Palermo", "Rome")
+      assert_equal nil, distination
+    end
   end
 
   def test_geohash
-    geohash = r.geohash("Sicily", "Palermo")
-    assert_equal ["sqc8b49rny0"], geohash
+    target_version "3.2.0" do
+      geohash = r.geohash("Sicily", "Palermo")
+      assert_equal ["sqc8b49rny0"], geohash
 
-    geohashes = r.geohash("Sicily", ["Palermo", "Catania"])
-    assert_equal %w(sqc8b49rny0 sqdtr74hyu0), geohashes
+      geohashes = r.geohash("Sicily", ["Palermo", "Catania"])
+      assert_equal %w(sqc8b49rny0 sqdtr74hyu0), geohashes
+    end
   end
 
   def test_geohash_with_nonexistant_location
-    geohashes = r.geohash("Sicily", ["Palermo", "Rome"])
-    assert_equal ["sqc8b49rny0", nil], geohashes
+    target_version "3.2.0" do
+      geohashes = r.geohash("Sicily", ["Palermo", "Rome"])
+      assert_equal ["sqc8b49rny0", nil], geohashes
+    end
   end
 end


### PR DESCRIPTION
While trying to figure out further optimizations, I noticed that jobs with `REDIS_BRANCH=3.0` were actually building `unstable`.

I though I broke it in #757, but actually looking at older builds the issue was already here, e.g.: https://travis-ci.org/redis/redis-rb/jobs/280892409

```bash
export REDIS_BRANCH=3.0
#....
wget https://github.com/antirez/redis/archive/unstable.tar.gz -O tmp/redis-unstable.tar.gz
```

Again my makefile foo isn't great, but this change seem to work.