### PR TITLE
Add ZPOP commands support of Redis5

### DIFF
--- a/test/lint/blocking_commands.rb
+++ b/test/lint/blocking_commands.rb
@@ -134,14 +134,16 @@ module Lint
     end
 
     def test_bzpopmin
-      target_version('4.9.0') do
-        assert_equal %w[{szap}foo a 0], r.bzpopmin('{szap}foo', '{szap}bar', 0)
+      target_version('5.0.0') do
+        assert_equal ['{szap}foo', 'a', 0.0], r.bzpopmin('{szap}foo', '{szap}bar', 1)
+        assert_equal nil, r.bzpopmin('{szap}aaa', '{szap}bbb', 1)
       end
     end
 
     def test_bzpopmax
-      target_version('4.9.0') do
-        assert_equal %w[{szap}foo c 2], r.bzpopmax('{szap}foo', '{szap}bar', 0)
+      target_version('5.0.0') do
+        assert_equal ['{szap}foo', 'c', 2.0], r.bzpopmax('{szap}foo', '{szap}bar', 1)
+        assert_equal nil, r.bzpopmax('{szap}aaa', '{szap}bbb', 1)
       end
     end
 

--- a/test/lint/sorted_sets.rb
+++ b/test/lint/sorted_sets.rb
@@ -316,16 +316,20 @@ module Lint
     end
 
     def test_zpopmax
-      target_version('4.9.0') do
-        r.zadd('foo', %w[0 a 1 b 2 c])
-        assert_equal %w[c 2], r.zpopmax('foo')
+      target_version('5.0.0') do
+        r.zadd('foo', %w[0 a 1 b 2 c 3 d])
+        assert_equal ['d', 3.0], r.zpopmax('foo')
+        assert_equal [['c', 2.0], ['b', 1.0]], r.zpopmax('foo', 2)
+        assert_equal [['a', 0.0]], r.zrange('foo', 0, -1, with_scores: true)
       end
     end
 
     def test_zpopmin
-      target_version('4.9.0') do
-        r.zadd('foo', %w[0 a 1 b 2 c])
-        assert_equal %w[a 0], r.zpopmin('foo')
+      target_version('5.0.0') do
+        r.zadd('foo', %w[0 a 1 b 2 c 3 d])
+        assert_equal ['a', 0.0], r.zpopmin('foo')
+        assert_equal [['b', 1.0], ['c', 2.0]], r.zpopmin('foo', 2)
+        assert_equal [['d', 3.0]], r.zrange('foo', 0, -1, with_scores: true)
       end
     end
 


### PR DESCRIPTION
* [Redis 5.0 is here!](https://redislabs.com/blog/redis-5-0-is-here/)
  * > ZPOP and friends
* [ZPOPMAX](https://redis.io/commands/zpopmax)
* [ZPOPMIN](https://redis.io/commands/zpopmin)
* [BZPOPMAX](https://redis.io/commands/bzpopmax)
* [BZPOPMIN](https://redis.io/commands/bzpopmin)
* ref: https://github.com/redis/redis-rb/issues/810