### PR TITLE
Use TCP_NODELAY to reduce remote connection lag

### DIFF
--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -321,6 +321,7 @@ class Redis
         instance.timeout = config[:read_timeout]
         instance.write_timeout = config[:write_timeout]
         instance.set_tcp_keepalive config[:tcp_keepalive]
+        instance.set_tcp_nodelay if sock.is_a? TCPSocket
         instance
       end
 
@@ -348,6 +349,16 @@ class Redis
         def get_tcp_keepalive
           {
           }
+        end
+      end
+
+      # disables Nagle's Algorithm, prevents multiple round trips with MULTI
+      if [:IPPROTO_TCP, :TCP_NODELAY].all?{|c| Socket.const_defined? c}
+        def set_tcp_nodelay        
+          @sock.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)        
+        end
+      else
+        def set_tcp_nodelay
         end
       end
 


### PR DESCRIPTION
I have recently been looking at Crystal Redis latency issues and (during comparison) noticed that the Redis Ruby client's MULTI transactions seem slower than they should be (particularly for remote hosts e.g. 40ms ping, there appeared to be 2 round trips rather than 1).

I originally produced a local buffering solution to solve the issue, which was functional and did not affect tests. However, it was additional code and whilst investigating I discovered that TCP_NODELAY was not set on the socket and that setting this flag appears to solve the issue (by disabling Nagle's algorithm).

Results follow below, please let me know what you think.

### BEFORE:

#### Redis Ruby logger

D, [2019-08-02T23:32:08.958705 #24749] DEBUG -- : [Redis] command=MULTI args=
D, [2019-08-02T23:32:08.958842 #24749] DEBUG -- : [Redis] command=SET args="test123" "123456"
D, [2019-08-02T23:32:08.958912 #24749] DEBUG -- : [Redis] command=GET args="test123"
D, [2019-08-02T23:32:08.958975 #24749] DEBUG -- : [Redis] command=EXEC args=
D, [2019-08-02T23:32:09.046421 #24749] DEBUG -- : [Redis] call_time=**87.37 ms**

#### Redis MONITOR log (for basic transaction above)

1564781529.**001666** [0 99.99.99.99:50474] "multi"
1564781529.**046062** [0 99.99.99.99:50474] "set" "test123" "123456"
1564781529.046101 [0 99.99.99.99:50474] "get" "test123"
1564781529.046124 [0 99.99.99.99:50474] "exec"

#### Redis MONITOR log (for a standard Sidekiq push)

1564779615.**017052** [0 99.99.99.99:50264] "multi"
1564779615.**076414** [0 99.99.99.99:50264] "sadd" "queues" "from_sk_ruby"
1564779615.076435 [0 99.99.99.99:50264] "lpush" "queue:from_sk_ruby" "{\"queue\":\"from_sk_ruby\",\"class\":\"Sample::MyWorker\",\"args\":[{\"test\":\"payload\",\"activity_id\":15838549}],\"retry\":true,\"jid\":\"b8dda0af8fb6efe84dcfe2ea\",\"created_at\":1564779605.996376,\"enqueued_at\":1564779614.9788728}"
1564779615.076520 [0 99.99.99.99:50264] "exec"


### AFTER:

#### Redis Ruby logger

D, [2019-08-02T23:28:19.232984 #24339] DEBUG -- : [Redis] command=MULTI args=
D, [2019-08-02T23:28:19.233134 #24339] DEBUG -- : [Redis] command=SET args="test123" "123456"
D, [2019-08-02T23:28:19.233206 #24339] DEBUG -- : [Redis] command=GET args="test123"
D, [2019-08-02T23:28:19.233260 #24339] DEBUG -- : [Redis] command=EXEC args=
D, [2019-08-02T23:28:19.279699 #24339] DEBUG -- : [Redis] call_time=**46.34 ms**

#### Redis MONITOR log (for basic transaction above)

1564781299.274736 [0 99.99.99.99:50466] "multi"
1564781299.274764 [0 99.99.99.99:50466] "set" "test123" "123456"
1564781299.274783 [0 99.99.99.99:50466] "get" "test123"
1564781299.274794 [0 99.99.99.99:50466] "exec"

#### Redis MONITOR log (for a standard Sidekiq push)

1564779431.460906 [0 99.99.99.99:50258] "multi"
1564779431.461248 [0 99.99.99.99:50258] "sadd" "queues" "from_sk_ruby"
1564779431.461267 [0 99.99.99.99:50258] "lpush" "queue:from_sk_ruby" "{\"queue\":\"from_sk_ruby\",\"class\":\"Sample::MyWorker\",\"args\":[{\"test\":\"payload\",\"activity_id\":15838549}],\"retry\":true,\"jid\":\"fa7ddd669dd6382fc94fd357\",\"created_at\":1564779426.583655,\"enqueued_at\":1564779431.421699}"
1564779431.461391 [0 99.99.99.99:50258] "exec"


### 100 Sidekiq job pushes to remote Redis w/ ~45ms ping

BEFORE: **~9s**
AFTER: **~4.9s**