### PR TITLE
Fix sentinel authentication for Redis5

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -525,7 +525,6 @@ class Redis
         def initialize(options)
           super(options)
 
-          @options[:password] = DEFAULTS.fetch(:password)
           @options[:db] = DEFAULTS.fetch(:db)
 
           @sentinels = @options.delete(:sentinels).dup
@@ -586,6 +585,11 @@ class Redis
           end
 
           raise CannotConnectError, "No sentinels available."
+        rescue Redis::CommandError => err
+          # this feature is only available starting with Redis 5.0.1
+          raise unless err.message.start_with?('ERR unknown command `auth`')
+          @options[:password] = DEFAULTS.fetch(:password)
+          retry
         end
 
         def resolve_master

--- a/test/sentinel_command_test.rb
+++ b/test/sentinel_command_test.rb
@@ -4,17 +4,7 @@ require_relative 'helper'
 
 # @see https://redis.io/topics/sentinel#sentinel-commands Sentinel commands
 class SentinelCommandsTest < Test::Unit::TestCase
-  include Helper::Client
-
-  MASTER_PORT = PORT.to_s
-  SLAVE_PORT = '6382'
-  SENTINEL_PORT = '6400'
-  MASTER_NAME = 'master1'
-  LOCALHOST = '127.0.0.1'
-
-  def build_sentinel_client
-    Redis.new(host: LOCALHOST, port: SENTINEL_PORT, timeout: TIMEOUT)
-  end
+  include Helper::Sentinel
 
   def test_sentinel_command_master
     redis = build_sentinel_client
@@ -49,7 +39,7 @@ class SentinelCommandsTest < Test::Unit::TestCase
     assert_equal result[0]['ip'], LOCALHOST
 
     actual_ports = result.map { |r| r['port'] }.sort
-    expected_ports = (SENTINEL_PORT.to_i + 1..SENTINEL_PORT.to_i + 2).map(&:to_s)
+    expected_ports = SENTINEL_PORTS[1..-1]
     assert_equal actual_ports, expected_ports
   end
 


### PR DESCRIPTION
Hi,

This is related https://github.com/redis/redis-rb/issues/813.

---
Postscript:
It seems that the feature is a miner change of Redis5.
[Configuring Sentinel instances with authentication](https://redis.io/topics/sentinel#configuring-sentinel-instances-with-authentication)
> this feature is only available starting with Redis 5.0.1
---

The findings:
I think there is no way to be able to authenticate by current implementation. The error related the issue was reproduced on my local real Sentinels like the following.

I ran three Sentinels with a master Redis and a replica Redis.
```
+------------------------+
| M1 <--- slaveof --- R1 |
| ^                    ^ |
| |                    | |
| +----------+---------+ |
|            |           |
|       +----+----+      |
|       |    |    |      |
|      S1   S2   S3      |
+------------------------+
```

I configured `requirepass` and `masterauth` options each instance. `M1` `R1` `S1` `S2` `S3`

```
requirepass hogehoge
masterauth hogehoge
```

I configured `auth-pass` option each Sentinel. `S1` `S2` `S3`

```
sentinel auth-pass mymaster hogehoge
```

I tried to use the client in `bin/console`, and then, the following error was occurred.

```
irb(main):008:0> r = Redis.new(url: 'redis://mymaster', sentinels: [{host:'127.0.0.1',port:6400}], password: 'hogehoge')
=> #<Redis client v4.1.0 for redis://mymaster:6379/0>       
irb(main):009:0> r.get :hoge         
Traceback (most recent call last):                                   
       16: from /path/to/redis-rb/lib/redis/client.rb:123:in `call'
       15: from /path/to/redis-rb/lib/redis/client.rb:223:in `process'
       14: from /path/to/redis-rb/lib/redis/client.rb:312:in `logging'
       13: from /path/to/redis-rb/lib/redis/client.rb:224:in `block in process'
       12: from /path/to/redis-rb/lib/redis/client.rb:372:in `ensure_connected'
       11: from /path/to/redis-rb/lib/redis/client.rb:103:in `connect'
       10: from /path/to/redis-rb/lib/redis/client.rb:299:in `with_reconnect'
        9: from /path/to/redis-rb/lib/redis/client.rb:104:in `block in connect'               
        8: from /path/to/redis-rb/lib/redis/client.rb:337:in `establish_connection'
        7: from /path/to/redis-rb/lib/redis/client.rb:556:in `resolve'
        6: from /path/to/redis-rb/lib/redis/client.rb:592:in `resolve_master'
        5: from /path/to/redis-rb/lib/redis/client.rb:567:in `sentinel_detect'
        4: from /path/to/redis-rb/lib/redis/client.rb:567:in `each'                              
        3: from /path/to/redis-rb/lib/redis/client.rb:575:in `block in sentinel_detect'
        2: from /path/to/redis-rb/lib/redis/client.rb:593:in `block in resolve_master'
        1: from /path/to/redis-rb/lib/redis/client.rb:124:in `call'
Redis::CommandError (NOAUTH Authentication required.)
```

ref: [Sentinel and Redis authentication](https://redis.io/topics/sentinel#sentinel-and-redis-authentication)
ref: https://github.com/redis/redis-rb/issues/810