### PR TITLE
Exclude test files from bundled gem

### DIFF
--- a/redis.gemspec
+++ b/redis.gemspec
@@ -30,8 +30,7 @@ Gem::Specification.new do |s|
 
   s.email = ["redis-db@googlegroups.com"]
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.files         = Dir["CHANGELOG.md", "LICENSE", "README.md", "lib/**/*"]
   s.executables   = `git ls-files -- exe/*`.split("\n").map{ |f| File.basename(f) }
 
   s.required_ruby_version = '>= 2.2.2'


### PR DESCRIPTION
Rubygems doesn't use `test_files` anymore ([issue](https://github.com/rubygems/guides/issues/90)), and by removing the tests from the bundled gem size drops by 2/3rds. (It's not a big gem anyway, but since each version is installed millions of times hopefully that's a saving worth having.)