### PR TITLE
Fix resharding test helper method for cluster mode and enhance migrate command method

### DIFF
--- a/test/commands_on_value_types_test.rb
+++ b/test/commands_on_value_types_test.rb
@@ -202,6 +202,21 @@ class TestCommandsOnValueTypes < Test::Unit::TestCase
       actual = redis.migrate("foo", options.merge(:timeout => default_timeout + 1))
       expected = ["127.0.0.1", "1234", "foo", default_db.to_s, (default_timeout + 1).to_s]
       assert_equal expected, actual
+
+      # Test copy override
+      actual = redis.migrate('foo', options.merge(copy: true))
+      expected = ['127.0.0.1', '1234', 'foo', default_db.to_s, default_timeout.to_s, 'COPY']
+      assert_equal expected, actual
+
+      # Test replace override
+      actual = redis.migrate('foo', options.merge(replace: true))
+      expected = ['127.0.0.1', '1234', 'foo', default_db.to_s, default_timeout.to_s, 'REPLACE']
+      assert_equal expected, actual
+
+      # Test multiple keys
+      actual = redis.migrate(%w[foo bar baz], options)
+      expected = ['127.0.0.1', '1234', '', default_db.to_s, default_timeout.to_s, 'KEYS', 'foo', 'bar', 'baz']
+      assert_equal expected, actual
     end
   end
 end


### PR DESCRIPTION
I apologize for the [CI failure](https://travis-ci.org/redis/redis-rb/jobs/443189621). It's a resharding related error. It  seems to occur with low frequency even if the timeout is 30 seconds, so I added retry code.

```
/home/travis/build/redis/redis-rb/test/helper.rb:34:in `run'
     87:   def test_redirection_when_slot_is_resharding
     88:     100.times { |i| redis.set("{key}#{i}", i) }
     89: 
  => 90:     redis_cluster_resharding(12539, src: '127.0.0.1:7002', dest: '127.0.0.1:7000') do
     91:       100.times { |i| assert_equal i.to_s, redis.get("{key}#{i}") }
     92:     end
     93:   end
/home/travis/build/redis/redis-rb/test/cluster_client_slots_test.rb:90:in `test_redirection_when_slot_is_resharding'
/home/travis/build/redis/redis-rb/test/helper.rb:319:in `redis_cluster_resharding'
/home/travis/build/redis/redis-rb/test/support/cluster/orchestrator.rb:48:in `start_resharding'
/home/travis/build/redis/redis-rb/test/support/cluster/orchestrator.rb:48:in `loop'
/home/travis/build/redis/redis-rb/test/support/cluster/orchestrator.rb:51:in `block in start_resharding'
/home/travis/build/redis/redis-rb/test/support/cluster/orchestrator.rb:51:in `each'
/home/travis/build/redis/redis-rb/test/support/cluster/orchestrator.rb:51:in `block (2 levels) in start_resharding'
/home/travis/build/redis/redis-rb/lib/redis.rb:515:in `migrate'
/home/travis/build/redis/redis-rb/lib/redis.rb:50:in `synchronize'
/home/travis/.rvm/rubies/ruby-2.5.0/lib/ruby/2.5.0/monitor.rb:226:in `mon_synchronize'
/home/travis/build/redis/redis-rb/lib/redis.rb:50:in `block in synchronize'
/home/travis/build/redis/redis-rb/lib/redis.rb:516:in `block in migrate'
/home/travis/build/redis/redis-rb/lib/redis/client.rb:124:in `call'
Error: test_redirection_when_slot_is_resharding(TestClusterClientSlots): Redis::CommandError: IOERR error or timeout reading to target instance
```

[MIGRATE command reference](https://redis.io/commands/migrate)

> [MIGRATE](https://redis.io/commands/migrate) needs to perform I/O operations and to honor the specified timeout.
> When there is an I/O error during the transfer or if the timeout is reached the operation is aborted and the special error - IOERR returned.
> When this happens the following two cases are possible:
> 
> * The key may be on both the instances.
> * The key may be only in the source instance.
> 
> It is not possible for the key to get lost in the event of a timeout, but the client calling MIGRATE, in the event of a timeout error, should check if the key is also present in the target instance and act accordingly.