### PR TITLE
Fix Sentinel authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ but a few so that if one is down the client will try the next one. The client
 is able to remember the last Sentinel that was able to reply correctly and will
 use it for the next requests.
 
+If you want to [authenticate](https://redis.io/topics/sentinel#configuring-sentinel-instances-with-authentication) Sentinel itself, you must specify the `password` option per instance.
+
+```ruby
+SENTINELS = [{ host: '127.0.0.1', port: 26380, password: 'mysecret' },
+             { host: '127.0.0.1', port: 26381, password: 'mysecret' }]
+
+redis = Redis.new(host: 'mymaster', sentinels: SENTINELS, role: :master)
+```
+
 ## Cluster support
 
 `redis-rb` supports [clustering](https://redis.io/topics/cluster-spec).

--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -577,6 +577,7 @@ class Redis
             client = Client.new(@options.merge({
               :host => sentinel[:host],
               :port => sentinel[:port],
+              password: sentinel[:password],
               :reconnect_attempts => 0,
             }))
 
@@ -595,11 +596,6 @@ class Redis
           end
 
           raise CannotConnectError, "No sentinels available."
-        rescue Redis::CommandError => err
-          # this feature is only available starting with Redis 5.0.1
-          raise if err.message !~ /ERR unknown command (`|')auth(`|')/
-          @options[:password] = DEFAULTS.fetch(:password)
-          retry
         end
 
         def resolve_master


### PR DESCRIPTION
This is related to #855.

I modified the Sentinel authentication like separating the `password` option into for Sentinel and for Redis.

```ruby
sentinels = [{ host: '127.0.0.1', port: 6400, password: 'foo' },
             { host: '127.0.0.1', port: 6401, password: 'foo' }]

redis = Redis.new(host: 'mymaster', sentinels: sentinels, role: :master, password: 'bar')
```

* [Sentinel and Redis authentication](https://redis.io/topics/sentinel#sentinel-and-redis-authentication)
* [Configuring Sentinel instances with authentication](https://redis.io/topics/sentinel#configuring-sentinel-instances-with-authentication)