### PR TITLE
Use nonblocking IO for SSL socket connect.

### DIFF
--- a/test/ssl_test.rb
+++ b/test/ssl_test.rb
@@ -6,6 +6,13 @@ class SslTest < Test::Unit::TestCase
 
   driver(:ruby) do
 
+    def test_connection_to_non_ssl_server
+      assert_raise(Redis::CannotConnectError) do
+        redis = Redis.new(OPTIONS.merge(ssl: true))
+        redis.ping
+      end
+    end
+
     def test_verified_ssl_connection
       RedisMock.start({ :ping => proc { "+PONG" } }, ssl_server_opts("trusted")) do |port|
         redis = Redis.new(:port => port, :ssl => true, :ssl_params => { :ca_file => ssl_ca_file })


### PR DESCRIPTION
Attempting to use SSL when the server isn't configured this way will
lead to the connection hanging forever.  By using nonblocking IO we
can respect a timeout.

fixes #835