### PR TITLE
Stream feature polish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,9 @@ before_install:
 script: make
 
 rvm:
-  - 2.2.2
-  - 2.3.3
-  - 2.4.1
-  - 2.5.0
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
   - jruby-9.1.17.0
 
 gemfile: ".travis/Gemfile"
@@ -30,11 +29,10 @@ env:
   matrix:
     - DRIVER=ruby      REDIS_BRANCH=3.0
     - DRIVER=ruby      REDIS_BRANCH=3.2
-    - DRIVER=hiredis   REDIS_BRANCH=3.0
-    - DRIVER=hiredis   REDIS_BRANCH=3.2
-    - DRIVER=synchrony REDIS_BRANCH=3.0
-    - DRIVER=synchrony REDIS_BRANCH=3.2
     - DRIVER=ruby      REDIS_BRANCH=4.0
+    - DRIVER=ruby      REDIS_BRANCH=5.0
+    - DRIVER=hiredis   REDIS_BRANCH=5.0
+    - DRIVER=synchrony REDIS_BRANCH=5.0
 
 branches:
   only:
@@ -52,8 +50,6 @@ matrix:
       env: DRIVER=ruby REDIS_BRANCH=3.2 LOW_TIMEOUT=0.3
     - rvm: jruby-9.1.17.0
       env: DRIVER=ruby REDIS_BRANCH=4.0 LOW_TIMEOUT=0.3
-    - rvm: 2.5.3
-      env: DRIVER=ruby REDIS_BRANCH=5.0
 
 notifications:
   irc:

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
+require 'redis'
+
+require 'irb'
+IRB.start

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -3055,8 +3055,8 @@ class Redis
   # @return [Hash{String => Hash{String => Hash}}] the entries
   def xread(keys, ids, count: nil, block: nil)
     args = [:xread]
-    args.concat(['COUNT', count])      if count
-    args.concat(['BLOCK', block.to_i]) if block
+    args << 'COUNT' << count if count
+    args << 'BLOCK' << block.to_i if block
     _xread(args, keys, ids, block)
   end
 
@@ -3113,9 +3113,9 @@ class Redis
   # @return [Hash{String => Hash{String => Hash}}] the entries
   def xreadgroup(group, consumer, keys, ids, opts = {})
     args = [:xreadgroup, 'GROUP', group, consumer]
-    args.concat(['COUNT', opts[:count]])      if opts[:count]
-    args.concat(['BLOCK', opts[:block].to_i]) if opts[:block]
-    args << 'NOACK'                           if opts[:noack]
+    args << 'COUNT' << opts[:count] if opts[:count]
+    args << 'BLOCK' << opts[:block].to_i if opts[:block]
+    args << 'NOACK' if opts[:noack]
     _xread(args, keys, ids, opts[:block])
   end
 
@@ -3459,7 +3459,9 @@ private
   def _xread(args, keys, ids, blocking_timeout_msec)
     keys = keys.is_a?(Array) ? keys : [keys]
     ids = ids.is_a?(Array) ? ids : [ids]
-    args.concat(['STREAMS'], keys, ids)
+    args << 'STREAMS'
+    args.concat(keys)
+    args.concat(ids)
 
     synchronize do |client|
       if blocking_timeout_msec.nil?

--- a/test/cluster_commands_on_streams_test.rb
+++ b/test/cluster_commands_on_streams_test.rb
@@ -19,11 +19,14 @@ class TestClusterCommandsOnStreams < Test::Unit::TestCase
     redis.xadd('{s}1', { f: 'v02' }, id: '0-2')
     redis.xadd('{s}2', { f: 'v11' }, id: '1-1')
     redis.xadd('{s}2', { f: 'v12' }, id: '1-2')
+
     actual = redis.xread(%w[{s}1 {s}2], %w[0-1 1-1])
