### PR TITLE
Update rubygems version for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache:
     directories:
       - tmp/cache
 before_install:
-  - gem update --system 2.6.14
+  - gem update --system 3.0.3
   - gem --version
 
 script: make


### PR DESCRIPTION
https://blog.rubygems.org/2019/03/05/security-advisories-2019-03.html

> We strongly recommend to upgrade the latest stable version of RubyGems 3.0.3 or 2.7.8.
> If you can’t upgrade RubyGems 2.7 or 3.0, please use this patch for RubyGems 2.6.