### PR TITLE
 Add mexists method that allow to check the existance of multiple keys

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -559,6 +559,16 @@ class Redis
     end
   end
 
+  # Count existing keys.
+  #
+  # @param [Array<String>] key
+  # @return [Fixnum]
+  def mexists(*keys)
+    synchronize do |client|
+      client.call([:exists] + keys)
+    end
+  end
+
   # Find all keys matching the given pattern.
   #
   # @param [String] pattern

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -174,6 +174,14 @@ class Redis
       node_for(key).exists(key)
     end
 
+    # Count existing keys.
+    def mexists(*args)
+      keys_per_node = args.group_by { |key| node_for(key) }
+      keys_per_node.inject(0) do |sum, (node, keys)|
+        sum + node.mexists(*keys)
+      end
+    end
+
     # Find all keys matching the given pattern.
     def keys(glob = "*")
       on_each_node(:keys, glob).flatten

--- a/test/lint/value_types.rb
+++ b/test/lint/value_types.rb
@@ -10,6 +10,18 @@ module Lint
       assert_equal true,  r.exists("foo")
     end
 
+    def test_mexists
+      refute r.exists(["foo", "baz"])
+
+      r.set("foo", "s1")
+
+      assert_equal 1,  r.mexists(["foo", "baz"])
+
+      r.set("baz", "s2")
+
+      assert_equal 2,  r.mexists(["foo", "baz"])
+    end
+
     def test_type
       assert_equal "none", r.type("foo")
 


### PR DESCRIPTION
When calling `exists` with multiple keys, the return value depending on the arguments could be either a Boolean or an Integer.

This PR aims to fix that by creating a new method called `mexists` that accepts an array of keys

Example of `exists`

```ruby
redis.set("foo", "world")
=> "OK"
[3] pry(main)> redis.exists(['foo', 'foo2'])
=> true
[4] pry(main)> redis.exists(['foo3', 'foo2'])
=> false
[5] pry(main)> redis.exists(['foo', 'foo2'])
=> true
[6] pry(main)> redis.set('foo2', 'world')
=> "OK"
[7] pry(main)> redis.exists(['foo', 'foo2'])
=> 2
```

Example of `exists`

```ruby
redis.set("foo", "world")
=> "OK"
[3] pry(main)> redis.mexists(['foo', 'foo2'])
=> 1
[4] pry(main)> redis.exists(['foo3', 'foo2'])
=> 0
[5] pry(main)> redis.set('foo2', 'world')
=> "OK"
[7] pry(main)> redis.exists(['foo', 'foo2'])
=> 2
```