-    assert_equal 1, actual['{s}1'].size
-    assert_equal 1, actual['{s}2'].size
-    assert_equal 'v02', actual['{s}1']['0-2']['f']
-    assert_equal 'v12', actual['{s}2']['1-2']['f']
+
+    assert_equal %w(0-2), actual['{s}1'].map(&:first)
+    assert_equal %w(v02), actual['{s}1'].map { |i| i.last['f'] }
+
+    assert_equal %w(1-2), actual['{s}2'].map(&:first)
+    assert_equal %w(v12), actual['{s}2'].map { |i| i.last['f'] }
   end
 
   def test_xreadgroup_with_multiple_keys
@@ -38,10 +41,13 @@ class TestClusterCommandsOnStreams < Test::Unit::TestCase
     redis.xgroup(:create, '{s}2', 'g1', '$')
     redis.xadd('{s}1', { f: 'v02' }, id: '0-2')
     redis.xadd('{s}2', { f: 'v12' }, id: '1-2')
+
     actual = redis.xreadgroup('g1', 'c1', %w[{s}1 {s}2], %w[> >])
-    assert_equal 1, actual['{s}1'].size
-    assert_equal 1, actual['{s}2'].size
-    assert_equal 'v02', actual['{s}1']['0-2']['f']
-    assert_equal 'v12', actual['{s}2']['1-2']['f']
+
+    assert_equal %w(0-2), actual['{s}1'].map(&:first)
+    assert_equal %w(v02), actual['{s}1'].map { |i| i.last['f'] }
+
+    assert_equal %w(1-2), actual['{s}2'].map(&:first)
+    assert_equal %w(v12), actual['{s}2'].map { |i| i.last['f'] }
   end
 end

--- a/test/lint/streams.rb
+++ b/test/lint/streams.rb
@@ -152,43 +152,36 @@ module Lint
 
       actual = redis.xrange('s1')
 
-      assert_equal 'v1', actual['0-1']['f']
-      assert_equal 'v2', actual['0-2']['f']
-      assert_equal 'v3', actual['0-3']['f']
+      assert_equal %w(v1 v2 v3), actual.map { |i| i.last['f'] }
     end
 
-    def test_xrange_with_first_option
+    def test_xrange_with_start_option
       redis.xadd('s1', { f: 'v' }, id: '0-1')
       redis.xadd('s1', { f: 'v' }, id: '0-2')
       redis.xadd('s1', { f: 'v' }, id: '0-3')
 
-      actual = redis.xrange('s1', first: '0-2')
+      actual = redis.xrange('s1', '0-2')
 
-      assert_equal 2, actual.size
-      assert_equal '0-2', actual.keys.first
+      assert_equal %w(0-2 0-3), actual.map(&:first)
     end
 
-    def test_xrange_with_last_option
+    def test_xrange_with_end_option
       redis.xadd('s1', { f: 'v' }, id: '0-1')
       redis.xadd('s1', { f: 'v' }, id: '0-2')
       redis.xadd('s1', { f: 'v' }, id: '0-3')
 
-      actual = redis.xrange('s1', last: '0-2')
-
-      assert_equal 2, actual.size
-      assert_equal '0-1', actual.keys.first
-      assert_equal '0-2', actual.keys.last
+      actual = redis.xrange('s1', '-', '0-2')
+      assert_equal %w(0-1 0-2), actual.map(&:first)
     end
 
-    def test_xrange_with_first_and_last_options
+    def test_xrange_with_start_and_end_options
       redis.xadd('s1', { f: 'v' }, id: '0-1')
       redis.xadd('s1', { f: 'v' }, id: '0-2')
       redis.xadd('s1', { f: 'v' }, id: '0-3')
 
-      actual = redis.xrange('s1', first: '0-2', last: '0-2')
+      actual = redis.xrange('s1', '0-2', '0-2')
 
-      assert_equal 1, actual.size
-      assert_equal '0-2', actual.keys.first
+      assert_equal %w(0-2), actual.map(&:first)
     end
 
     def test_xrange_with_incomplete_entry_id_options
