### PR TITLE
Use real sentinel for test

### DIFF
--- a/makefile
+++ b/makefile
@@ -9,6 +9,11 @@ REDIS_TRIB         := ${BUILD_DIR}/src/redis-trib.rb
 PID_PATH           := ${BUILD_DIR}/redis.pid
 SOCKET_PATH        := ${BUILD_DIR}/redis.sock
 PORT               := 6381
+SLAVE_PORT         := 6382
+SLAVE_PID_PATH     := ${BUILD_DIR}/redis_slave.pid
+SLAVE_SOCKET_PATH  := ${BUILD_DIR}/redis_slave.sock
+SENTINEL_PORTS     := 6400 6401 6402
+SENTINEL_PID_PATHS := $(addprefix ${TMP}/redis,$(addsuffix .pid,${SENTINEL_PORTS}))
 CLUSTER_PORTS      := 7000 7001 7002 7003 7004 7005
 CLUSTER_PID_PATHS  := $(addprefix ${TMP}/redis,$(addsuffix .pid,${CLUSTER_PORTS}))
 CLUSTER_CONF_PATHS := $(addprefix ${TMP}/nodes,$(addsuffix .conf,${CLUSTER_PORTS}))
@@ -19,10 +24,20 @@ define kill-redis
 endef
 
 all:
+	make start_all
+	make test
+	make stop_all
+
+start_all:
 	make start
+	make start_slave
+	make start_sentinel
 	make start_cluster
 	make create_cluster
-	make test
+
+stop_all:
+	make stop_sentinel
+	make stop_slave
 	make stop
 	make stop_cluster
 
@@ -45,6 +60,37 @@ start: ${BINARY}
 		--pidfile    ${PID_PATH}    \
 		--port       ${PORT}        \
 		--unixsocket ${SOCKET_PATH}
+
+stop_slave:
+	$(call kill-redis,${SLAVE_PID_PATH})
+
+start_slave: ${BINARY}
+	${BINARY}\
+		--daemonize  yes\
+		--pidfile    ${SLAVE_PID_PATH}\
+		--port       ${SLAVE_PORT}\
+		--unixsocket ${SLAVE_SOCKET_PATH}\
+		--slaveof    127.0.0.1 ${PORT}
+
+stop_sentinel:
+	$(call kill-redis,${SENTINEL_PID_PATHS})
+	rm -f ${TMP}/sentinel*.conf || true
+
+start_sentinel: ${BINARY}
+	for port in ${SENTINEL_PORTS}; do\
+		conf=${TMP}/sentinel$$port.conf;\
+		touch $$conf;\
+		echo '' >  $$conf;\
+		echo 'sentinel monitor                 master1 127.0.0.1 ${PORT} 2' >> $$conf;\
+		echo 'sentinel down-after-milliseconds master1 5000'                >> $$conf;\
+		echo 'sentinel failover-timeout        master1 30000'               >> $$conf;\
+		echo 'sentinel parallel-syncs          master1 1'                   >> $$conf;\
+		${BINARY} $$conf\
+			--daemonize yes\
+			--pidfile   ${TMP}/redis$$port.pid\
+			--port      $$port\
+			--sentinel;\
+	done
 
 stop_cluster:
 	$(call kill-redis,${CLUSTER_PID_PATHS})
@@ -71,4 +117,5 @@ create_cluster:
 clean:
 	(test -d ${BUILD_DIR} && cd ${BUILD_DIR}/src && make clean distclean) || true
 
-.PHONY: all test stop start stop_cluster start_cluster create_cluster clean
+.PHONY: all test stop start stop_slave start_slave stop_sentinel start_sentinel\
+	stop_cluster start_cluster create_cluster stop_all start_all clean

--- a/test/publish_subscribe_test.rb
+++ b/test/publish_subscribe_test.rb
@@ -119,6 +119,7 @@ class TestPublishSubscribe < Test::Unit::TestCase
       Wire.pass while !@subscribed
       redis = Redis.new(OPTIONS)
       channels_result = redis.pubsub(:channels)
+      channels_result.delete('__sentinel__:hello')
       numsub_result   = redis.pubsub(:numsub, 'foo', 'boo')
 
       redis.publish("foo", "s1")

--- a/test/sentinel_command_test.rb
+++ b/test/sentinel_command_test.rb
@@ -1,78 +1,69 @@
-require_relative "helper"
+# frozen_string_literal: true
 
+require_relative 'helper'
+
+# @see https://redis.io/topics/sentinel#sentinel-commands Sentinel commands
 class SentinelCommandsTest < Test::Unit::TestCase
-
   include Helper::Client
 
+  MASTER_PORT = PORT.to_s
+  SLAVE_PORT = '6382'
+  SENTINEL_PORT = '6400'
+  MASTER_NAME = 'master1'
+  LOCALHOST = '127.0.0.1'
+
+  def build_sentinel_client
+    Redis.new(host: LOCALHOST, port: SENTINEL_PORT, timeout: TIMEOUT)
+  end
+
   def test_sentinel_command_master
