### PR TITLE
Remove old (and inaccurate) documetation

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -2977,24 +2977,6 @@ class Redis
     synchronize { |client| client.call(args) }
   end
 
-  # Fetches entries of the stream.
-  #
-  # @example Without options
-  #   redis.xrange('mystream')
-  # @example With first entry id option
-  #   redis.xrange('mystream', first: '0-1')
-  # @example With first and last entry id options
-  #   redis.xrange('mystream', first: '0-1', last: '0-3')
-  # @example With count options
-  #   redis.xrange('mystream', count: 10)
-  #
-  # @param key   [String]  the stream key
-  # @param start  [String]  first entry id of range, default value is `+`
-  # @param end [String]  last entry id of range, default value is `-`
-  # @param count [Integer] the number of entries as limit
-  #
-  # @return [Hash{String => Hash}] the entries
-
   # Fetches entries of the stream in ascending order.
   #
   # @example Without options


### PR DESCRIPTION
This section of comments appears to be left in accidentally when the argument for the `xrange` and `xrevrange` methods were changed [here.](https://github.com/jrmhaig/redis-rb/commit/60079e44ae4d71a378ea248055fd37ca29118e59)