### PR TITLE
Increase timeout seconds for the CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
 env:
   global:
     - VERBOSE=true
-    - TIMEOUT=9
+    - TIMEOUT=30
   matrix:
     - DRIVER=ruby      REDIS_BRANCH=3.0
     - DRIVER=ruby      REDIS_BRANCH=3.2


### PR DESCRIPTION
https://travis-ci.org/redis/redis-rb/jobs/423903215

I apologize for several timeout errors. It seems Redis 3.0 Cluster often needs long timeout seconds.
