### PR TITLE
Fix error handling for sentinel authantication command

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -597,7 +597,7 @@ class Redis
           raise CannotConnectError, "No sentinels available."
         rescue Redis::CommandError => err
           # this feature is only available starting with Redis 5.0.1
-          raise unless err.message.start_with?('ERR unknown command `auth`')
+          raise if err.message !~ /ERR unknown command (`|')auth(`|')/
           @options[:password] = DEFAULTS.fetch(:password)
           retry
         end


### PR DESCRIPTION
ref: #849
ref: #814

https://github.com/antirez/redis/blob/990cd2c8357f2fa6629f55b75f88e76873ab8c97/src/server.c#L2382-L2383

https://github.com/antirez/redis/blob/cc10172176365fe1a1994399a6b4eb9dab720b45/src/server.c#L2567-L2568

It seems the error message was changed a bit.