### PR TITLE
Allow to skip SSL host check with verify_hostname: false

### DIFF
--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -289,7 +289,7 @@ class Redis
             end
           end
 
-          unless ctx.verify_mode == OpenSSL::SSL::VERIFY_NONE
+          unless ctx.verify_mode == OpenSSL::SSL::VERIFY_NONE || (ctx.respond_to?(:verify_hostname) && !ctx.verify_hostname)
             ssl_sock.post_connection_check(host)
           end
 


### PR DESCRIPTION
OpenSSL context allow to set `verify_hostname` flag to `false` to skip the hostname verification (https://ruby.github.io/openssl/OpenSSL/SSL/SSLContext.html#attribute-i-verify_hostname).
Because `post_connection_check` is doing a hostname verification (https://apidock.com/ruby/v2_6_3/OpenSSL/SSL/SSLSocket/post_connection_check) we should not execute it if `verify_hostname` is `false`.