### PR TITLE
Handle blocking commands inside pipelines and transactions

### DIFF
--- a/test/blocking_commands_test.rb
+++ b/test/blocking_commands_test.rb
@@ -36,4 +36,22 @@ class TestBlockingCommands < Test::Unit::TestCase
       assert_equal '0', r.brpoplpush('foo', 'bar')
     end
   end
+
+  def test_brpoplpush_in_transaction
+    results = r.multi do
+      r.brpoplpush('foo', 'bar')
+      r.brpoplpush('foo', 'bar', timeout: 2)
+    end
+    assert_equal [nil, nil], results
+  end
+
+  def test_brpoplpush_in_pipeline
+    mock do |r|
+      results = r.pipelined do
+        r.brpoplpush('foo', 'bar')
+        r.brpoplpush('foo', 'bar', timeout: 2)
+      end
+      assert_equal ['0', '2'], results
+    end
+  end
 end

--- a/test/lint/blocking_commands.rb
+++ b/test/lint/blocking_commands.rb
@@ -152,7 +152,7 @@ module Lint
     def test_bzpopmin
       target_version('5.0.0') do
         assert_equal ['{szap}foo', 'a', 0.0], r.bzpopmin('{szap}foo', '{szap}bar', 1)
-        assert_equal nil, r.bzpopmin('{szap}aaa', '{szap}bbb', 1)
+        assert_equal nil, r.bzpopmin('{szap}aaa', '{szap}bbb', 2)
       end
     end
 


### PR DESCRIPTION
Fix: #753

The Redis server documentation is pretty clear that blocking commands make no sense inside pipelines, however it does handle them in a degraded way.

This PR simply shim `call_with_timeout` on `Pipeline` and `Multi` objects.