@@ -196,10 +189,10 @@ module Lint
       redis.xadd('s1', { f: 'v' }, id: '1-1')
       redis.xadd('s1', { f: 'v' }, id: '2-1')
 
-      actual = redis.xrange('s1', first: '0', last: '1')
+      actual = redis.xrange('s1', '0', '1')
 
       assert_equal 2, actual.size
-      assert_equal '0-1', actual.keys.first
+      assert_equal %w(0-1 1-1), actual.map(&:first)
     end
 
     def test_xrange_with_count_option
@@ -209,21 +202,20 @@ module Lint
 
       actual = redis.xrange('s1', count: 2)
 
-      assert_equal 2, actual.size
-      assert_equal '0-1', actual.keys.first
+      assert_equal %w(0-1 0-2), actual.map(&:first)
     end
 
     def test_xrange_with_not_existed_stream_key
-      assert_equal({}, redis.xrange('not-existed'))
+      assert_equal([], redis.xrange('not-existed'))
     end
 
     def test_xrange_with_invalid_entry_id_options
-      assert_raise(Redis::CommandError) { redis.xrange('s1', first: 'invalid', last: 'invalid') }
+      assert_raise(Redis::CommandError) { redis.xrange('s1', 'invalid', 'invalid') }
     end
 
     def test_xrange_with_invalid_arguments
-      assert_equal({}, redis.xrange(nil))
-      assert_equal({}, redis.xrange(''))
+      assert_equal([], redis.xrange(nil))
+      assert_equal([], redis.xrange(''))
     end
 
     def test_xrevrange
@@ -233,44 +225,38 @@ module Lint
 
       actual = redis.xrevrange('s1')
 
-      assert_equal '0-3', actual.keys.first
-      assert_equal 'v1', actual['0-1']['f']
-      assert_equal 'v2', actual['0-2']['f']
-      assert_equal 'v3', actual['0-3']['f']
+      assert_equal %w(0-3 0-2 0-1), actual.map(&:first)
+      assert_equal %w(v3 v2 v1), actual.map { |i| i.last['f'] }
     end
 
-    def test_xrevrange_with_first_option
+    def test_xrevrange_with_start_option
       redis.xadd('s1', { f: 'v' }, id: '0-1')
       redis.xadd('s1', { f: 'v' }, id: '0-2')
       redis.xadd('s1', { f: 'v' }, id: '0-3')
 
-      actual = redis.xrevrange('s1', first: '0-2')
+      actual = redis.xrevrange('s1', '+', '0-2')
 
-      assert_equal 2, actual.size
-      assert_equal '0-3', actual.keys.first
+      assert_equal %w(0-3 0-2), actual.map(&:first)
     end
 
-    def test_xrevrange_with_last_option
+    def test_xrevrange_with_end_option
       redis.xadd('s1', { f: 'v' }, id: '0-1')
       redis.xadd('s1', { f: 'v' }, id: '0-2')
       redis.xadd('s1', { f: 'v' }, id: '0-3')
 
-      actual = redis.xrevrange('s1', last: '0-2')
+      actual = redis.xrevrange('s1', '0-2')
 
-      assert_equal 2, actual.size
-      assert_equal '0-2', actual.keys.first
-      assert_equal '0-1', actual.keys.last
+      assert_equal %w(0-2 0-1), actual.map(&:first)
     end
 
-    def test_xrevrange_with_first_and_last_options
+    def test_xrevrange_with_start_and_end_options
       redis.xadd('s1', { f: 'v' }, id: '0-1')
       redis.xadd('s1', { f: 'v' }, id: '0-2')
       redis.xadd('s1', { f: 'v' }, id: '0-3')
 
-      actual = redis.xrevrange('s1', first: '0-2', last: '0-2')
+      actual = redis.xrevrange('s1', '0-2', '0-2')
 
-      assert_equal 1, actual.size
-      assert_equal '0-2', actual.keys.first
+      assert_equal %w(0-2), actual.map(&:first)
     end
 
     def test_xrevrange_with_incomplete_entry_id_options
