### PR TITLE
Handle integer like objects as timeout of blpop and brpop

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -1162,9 +1162,9 @@ class Redis
     case args.last
     when Hash
       options = args.pop
-    when Integer
+    when args.last.respond_to?(:to_int)
       # Issue deprecation notice in obnoxious mode...
-      options[:timeout] = args.pop
+      options[:timeout] = args.pop.to_int
     end
 
     if args.size > 1

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -1159,10 +1159,9 @@ class Redis
   def _bpop(cmd, args, &blk)
     options = {}
 
-    case args.last
-    when Hash
+    if args.last.is_a?(Hash)
       options = args.pop
-    when args.last.respond_to?(:to_int)
+    elsif args.last.respond_to?(:to_int)
       # Issue deprecation notice in obnoxious mode...
       options[:timeout] = args.pop.to_int
     end

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -406,9 +406,9 @@ class Redis
       case args.last
       when Hash
         options = args.pop
-      when Integer
+      when args.last.respond_to?(:to_int)
         # Issue deprecation notice in obnoxious mode...
-        options[:timeout] = args.pop
+        options[:timeout] = args.pop.to_int
       end
 
       if args.size > 1

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -403,10 +403,9 @@ class Redis
     def _bpop(cmd, args)
       options = {}
 
-      case args.last
-      when Hash
+      if args.last.is_a?(Hash)
         options = args.pop
-      when args.last.respond_to?(:to_int)
+      elsif args.last.respond_to?(:to_int)
         # Issue deprecation notice in obnoxious mode...
         options[:timeout] = args.pop.to_int
       end

--- a/test/lint/blocking_commands.rb
+++ b/test/lint/blocking_commands.rb
@@ -79,7 +79,7 @@ module Lint
 
     def test_blpop_integer_like_timeout
       mock do |r|
-        assert_equal ["{zap}foo", "0"], r.blpop("{zap}foo", FakeDuration.new(1))
+        assert_equal ["{zap}foo", "1"], r.blpop("{zap}foo", FakeDuration.new(1))
       end
     end
 

--- a/test/lint/blocking_commands.rb
+++ b/test/lint/blocking_commands.rb
@@ -67,6 +67,22 @@ module Lint
       end
     end
 
+    class FakeDuration
+      def initialize(int)
+        @int = int
+      end
+
+      def to_int
+        @int
+      end
+    end
+
+    def test_blpop_integer_like_timeout
+      mock do |r|
+        assert_equal ["{zap}foo", "0"], r.blpop("{zap}foo", FakeDuration.new(1))
+      end
+    end
+
     def test_blpop_with_old_prototype
       assert_equal ['{zap}foo', 's1'], r.blpop('{zap}foo', 0)
       assert_equal ['{zap}foo', 's2'], r.blpop('{zap}foo', 0)


### PR DESCRIPTION
Fix: https://github.com/redis/redis-rb/issues/782

