### PR TITLE
Fix unstable test cases for CI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,25 @@
 require 'rake/testtask'
 Rake::TestTask.new 'test' do |t|
+  if ENV['SOCKET_PATH'].nil?
+    sock_file = Dir.glob("#{__dir__}/**/redis.sock").first
+
+    if sock_file.nil?
+      puts '`SOCKET_PATH` environment variable required'
+      exit 1
+    end
+
+    ENV['SOCKET_PATH'] = sock_file
+  end
+
   t.libs = %w(lib test)
-  t.pattern = "test/*_test.rb"
+
+  if ARGV.size == 1
+    t.pattern = 'test/*_test.rb'
+  else
+    t.test_files = ARGV[1..-1]
+  end
+
+  t.options = '-v'
 end
 
 task default: :test

--- a/bin/cluster_creater
+++ b/bin/cluster_creater
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+
+# frozen_string_literal: true
+
+require_relative '../test/support/cluster/orchestrator'
+
+urls = ARGV.map { |host_port| "redis://#{host_port}" }
+orchestrator = ClusterOrchestrator.new(urls, timeout: 30.0)
+orchestrator.rebuild
+orchestrator.close

--- a/test/cluster_client_replicas_test.rb
+++ b/test/cluster_client_replicas_test.rb
@@ -13,10 +13,7 @@ class TestClusterClientReplicas < Minitest::Test
       assert_equal 'OK', r.set("key#{i}", i)
     end
 
-    begin
-      r.wait(6, 5_000)
-    rescue Redis::TimeoutError
-    end
+    r.wait(1, TIMEOUT.to_i * 1000)
 
     100.times do |i|
       assert_equal i.to_s, r.get("key#{i}")
@@ -35,10 +32,7 @@ class TestClusterClientReplicas < Minitest::Test
 
     5.times { |i| r.set("key#{i}", i) }
 
-    begin
-      r.wait(6, 5_000)
-    rescue Redis::TimeoutError
-    end
+    r.wait(1, TIMEOUT.to_i * 1000)
 
     assert_equal %w[key0 key1 key2 key3 key4], r.keys
     assert_equal 5, r.dbsize

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -19,7 +19,7 @@ require_relative 'support/cluster/orchestrator'
 
 PORT        = 6381
 DB          = 15
-TIMEOUT     = Float(ENV['TIMEOUT'] || 0.1)
+TIMEOUT     = Float(ENV['TIMEOUT'] || 1.0)
 LOW_TIMEOUT = Float(ENV['LOW_TIMEOUT'] || 0.01) # for blocking-command tests
 OPTIONS     = { port: PORT, db: DB, timeout: TIMEOUT }.freeze
 

--- a/test/support/cluster/orchestrator.rb
+++ b/test/support/cluster/orchestrator.rb
@@ -7,7 +7,13 @@ class ClusterOrchestrator
 
   def initialize(node_addrs, timeout: 30.0)
     raise 'Redis Cluster requires at least 3 master nodes.' if node_addrs.size < 3
-    @clients = node_addrs.map { |addr| Redis.new(url: addr, timeout: timeout) }
+    @clients = node_addrs.map do |addr|
+      Redis.new(url: addr,
+                timeout: timeout,
+                reconnect_attempts: 10,
+                reconnect_delay: 1.5,
+                reconnect_delay_max: 10.0)
+    end
     @timeout = timeout
   end
 


### PR DESCRIPTION
Hi,

Several test cases are unstable. I tried to reproduce them. I found the following failure patterns.

```
SEED=61387    # TestClusterCommandsOnCluster#test_cluster_slaves
SEED=22998    # TestClusterClientReplicas#test_some_reference_commands_are_sent_to_slaves_if_needed
```

It tends to fail when the cluster test cases is executed earlier priority.