@@ -278,10 +264,10 @@ module Lint
       redis.xadd('s1', { f: 'v' }, id: '1-1')
       redis.xadd('s1', { f: 'v' }, id: '2-1')
 
-      actual = redis.xrevrange('s1', first: '0', last: '1')
+      actual = redis.xrevrange('s1', '1', '0')
 
       assert_equal 2, actual.size
-      assert_equal '1-1', actual.keys.first
+      assert_equal '1-1', actual.first.first
     end
 
     def test_xrevrange_with_count_option
@@ -292,20 +278,20 @@ module Lint
       actual = redis.xrevrange('s1', count: 2)
 
       assert_equal 2, actual.size
-      assert_equal '0-3', actual.keys.first
+      assert_equal '0-3', actual.first.first
     end
 
     def test_xrevrange_with_not_existed_stream_key
-      assert_equal({}, redis.xrevrange('not-existed'))
+      assert_equal([], redis.xrevrange('not-existed'))
     end
 
     def test_xrevrange_with_invalid_entry_id_options
-      assert_raise(Redis::CommandError) { redis.xrevrange('s1', first: 'invalid', last: 'invalid') }
+      assert_raise(Redis::CommandError) { redis.xrevrange('s1', 'invalid', 'invalid') }
     end
 
     def test_xrevrange_with_invalid_arguments
-      assert_equal({}, redis.xrevrange(nil))
-      assert_equal({}, redis.xrevrange(''))
+      assert_equal([], redis.xrevrange(nil))
+      assert_equal([], redis.xrevrange(''))
     end
 
     def test_xlen
@@ -329,9 +315,7 @@ module Lint
 
       actual = redis.xread('s1', 0)
 
-      assert_equal 2, actual['s1'].size
-      assert_equal 'v1', actual['s1']['0-1']['f']
-      assert_equal 'v2', actual['s1']['0-2']['f']
+      assert_equal %w(v1 v2), actual.fetch('s1').map { |i| i.last['f'] }
     end
 
     def test_xread_with_multiple_keys
@@ -344,8 +328,8 @@ module Lint
 
       assert_equal 1, actual['s1'].size
       assert_equal 1, actual['s2'].size
-      assert_equal 'v02', actual['s1']['0-2']['f']
-      assert_equal 'v12', actual['s2']['1-2']['f']
+      assert_equal 'v02', actual['s1'][0].last['f']
+      assert_equal 'v12', actual['s2'][0].last['f']
     end
 
     def test_xread_with_count_option
@@ -423,8 +407,8 @@ module Lint
       actual = redis.xreadgroup('g1', 'c1', 's1', '>')
 
       assert_equal 2, actual['s1'].size
-      assert_equal 'v2', actual['s1']['0-2']['f']
-      assert_equal 'v3', actual['s1']['0-3']['f']
+      assert_equal 'v2', actual['s1'][0].last['f']
+      assert_equal 'v3', actual['s1'][1].last['f']
     end
 
     def test_xreadgroup_with_multiple_keys
@@ -439,8 +423,8 @@ module Lint
 
       assert_equal 1, actual['s1'].size
       assert_equal 1, actual['s2'].size
-      assert_equal 'v02', actual['s1']['0-2']['f']
-      assert_equal 'v12', actual['s2']['1-2']['f']
+      assert_equal 'v02', actual['s1'][0].last['f']
+      assert_equal 'v12', actual['s2'][0].last['f']
     end
 
     def test_xreadgroup_with_count_option
@@ -533,9 +517,8 @@ module Lint
 
       actual = redis.xclaim('s1', 'g1', 'c2', 10, '0-2', '0-3')
 
-      assert_equal 2, actual.size
-      assert_equal 'v2', actual['0-2']['f']
-      assert_equal 'v3', actual['0-3']['f']
+      assert_equal %w(0-2 0-3), actual.map(&:first)
+      assert_equal %w(v2 v3), actual.map { |i| i.last['f'] }
     end
 
     def test_xclaim_with_arrayed_entry_ids
