### PR TITLE
Add timeout option value to test support helper for cluster

### DIFF
--- a/test/support/cluster/orchestrator.rb
+++ b/test/support/cluster/orchestrator.rb
@@ -7,7 +7,8 @@ class ClusterOrchestrator
 
   def initialize(node_addrs)
     raise 'Redis Cluster requires at least 3 master nodes.' if node_addrs.size < 3
-    @clients = node_addrs.map { |addr| Redis.new(url: addr) }
+    timeout_sec = Float(ENV['TIMEOUT'] || 30.0)
+    @clients = node_addrs.map { |addr| Redis.new(url: addr, timeout: timeout_sec) }
   end
 
   def rebuild


### PR DESCRIPTION
Thank you for merging of the #780. After that, I've exactly understood the stack trace of timeout error. I apologize for splitting the PR.

https://travis-ci.org/redis/redis-rb/jobs/423903215

```
/home/travis/build/redis/redis-rb/test/cluster_client_slots_test.rb:90:in `test_redirection_when_slot_is_resharding'
/home/travis/build/redis/redis-rb/test/helper.rb:324:in `redis_cluster_resharding'
/home/travis/build/redis/redis-rb/test/support/cluster/orchestrator.rb:61:in `close'
/home/travis/build/redis/redis-rb/test/support/cluster/orchestrator.rb:61:in `each'
/home/travis/build/redis/redis-rb/lib/redis.rb:164:in `quit'
```

The default value is `5.0` seconds.
https://github.com/redis/redis-rb/blob/master/lib/redis/client.rb#L14