### PR TITLE
Add a benchmark file of cluster mode

### DIFF
--- a/benchmarking/cluster.rb
+++ b/benchmarking/cluster.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+# Execute the following commands before execution
+#
+# `$ make start`
+# `$ make start_cluster`
+# `$ make create_cluster`
+
+require 'redis'
+require 'benchmark'
+
+HOST            = '127.0.0.1'
+STANDALONE_PORT = 6381
+CLUSTER_PORT    = 7000
+N               = (ARGV.first || 100000).to_i
+
+rn = Redis.new(host: HOST, port: STANDALONE_PORT)
+rc = Redis.new(host: HOST, port: CLUSTER_PORT)
+rm = Redis.new(cluster: %W[redis://#{HOST}:#{CLUSTER_PORT}])
+rs = Redis.new(cluster: %W[redis://#{HOST}:#{CLUSTER_PORT}], replica: true)
+
+Benchmark.bmbm do |bm|
+  bm.report('client: normal,  server: standalone, command: SET,  key: fixed') do
+    N.times { rn.set('foo', '42') }
+  end
+
+  bm.report('client: normal,  server: standalone, command: GET,  key: fixed') do
+    N.times { rn.get('foo') }
+  end
+
+  bm.report('client: normal,  server: cluster,    command: SET,  key: fixed') do
+    N.times { rc.set('bar', '42') }
+  end
+
+  bm.report('client: normal,  server: cluster,    command: GET,  key: fixed') do
+    N.times { rc.get('bar') }
+  end
+
+  bm.report('client: cluster, server: cluster,    command: SET,  key: fixed') do
+    N.times { rm.set('baz', '42') }
+  end
+
+  rm.wait(1, 0)
+  bm.report('client: cluster, server: cluster,    command: GET,  key: fixed') do
+    N.times { rm.get('baz') }
+  end
+
+  bm.report('client: cluster, server: cluster,    command: SET,  key: fixed,    replica: true') do
+    N.times { rs.set('zap', '42') }
+  end
+
+  rs.wait(1, 0)
+  bm.report('client: cluster, server: cluster,    command: GET,  key: fixed,    replica: true') do
+    N.times { rs.get('zap') }
+  end
+
+  bm.report('client: normal,  server: standalone, command: SET,  key: variable') do
+    N.times { |i| rn.set("foo:#{i}", '42') }
+  end
+
+  bm.report('client: normal,  server: standalone, command: GET,  key: variable') do
+    N.times { |i| rn.get("foo:#{i}") }
+  end
+
+  bm.report('client: cluster, server: cluster,    command: SET,  key: variable') do
+    N.times { |i| rm.set("bar:#{i}", '42') }
+  end
+
+  rm.wait(1, 0)
+  bm.report('client: cluster, server: cluster,    command: GET,  key: variable') do
+    N.times { |i| rm.get("bar:#{i}") }
+  end
+
+  bm.report('client: cluster, server: cluster,    command: SET,  key: variable, replica: true') do
+    N.times { |i| rs.set("baz:#{i}", '42') }
+  end
+
+  rs.wait(1, 0)
+  bm.report('client: cluster, server: cluster,    command: GET,  key: variable, replica: true') do
+    N.times { |i| rs.get("baz:#{i}") }
+  end
+
+  rn.set('bar', 0)
+  bm.report('client: normal,  server: standalone, command: INCR, key: fixed') do
+    N.times { rn.incr('bar') }
+  end
+
+  rc.set('bar', 0)
+  bm.report('client: normal,  server: cluster,    command: INCR, key: fixed') do
+    N.times { rc.incr('bar') }
+  end
+
+  rm.set('bar', 0)
+  bm.report('client: cluster, server: cluster,    command: INCR, key: fixed') do
+    N.times { rm.incr('bar') }
+  end
+end


### PR DESCRIPTION
```
$ bundle exec ruby benchmarking/cluster.rb
Rehearsal --------------------------------------------------------------------------------------------------------------------
client: normal,  server: standalone, command: SET,  key: fixed                     5.025255   2.132680   7.157935 (  7.239508)
client: normal,  server: standalone, command: GET,  key: fixed                     5.053769   2.027107   7.080876 (  7.120763)
client: normal,  server: cluster,    command: SET,  key: fixed                     6.037943   2.653111   8.691054 ( 10.468176)
client: normal,  server: cluster,    command: GET,  key: fixed                     4.983509   2.150347   7.133856 (  7.207940)
client: cluster, server: cluster,    command: SET,  key: fixed                     7.485830   2.694341  10.180171 ( 11.986462)
client: cluster, server: cluster,    command: GET,  key: fixed                     6.255247   2.273863   8.529110 (  8.602060)
client: cluster, server: cluster,    command: SET,  key: fixed,    replica: true   7.292564   2.753175  10.045739 ( 11.632343)
client: cluster, server: cluster,    command: GET,  key: fixed,    replica: true   6.347431   2.144565   8.491996 (  8.540676)
client: normal,  server: standalone, command: SET,  key: variable                  5.077897   2.160398   7.238295 (  7.304453)
client: normal,  server: standalone, command: GET,  key: variable                  5.092365   2.049798   7.142163 (  7.184118)
client: cluster, server: cluster,    command: SET,  key: variable                  8.678517   3.196198  11.874715 ( 18.625434)
client: cluster, server: cluster,    command: GET,  key: variable                  7.860782   2.796122  10.656904 ( 13.932492)
client: cluster, server: cluster,    command: SET,  key: variable, replica: true   8.678782   3.292573  11.971355 ( 18.507118)
client: cluster, server: cluster,    command: GET,  key: variable, replica: true   7.764900   2.800140  10.565040 ( 13.822124)
client: normal,  server: standalone, command: INCR, key: fixed                     4.570833   2.216524   6.787357 (  6.821728)
client: normal,  server: cluster,    command: INCR, key: fixed                     5.652514   2.901361   8.553875 ( 10.142479)
client: cluster, server: cluster,    command: INCR, key: fixed                     7.483717   2.959978  10.443695 ( 12.666467)
--------------------------------------------------------------------------------------------------------- total: 152.544136sec

                                                                                       user     system      total        real
client: normal,  server: standalone, command: SET,  key: fixed                     5.237403   2.049530   7.286933 (  7.408394)
client: normal,  server: standalone, command: GET,  key: fixed                     4.996083   2.252753   7.248836 (  7.346924)
client: normal,  server: cluster,    command: SET,  key: fixed                     5.838588   2.754442   8.593030 ( 10.376374)
client: normal,  server: cluster,    command: GET,  key: fixed                     4.985741   2.014113   6.999854 (  7.042634)
client: cluster, server: cluster,    command: SET,  key: fixed                     7.136913   2.826932   9.963845 ( 11.602256)
client: cluster, server: cluster,    command: GET,  key: fixed                     6.244346   2.137967   8.382313 (  8.425954)
client: cluster, server: cluster,    command: SET,  key: fixed,    replica: true   7.015664   2.974640   9.990304 ( 11.607133)
client: cluster, server: cluster,    command: GET,  key: fixed,    replica: true   6.426408   2.042308   8.468716 (  8.506667)
client: normal,  server: standalone, command: SET,  key: variable                  4.960275   2.087291   7.047566 (  7.088360)
client: normal,  server: standalone, command: GET,  key: variable                  5.013781   2.226260   7.240041 (  7.283784)
client: cluster, server: cluster,    command: SET,  key: variable                  8.563282   3.323450  11.886732 ( 18.461693)
client: cluster, server: cluster,    command: GET,  key: variable                  7.779255   2.645424  10.424679 ( 13.842412)
client: cluster, server: cluster,    command: SET,  key: variable, replica: true   8.941458   3.077545  12.019003 ( 18.761730)
client: cluster, server: cluster,    command: GET,  key: variable, replica: true   7.622620   2.841806  10.464426 ( 13.719579)
client: normal,  server: standalone, command: INCR, key: fixed                     4.600323   2.190782   6.791105 (  6.837537)
client: normal,  server: cluster,    command: INCR, key: fixed                     5.763337   2.716607   8.479944 ( 10.116247)
client: cluster, server: cluster,    command: INCR, key: fixed                     6.927129   2.756522   9.683651 ( 11.270000)
```