@@ -548,9 +531,8 @@ module Lint
 
       actual = redis.xclaim('s1', 'g1', 'c2', 10, %w[0-2 0-3])
 
-      assert_equal 2, actual.size
-      assert_equal 'v2', actual['0-2']['f']
-      assert_equal 'v3', actual['0-3']['f']
+      assert_equal %w(0-2 0-3), actual.map(&:first)
+      assert_equal %w(v2 v3), actual.map { |i| i.last['f'] }
     end
 
     def test_xclaim_with_idle_option
@@ -563,9 +545,8 @@ module Lint
 
       actual = redis.xclaim('s1', 'g1', 'c2', 10, '0-2', '0-3', idle: 0)
 
-      assert_equal 2, actual.size
-      assert_equal 'v2', actual['0-2']['f']
-      assert_equal 'v3', actual['0-3']['f']
+      assert_equal %w(0-2 0-3), actual.map(&:first)
+      assert_equal %w(v2 v3), actual.map { |i| i.last['f'] }
     end
 
     def test_xclaim_with_time_option
@@ -579,9 +560,8 @@ module Lint
 
       actual = redis.xclaim('s1', 'g1', 'c2', 10, '0-2', '0-3', time: time)
 
-      assert_equal 2, actual.size
-      assert_equal 'v2', actual['0-2']['f']
-      assert_equal 'v3', actual['0-3']['f']
+      assert_equal %w(0-2 0-3), actual.map(&:first)
+      assert_equal %w(v2 v3), actual.map { |i| i.last['f'] }
     end
 
     def test_xclaim_with_retrycount_option
@@ -594,9 +574,8 @@ module Lint
 
       actual = redis.xclaim('s1', 'g1', 'c2', 10, '0-2', '0-3', retrycount: 10)
 
-      assert_equal 2, actual.size
-      assert_equal 'v2', actual['0-2']['f']
-      assert_equal 'v3', actual['0-3']['f']
+      assert_equal %w(0-2 0-3), actual.map(&:first)
+      assert_equal %w(v2 v3), actual.map { |i| i.last['f'] }
     end
 
     def test_xclaim_with_force_option
@@ -609,9 +588,8 @@ module Lint
 
       actual = redis.xclaim('s1', 'g1', 'c2', 10, '0-2', '0-3', force: true)
 
-      assert_equal 2, actual.size
-      assert_equal 'v2', actual['0-2']['f']
-      assert_equal 'v3', actual['0-3']['f']
+      assert_equal %w(0-2 0-3), actual.map(&:first)
+      assert_equal %w(v2 v3), actual.map { |i| i.last['f'] }
     end
 
     def test_xclaim_with_justid_option
@@ -658,7 +636,7 @@ module Lint
       redis.xadd('s1', { f: 'v4' }, id: '0-4')
       redis.xreadgroup('g1', 'c2', 's1', '>')
 
-      actual = redis.xpending('s1', 'g1', first: '-', last: '+', count: 10)
+      actual = redis.xpending('s1', 'g1', '-', '+', 10)
 
       assert_equal 3, actual.size
       assert_equal '0-2', actual[0]['entry_id']
@@ -684,7 +662,7 @@ module Lint
       redis.xadd('s1', { f: 'v4' }, id: '0-4')
       redis.xreadgroup('g1', 'c2', 's1', '>')
 
-      actual = redis.xpending('s1', 'g1', 'c1', first: '-', last: '+', count: 10)
+      actual = redis.xpending('s1', 'g1', '-', '+', 10, 'c1')
 
       assert_equal 2, actual.size
       assert_equal '0-2', actual[0]['entry_id']


### PR DESCRIPTION
While playing with https://github.com/redis/redis-rb/pull/799 locally, I realized it uses some modern Ruby feature like `Array#concat` varargs signature.

This PR updates the builds matrix so that it spots more of this kind of issues.

I'll wait for the results and fix what comes up.