### PR TITLE
Fix failing jruby tests, change default REDIS_BRANCH to 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
     - DRIVER=hiredis   REDIS_BRANCH=3.2
     - DRIVER=synchrony REDIS_BRANCH=3.0
     - DRIVER=synchrony REDIS_BRANCH=3.2
-    - DRIVER=ruby      REDIS_BRANCH=unstable
+    - DRIVER=ruby      REDIS_BRANCH=4.0
 
 branches:
   only:
@@ -45,18 +45,14 @@ matrix:
   exclude:
     # hiredis
     - rvm: jruby-9.1.17.0
-      gemfile: .travis/Gemfile
       env: DRIVER=hiredis   REDIS_BRANCH=3.0
     - rvm: jruby-9.1.17.0
-      gemfile: .travis/Gemfile
       env: DRIVER=hiredis   REDIS_BRANCH=3.2
 
     # synchrony
     - rvm: jruby-9.1.17.0
-      gemfile: .travis/Gemfile
       env: DRIVER=synchrony REDIS_BRANCH=3.0
     - rvm: jruby-9.1.17.0
-      gemfile: .travis/Gemfile
       env: DRIVER=synchrony REDIS_BRANCH=3.2
 
 notifications:

--- a/.travis/Gemfile
+++ b/.travis/Gemfile
@@ -2,6 +2,11 @@ source "https://rubygems.org"
 
 gemspec :path => "../"
 
+# Using jruby-openssl 0.10.0, we get NPEs in jruby tests: https://github.com/redis/redis-rb/issues/756
+platform :jruby do
+  gem 'jruby-openssl', '<0.10.0'
+end
+
 case ENV["DRIVER"]
 when "hiredis"
   gem "hiredis"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,8 @@
 source 'https://rubygems.org'
 
 gemspec
+
+# Using jruby-openssl 0.10.0, we get NPEs in jruby tests: https://github.com/redis/redis-rb/issues/756
+platform :jruby do
+  gem 'jruby-openssl', '<0.10.0'
+end

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-TEST_FILES   := $(shell find test -name *_test.rb -type f)
+TEST_FILES   := $(shell find ./test -name *_test.rb -type f)
 REDIS_BRANCH ?= unstable
 TMP          := tmp
 BUILD_DIR    := ${TMP}/cache/redis-${REDIS_BRANCH}
@@ -11,7 +11,7 @@ PORT         := 6381
 test: ${TEST_FILES}
 	make start
 	env SOCKET_PATH=${SOCKET_PATH} \
-		ruby -v $$(echo $? | tr ' ' '\n' | awk '{ print "-r./" $$0 }') -e ''
+		bundle exec ruby -v -e 'ARGV.each { |test_file| require test_file }' ${TEST_FILES}
 	make stop
 
 ${TMP}:

--- a/test/support/redis_mock.rb
+++ b/test/support/redis_mock.rb
@@ -42,7 +42,7 @@ module RedisMock
           end
         end
       rescue => ex
-        $stderr.puts "Error running mock server: #{ex.message}"
+        $stderr.puts "Error running mock server: #{ex.class}: #{ex.message}"
         $stderr.puts ex.backtrace
         retry
       ensure


### PR DESCRIPTION
Fix: https://github.com/redis/redis-rb/issues/756

~~jruby tests fail when using jruby_openssl 0.10.0 but not when using 0.9.21
This change adds 0.9.21 to the travis build matrix and sets 0.10.0 as an allowed failure.~~

~~This change also switches the default REDIS_BRANCH to stable since
the unstable branch of redis isn't always in a buildable state.~~

This change adds a Gemfile dependency for jruby_openssl <0.10.0

This change also switches the default REDIS_BRANCH to 4.0 since
the unstable branch of redis isn't always in a buildable state.

Also adds minor tweaks to how the tests are run due to minor issues with Gemfile / bundle usage.