+    redis = build_sentinel_client
+    result = redis.sentinel('master', MASTER_NAME)
 
-    handler = lambda do |id|
-      {
-        :sentinel => lambda do |command, *args|
-          ["name", "master1", "ip", "127.0.0.1"]
-        end
-      }
-    end
-
-    RedisMock.start(handler.call(:s1)) do |port|
-      redis = Redis.new(:host => "127.0.0.1", :port => port)
-
-      result = redis.sentinel('master', 'master1')
-      assert_equal result, { "name" => "master1", "ip" => "127.0.0.1" }
-    end
+    assert_equal result['name'], MASTER_NAME
+    assert_equal result['ip'], LOCALHOST
   end
 
   def test_sentinel_command_masters
+    redis = build_sentinel_client
+    result = redis.sentinel('masters')
 
-    handler = lambda do |id|
-      {
-        :sentinel => lambda do |command, *args|
-          [%w[name master1 ip 127.0.0.1 port 6381], %w[name master1 ip 127.0.0.1 port 6382]]
-        end
-      }
-    end
+    assert_equal result[0]['name'], MASTER_NAME
+    assert_equal result[0]['ip'], LOCALHOST
+    assert_equal result[0]['port'], MASTER_PORT
+  end
 
-    RedisMock.start(handler.call(:s1)) do |port|
-      redis = Redis.new(:host => "127.0.0.1", :port => port)
+  def test_sentinel_command_slaves
+    redis = build_sentinel_client
+    result = redis.sentinel('slaves', MASTER_NAME)
 
-      result = redis.sentinel('masters')
-      assert_equal result[0], { "name" => "master1", "ip" => "127.0.0.1", "port" => "6381" }
-      assert_equal result[1], { "name" => "master1", "ip" => "127.0.0.1", "port" => "6382" }
-    end
+    assert_equal result[0]['name'], "#{LOCALHOST}:#{SLAVE_PORT}"
+    assert_equal result[0]['ip'], LOCALHOST
+    assert_equal result[0]['port'], SLAVE_PORT
+  end
+
+  def test_sentinel_command_sentinels
+    redis = build_sentinel_client
+    result = redis.sentinel('sentinels', MASTER_NAME)
+
+    assert_equal result[0]['ip'], LOCALHOST
+
+    actual_ports = result.map { |r| r['port'] }.sort
+    expected_ports = (SENTINEL_PORT.to_i + 1..SENTINEL_PORT.to_i + 2).map(&:to_s)
+    assert_equal actual_ports, expected_ports
   end
 
   def test_sentinel_command_get_master_by_name
+    redis = build_sentinel_client
+    result = redis.sentinel('get-master-addr-by-name', MASTER_NAME)
 
-    handler = lambda do |id|
-      {
-        :sentinel => lambda do |command, *args|
-          ["127.0.0.1", "6381"]
-        end
-      }
-    end
-
-    RedisMock.start(handler.call(:s1)) do |port|
-      redis = Redis.new(:host => "127.0.0.1", :port => port)
-
-      result = redis.sentinel('get-master-addr-by-name', 'master1')
-      assert_equal result, ["127.0.0.1", "6381"]
-    end
+    assert_equal result, [LOCALHOST, MASTER_PORT]
   end
 
   def test_sentinel_command_ckquorum
-    handler = lambda do |id|
-      {
-        :sentinel => lambda do |command, *args|
-          "+OK 2 usable Sentinels. Quorum and failover authorization can be reached"
-        end
-      }
-    end
+    redis = build_sentinel_client
+    result = redis.sentinel('ckquorum', MASTER_NAME)
 
-    RedisMock.start(handler.call(:s1)) do |port|
-      redis = Redis.new(:host => "127.0.0.1", :port => port)
-
-      result = redis.sentinel('ckquorum', 'master1')
-      assert_equal result, "OK 2 usable Sentinels. Quorum and failover authorization can be reached"
-    end
+    assert_equal result, 'OK 3 usable Sentinels. Quorum and failover authorization can be reached'
   end
 end


### PR DESCRIPTION
Hi

This is related https://github.com/redis/redis-rb/issues/815.

I added the following instances to Makefile.

* three Sentinels
  * [Fundamental things to know about Sentinel before deploying](https://redis.io/topics/sentinel#fundamental-things-to-know-about-sentinel-before-deploying)
    * > You need at least three Sentinel instances for a robust deployment.
  * the quorum number is `2`
* a replica Redis
  * `SLAVEOF` a master Redis

```
+------------------------+
| M1 <--- slaveof --- R1 |
| ^                    ^ |
| |                    | |
| +----------+---------+ |
|            |           |
|       +----+----+      |
|       |    |    |      |
|      S1   S2   S3      |
+------------------------+
```

| instance | port |
| --- | --- |
| M1 | 6381 |
| R1 | 6382 |
| S1 | 6400 |
| S2 | 6401 |
| S3 | 6402 |

And I modified `test/sentinel_command_test.rb`.