### PR TITLE
Fix raising command error for first command in pipeline

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -2936,12 +2936,8 @@ private
 
   FloatifyPairs =
     lambda { |result|
-      if result.respond_to?(:each_slice)
-        result.each_slice(2).map do |member, score|
-          [member, Floatify.call(score)]
-        end
-      else
-        result
+      result.each_slice(2).map do |member, score|
+        [member, Floatify.call(score)]
       end
     }
 

--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -191,13 +191,10 @@ class Redis
         exception = nil
 
         process(commands) do
-          result[0] = read
-
-          @reconnect = false
-
-          (commands.size - 1).times do |i|
+          commands.size.times do |i|
             reply = read
-            result[i + 1] = reply
+            result[i] = reply
+            @reconnect = false
             exception = reply if exception.nil? && reply.is_a?(CommandError)
           end
         end


### PR DESCRIPTION
## Problem

When the first command in a redis pipeline has invalid arguments, then the Redis::CommandError object is passed to the transform block which can cause the exception to be transformed and ignored.  For example,

```ruby
set_result, * = redis.pipelined do
  redis.set('mykey', 0, nx: true, px: 900.0) # px value is invalid if a float is given
end
puts set_result.inspect # => false
```

This problem was mentioned before for zrange in https://github.com/redis/redis-rb/pull/733 but the fix was specific to the FloatifyPairs transform block so didn't also fix the problem for the `set` command that uses `BoolifySet` for the transform block when using the `nx: true` option.

## Solution

Remove the special case in Redis::Client#call_pipelined to `read` the first command reply which was there only to set `@reconnect = false`, since it is fine to call that in the loop after each call to `read`.

I've removed the workaround that https://github.com/redis/redis-rb/pull/733 added for this problem which isn't needed now that the exception gets raised before the transform block gets called.  That way we can also rely on the test in that PR to make sure this works for any transform block.