### PR TITLE
Fix several test cases that occasionally fail on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
   global:
     - VERBOSE=true
     - TIMEOUT=30
+    - LOW_TIMEOUT=0.01
   matrix:
     - DRIVER=ruby      REDIS_BRANCH=3.0
     - DRIVER=ruby      REDIS_BRANCH=3.2
@@ -43,17 +44,14 @@ branches:
 
 matrix:
   exclude:
-    # hiredis
     - rvm: jruby-9.1.17.0
-      env: DRIVER=hiredis   REDIS_BRANCH=3.0
+  include:
     - rvm: jruby-9.1.17.0
-      env: DRIVER=hiredis   REDIS_BRANCH=3.2
-
-    # synchrony
+      env: DRIVER=ruby REDIS_BRANCH=3.0 LOW_TIMEOUT=0.1
     - rvm: jruby-9.1.17.0
-      env: DRIVER=synchrony REDIS_BRANCH=3.0
+      env: DRIVER=ruby REDIS_BRANCH=3.2 LOW_TIMEOUT=0.1
     - rvm: jruby-9.1.17.0
-      env: DRIVER=synchrony REDIS_BRANCH=3.2
+      env: DRIVER=ruby REDIS_BRANCH=4.0 LOW_TIMEOUT=0.1
 
 notifications:
   irc:

--- a/test/cluster_client_options_test.rb
+++ b/test/cluster_client_options_test.rb
@@ -38,8 +38,7 @@ class TestClusterClientOptions < Test::Unit::TestCase
 
   def test_client_accepts_valid_options
     assert_nothing_raised do
-      timeout = Float(ENV['TIMEOUT'] || 1.0)
-      build_another_client(timeout: timeout)
+      build_another_client(timeout: TIMEOUT)
     end
   end
 

--- a/test/cluster_client_options_test.rb
+++ b/test/cluster_client_options_test.rb
@@ -38,7 +38,8 @@ class TestClusterClientOptions < Test::Unit::TestCase
 
   def test_client_accepts_valid_options
     assert_nothing_raised do
-      build_another_client(timeout: 1.0)
+      timeout = Float(ENV['TIMEOUT'] || 1.0)
+      build_another_client(timeout: timeout)
     end
   end
 

--- a/test/cluster_client_transactions_test.rb
+++ b/test/cluster_client_transactions_test.rb
@@ -40,7 +40,7 @@ class TestClusterClientTransactions < Test::Unit::TestCase
       100.times { |i| cli.set("{key}#{i}", i) }
     end
 
-    sleep 0.1
+    sleep 0.5
 
     100.times { |i| assert_equal i.to_s, rc1.get("{key}#{i}") }
     100.times { |i| assert_equal i.to_s, rc2.get("{key}#{i}") }

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -15,9 +15,11 @@ require_relative "support/redis_mock"
 require_relative "support/connection/#{ENV["DRIVER"]}"
 require_relative 'support/cluster/orchestrator'
 
-PORT    = 6381
-OPTIONS = {:port => PORT, :db => 15, :timeout => Float(ENV["TIMEOUT"] || 0.1)}
-NODES   = ["redis://127.0.0.1:#{PORT}/15"]
+PORT        = 6381
+DB          = 15
+TIMEOUT     = Float(ENV['TIMEOUT'] || 0.1)
+LOW_TIMEOUT = Float(ENV['LOW_TIMEOUT'] || 0.01) # for blocking-command tests
+OPTIONS     = { port: PORT, db: DB, timeout: TIMEOUT }.freeze
 
 def driver(*drivers, &blk)
   if drivers.map(&:to_s).include?(ENV["DRIVER"])
@@ -178,8 +180,9 @@ module Helper
   end
 
   module Distributed
-
     include Generic
+
+    NODES = ["redis://127.0.0.1:#{PORT}/15"].freeze
 
     def version
       Version.new(redis.info.first["redis_version"])

--- a/test/lint/blocking_commands.rb
+++ b/test/lint/blocking_commands.rb
@@ -1,7 +1,5 @@
 module Lint
   module BlockingCommands
-    LOW_TIMEOUT = 0.01
-
     def setup
       super
 


### PR DESCRIPTION
I apologize for the following unstable test cases. 

https://travis-ci.org/redis/redis-rb/jobs/454884508

> Redis::CommandError: CLUSTERDOWN The cluster is down

It is occur after cluster rebuilding or failover. I have fixed them as to use surely waiting logic instead of unstable sleeping.

https://travis-ci.org/redis/redis-rb/jobs/455346049

> Redis::TimeoutError(Connection timed out)

I have fixed it as to use environment variable instead of hard-coded value.

https://travis-ci.org/redis/redis-rb/jobs/455358667

```
/home/travis/build/redis/redis-rb/test/cluster_client_transactions_test.rb:45:in `times'
     42: 
     43:     sleep 0.1
     44: 
  => 45:     100.times { |i| assert_equal i.to_s, rc1.get("{key}#{i}") }
     46:     100.times { |i| assert_equal i.to_s, rc2.get("{key}#{i}") }
     47:   end
     48: 

<"0"> expected but was <nil>
```
I have fixed it as to increase sleep seconds for replication delay.

https://travis-ci.org/redis/redis-rb/jobs/455378487

> test_blpop_disable_client_timeout(TestBlockingCommands): Redis::TimeoutError: Connection timed out

https://github.com/redis/redis-rb/pull/795 was merged. Then the timeout error occasionally occur on JRuby. Therefore, I have fixed it as to increase timeout seconds from `0.01` to `0.1` only JRuby matrix test.

### Build Jobs Errors

| build | error | Ruby | Redis | frequency | status |
| --- | --- | --- | --- | --- | --- |
| https://travis-ci.org/redis/redis-rb/jobs/455364568 | Cluster Down | 2.2 | 3.0 | low | fixed |
| https://travis-ci.org/redis/redis-rb/jobs/455378465 | Cluster Down | 2.2 | 3.0 | low | fixed |
| https://travis-ci.org/redis/redis-rb/jobs/455378487 | Timeout | JRuby | 4.0 | high | fixed |
| https://travis-ci.org/redis/redis-rb/jobs/455401867 | `-IOERR` | 2.4 | 4.0 | low | https://github.com/redis/redis-rb/pull/789 |
| https://travis-ci.org/redis/redis-rb/jobs/455413570 | Timeout | JRuby | 4.0 | high | fixed |
| https://travis-ci.org/redis/redis-rb/jobs/455430947 | Timeout | JRuby | 3.0 | high | fixed |
| https://travis-ci.org/redis/redis-rb/jobs/455430973 | Timeout | JRuby | 4.0 | high | fixed |
| https://travis-ci.org/redis/redis-rb/jobs/455448991 | Timeout | JRuby | 3.0 | high | fixed |
| https://travis-ci.org/redis/redis-rb/jobs/455461124 | Timeout | JRuby | 3.0 | high | fixed |
| https://travis-ci.org/redis/redis-rb/jobs/455461126 | `-IOERR` | 2.3 | 3.2 | low | https://github.com/redis/redis-rb/pull/789 |
| https://travis-ci.org/redis/redis-rb/jobs/455472694 | `-IOERR` | JRuby | 4.0 | low | https://github.com/redis/redis-rb/pull/789 |
| https://travis-ci.org/redis/redis-rb/jobs/455485405 | Cluster Down | 2.5 | 3.2 | low | fixed |
| https://travis-ci.org/redis/redis-rb/jobs/455485417 | `-IOERR` | 2.5 | 4.0 | low | https://github.com/redis/redis-rb/pull/789 |