### PR TITLE
Reduce timeout for ssl test

### DIFF
--- a/test/ssl_test.rb
+++ b/test/ssl_test.rb
@@ -8,7 +8,7 @@ class SslTest < Minitest::Test
 
     def test_connection_to_non_ssl_server
       assert_raises(Redis::CannotConnectError) do
-        redis = Redis.new(OPTIONS.merge(ssl: true))
+        redis = Redis.new(OPTIONS.merge(ssl: true, timeout: LOW_TIMEOUT))
         redis.ping
       end
     end


### PR DESCRIPTION
I found a slow test case.
https://travis-ci.org/redis/redis-rb/jobs/539118520

> SslTest#test_connection_to_non_ssl_server = 60.07 s = .

https://github.com/redis/redis-rb/blob/9101933c84d11f08794466ad0903467958e014ba/test/ssl_test.rb#L9-L14