### PR TITLE
Always return Fixnum (or Float when :incr is specified) for SADD / ZADD

### DIFF
--- a/test/lint/sets.rb
+++ b/test/lint/sets.rb
@@ -3,9 +3,9 @@ module Lint
   module Sets
 
     def test_sadd
-      assert_equal true, r.sadd("foo", "s1")
-      assert_equal true, r.sadd("foo", "s2")
-      assert_equal false, r.sadd("foo", "s1")
+      assert_equal 1, r.sadd("foo", "s1")
+      assert_equal 1, r.sadd("foo", "s2")
+      assert_equal 0, r.sadd("foo", "s1")
 
       assert_equal ["s1", "s2"], r.smembers("foo").sort
     end
@@ -23,8 +23,8 @@ module Lint
       r.sadd("foo", "s1")
       r.sadd("foo", "s2")
 
-      assert_equal true, r.srem("foo", "s1")
-      assert_equal false, r.srem("foo", "s3")
+      assert_equal 1, r.srem("foo", "s1")
+      assert_equal 0, r.srem("foo", "s3")
 
       assert_equal ["s2"], r.smembers("foo")
     end

--- a/test/lint/sorted_sets.rb
+++ b/test/lint/sorted_sets.rb
@@ -6,33 +6,33 @@ module Lint
 
     def test_zadd
       assert_equal 0, r.zcard("foo")
-      assert_equal true, r.zadd("foo", 1, "s1")
-      assert_equal false, r.zadd("foo", 1, "s1")
+      assert_equal 1, r.zadd("foo", 1, "s1")
+      assert_equal 0, r.zadd("foo", 1, "s1")
       assert_equal 1, r.zcard("foo")
       r.del "foo"
 
       target_version "3.0.2" do
         # XX option
         assert_equal 0, r.zcard("foo")
-        assert_equal false, r.zadd("foo", 1, "s1", :xx => true)
+        assert_equal 0, r.zadd("foo", 1, "s1", :xx => true)
         r.zadd("foo", 1, "s1")
-        assert_equal false, r.zadd("foo", 2, "s1", :xx => true)
+        assert_equal 0, r.zadd("foo", 2, "s1", :xx => true)
         assert_equal 2, r.zscore("foo", "s1")
         r.del "foo"
 
         # NX option
         assert_equal 0, r.zcard("foo")
-        assert_equal true, r.zadd("foo", 1, "s1", :nx => true)
-        assert_equal false, r.zadd("foo", 2, "s1", :nx => true)
+        assert_equal 1, r.zadd("foo", 1, "s1", :nx => true)
+        assert_equal 0, r.zadd("foo", 2, "s1", :nx => true)
         assert_equal 1, r.zscore("foo", "s1")
         assert_equal 1, r.zcard("foo")
         r.del "foo"
 
         # CH option
         assert_equal 0, r.zcard("foo")
-        assert_equal true, r.zadd("foo", 1, "s1", :ch => true)
-        assert_equal false, r.zadd("foo", 1, "s1", :ch => true)
-        assert_equal true, r.zadd("foo", 2, "s1", :ch => true)
+        assert_equal 1, r.zadd("foo", 1, "s1", :ch => true)
+        assert_equal 0, r.zadd("foo", 1, "s1", :ch => true)
+        assert_equal 1, r.zadd("foo", 2, "s1", :ch => true)
         assert_equal 1, r.zcard("foo")
         r.del "foo"
 
@@ -118,8 +118,8 @@ module Lint
       r.zadd("foo", 2, "s2")
 
       assert_equal 2, r.zcard("foo")
-      assert_equal true, r.zrem("foo", "s1")
-      assert_equal false, r.zrem("foo", "s1")
+      assert_equal 1, r.zrem("foo", "s1")
+      assert_equal 0, r.zrem("foo", "s1")
       assert_equal 1, r.zcard("foo")
     end
 


### PR DESCRIPTION
For someone who is familiar with Redis, returning booleans from SADD and ZADD (and SREM / ZREM) is confusing at first, and I don't see the benefit, so I've removed the boolean casting from these methods.

Further explanation here: #820 