### PR TITLE
Fix bug for equal params to georadius. Allow array param for geoadd

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -2818,7 +2818,7 @@ class Redis
   # @return [Intger] number of elements added to the sorted set
   def geoadd(key, *member)
     synchronize do |client|
-      client.call([:geoadd, key, member])
+      client.call([:geoadd, key, *member])
     end
   end
 
@@ -3441,8 +3441,7 @@ private
     args.push sort if sort
     args.push 'count', count if count
     args.push options if options
-
-    args.uniq
+    args
   end
 
   def _subscription(method, timeout, channels, block)

--- a/test/commands_on_geo_test.rb
+++ b/test/commands_on_geo_test.rb
@@ -12,6 +12,21 @@ class TestCommandsGeo < Test::Unit::TestCase
     end
   end
 
+  def test_geoadd_with_array_params
+    target_version "3.2.0" do
+      added_items_count = r.geoadd("SicilyArray", [13.361389, 38.115556, "Palermo", 15.087269, 37.502669, "Catania"])
+      assert_equal 2, added_items_count
+    end
+  end
+
+  def test_georadius_with_same_params
+    target_version "3.2.0" do
+      r.geoadd("Chad", 15, 15, "Kanem")
+      nearest_cities = r.georadius("Chad", 15, 15, 15, 'km', sort: 'asc')
+      assert_equal %w(Kanem), nearest_cities
+    end
+  end
+
   def test_georadius_with_sort
     target_version "3.2.0" do
       nearest_cities = r.georadius("Sicily", 15, 37, 200, 'km', sort: 'asc')


### PR DESCRIPTION
- Currently there's bug when searching with same params for Georadius
and georadiusbymember, due to `args.uniq` (not sure why uniq is being
called). Example calling for (lat = 15, lng = 15), it returns `ERR wrong number of arguments for 'georadius' command`
- Georadius and georadiusbymember accept array params while geoadd
doesnt. Making geoadd consistent and more user-friendly.