### PR TITLE
Fix client ID scheme

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -107,7 +107,7 @@ class Redis
     end
 
     def id
-      @options[:id] || "redis://#{location}/#{db}"
+      @options[:id] || "#{@options[:path] ? 'redis' : scheme}://#{location}/#{db}"
     end
 
     def location

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -22,8 +22,8 @@ class TestConnection < Test::Unit::TestCase
   end
 
   def test_default_id_with_host_and_port_and_explicit_scheme
-    redis = Redis.new(OPTIONS.merge(:host => "host", :port => "1234", :db => 0, :scheme => "foo"))
-    assert_equal "redis://host:1234/0", redis.connection.fetch(:id)
+    redis = Redis.new(OPTIONS.merge(:host => "host", :port => "1234", :db => 0, :scheme => "rediss"))
+    assert_equal "rediss://host:1234/0", redis.connection.fetch(:id)
   end
 
   def test_default_id_with_path


### PR DESCRIPTION
This fix `Redis::Client#id` to display the scheme being used correctly. It used to show **redis** scheme regardless of any other scheme we use (rediss, unix...)