### PR TITLE
Do not allocate useless hash for b*pop* commands

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -1164,21 +1164,21 @@ class Redis
   end
 
   def _bpop(cmd, args, &blk)
-    options = {}
-
-    if args.last.is_a?(Hash)
+    timeout = if args.last.is_a?(Hash)
       options = args.pop
+      options[:timeout]
     elsif args.last.respond_to?(:to_int)
       # Issue deprecation notice in obnoxious mode...
-      options[:timeout] = args.pop.to_int
+      args.pop.to_int
     end
+
+    timeout ||= 0
 
     if args.size > 1
       # Issue deprecation notice in obnoxious mode...
     end
 
     keys = args.flatten
-    timeout = options[:timeout] || 0
 
     synchronize do |client|
       command = [cmd, keys, timeout]

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -401,13 +401,12 @@ class Redis
     end
 
     def _bpop(cmd, args)
-      options = {}
-
-      if args.last.is_a?(Hash)
+      timeout = if args.last.is_a?(Hash)
         options = args.pop
+        options[:timeout]
       elsif args.last.respond_to?(:to_int)
         # Issue deprecation notice in obnoxious mode...
-        options[:timeout] = args.pop.to_int
+        args.pop.to_int
       end
 
       if args.size > 1
@@ -417,7 +416,11 @@ class Redis
       keys = args.flatten
 
       ensure_same_node(cmd, keys) do |node|
-        node.__send__(cmd, keys, options)
+        if timeout
+          node.__send__(cmd, keys, timeout: timeout)
+        else
+          node.__send__(cmd, keys)
+        end
       end
     end
 


### PR DESCRIPTION
Sidekiq extensively uses bpop-like commands (especially `brpop`) for processing it's jobs and I noticed that this command generates plenty of trash due to this useless hash creation. 