### PR TITLE
Fix slow test cases and resolve #801

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -277,12 +277,15 @@ class Redis
 
     def with_socket_timeout(timeout)
       connect unless connected?
+      original = @options[:read_timeout]
 
       begin
         connection.timeout = timeout
+        @options[:read_timeout] = timeout # for reconnection
         yield
       ensure
         connection.timeout = self.timeout if connected?
+        @options[:read_timeout] = original
       end
     end
 

--- a/test/publish_subscribe_test.rb
+++ b/test/publish_subscribe_test.rb
@@ -254,7 +254,7 @@ class TestPublishSubscribe < Test::Unit::TestCase
     received = false
 
     assert_raise Redis::TimeoutError do
-      r.subscribe_with_timeout(1, "foo")  do |on|
+      r.subscribe_with_timeout(LOW_TIMEOUT, "foo")  do |on|
         on.message do |channel, message|
           received = true
         end
@@ -268,7 +268,7 @@ class TestPublishSubscribe < Test::Unit::TestCase
     received = false
 
     assert_raise Redis::TimeoutError do
-      r.psubscribe_with_timeout(1, "f*")  do |on|
+      r.psubscribe_with_timeout(LOW_TIMEOUT, "f*")  do |on|
         on.message do |channel, message|
           received = true
         end


### PR DESCRIPTION
#801 

| before | after |
| --- | --- |
| `62.0` | `0.07` |

```
$ TIMEOUT=30 bundle exec ruby -w -Itest test/publish_subscribe_test.rb -v -n '/\Atest_p?subscribe_with_timeout\z/'
Loaded suite test/publish_subscribe_test
Started
TestPublishSubscribe: 
  test_psubscribe_with_timeout: .: (0.034897)                                                                                                                                                                   
  test_subscribe_with_timeout:  .: (0.036232)                                                                                                                                                                           

Finished in 0.071604136 seconds.
---------------------------------------------------------------------------------------
2 tests, 4 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
---------------------------------------------------------------------------------------
27.93 tests/s, 55.86 assertions/s
```