### PR TITLE
Handle permanent node failure for redis cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ redis.mget('{key}1', '{key}2')
 ```
 
 * The client automatically reconnects after a failover occurred, but the caller is responsible for handling errors while it is happening.
+* The client support permanent node failures, and will reroute requests to promoted slaves.
 * The client supports `MOVED` and `ASK` redirections transparently.
 
 ## Storing objects

--- a/lib/redis/cluster.rb
+++ b/lib/redis/cluster.rb
@@ -69,12 +69,7 @@ class Redis
     end
 
     def call(command, &block)
-      begin
-        send_command(command, &block)
-      rescue CannotConnectError
-        update_cluster_info!
-        raise
-      end
+      send_command(command, &block)
     end
 
     def call_loop(command, timeout = 0, &block)
@@ -231,6 +226,9 @@ class Redis
       else
         raise
       end
+    rescue CannotConnectError
+      update_cluster_info!
+      raise
     end
 
     def assign_redirection_node(err_msg)

--- a/lib/redis/cluster.rb
+++ b/lib/redis/cluster.rb
@@ -71,9 +71,9 @@ class Redis
     def call(command, &block)
       begin
         send_command(command, &block)
-      rescue CannotConnectError => error
+      rescue CannotConnectError
         update_cluster_info!
-        raise error
+        raise
       end
     end
 

--- a/lib/redis/cluster.rb
+++ b/lib/redis/cluster.rb
@@ -69,7 +69,12 @@ class Redis
     end
 
     def call(command, &block)
-      send_command(command, &block)
+      begin
+        send_command(command, &block)
+      rescue CannotConnectError => error
+        update_cluster_info!
+        raise error
+      end
     end
 
     def call_loop(command, timeout = 0, &block)

--- a/test/cluster_abnormal_state_test.rb
+++ b/test/cluster_abnormal_state_test.rb
@@ -18,11 +18,11 @@ class TestClusterAbnormalState < Minitest::Test
 
   def test_the_state_of_cluster_failover
     redis_cluster_failover do
-      100.times do |i|
+      10.times do |i|
         assert_equal 'OK', r.set("key#{i}", i)
       end
 
-      100.times do |i|
+      10.times do |i|
         assert_equal i.to_s, r.get("key#{i}")
       end
 
@@ -36,11 +36,11 @@ class TestClusterAbnormalState < Minitest::Test
         r.set('key0', 0)
       end
 
-      100.times do |i|
+      10.times do |i|
         assert_equal 'OK', r.set("key#{i}", i)
       end
 
-      100.times do |i|
+      10.times do |i|
         assert_equal i.to_s, r.get("key#{i}")
       end
 

--- a/test/cluster_abnormal_state_test.rb
+++ b/test/cluster_abnormal_state_test.rb
@@ -30,6 +30,24 @@ class TestClusterAbnormalState < Minitest::Test
     end
   end
 
+  def test_the_state_of_cluster_node_failure
+    redis_cluster_fail_master do
+      assert_raises(Redis::CannotConnectError, 'Error connecting to Redis on 127.0.0.1:7002') do
+        r.set('key0', 0)
+      end
+
+      100.times do |i|
+        assert_equal 'OK', r.set("key#{i}", i)
+      end
+
+      100.times do |i|
+        assert_equal i.to_s, r.get("key#{i}")
+      end
+
+      assert_equal 'ok', redis.cluster(:info).fetch('cluster_state')
+    end
+  end
+
   def test_raising_error_when_nodes_are_not_cluster_mode
     assert_raises(Redis::CannotConnectError, 'Redis client could not connect to any cluster nodes') do
       build_another_client(cluster: %W[redis://127.0.0.1:#{PORT}])

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -356,6 +356,16 @@ module Helper
       trib.close
     end
 
+    def redis_cluster_fail_master
+      trib = ClusterOrchestrator.new(_default_nodes, timeout: TIMEOUT)
+      trib.fail_serving_master
+      yield
+    ensure
+      trib.restart_cluster_nodes
+      trib.rebuild
+      trib.close
+    end
+
     # @param slot [Integer]
     # @param src [String] <ip>:<port>
     # @param dest [String] <ip>:<port>

--- a/test/support/cluster/orchestrator.rb
+++ b/test/support/cluster/orchestrator.rb
@@ -18,7 +18,7 @@ class ClusterOrchestrator
   end
 
   def restart_cluster_nodes
-    system("make --no-print-directory start_cluster > /dev/null 2>&1")
+    system('make', '--no-print-directory', 'start_cluster', out: File::NULL, err: File::NULL)
   end
 
   def rebuild
@@ -43,8 +43,8 @@ class ClusterOrchestrator
   def fail_serving_master
     master, slave = take_replication_pairs(@clients)
     master.shutdown
-    max_attempts = 600
     attempt_count = 1
+    max_attempts = 200
     attempt_count.step(max_attempts) do |i|
       return if slave.role == 'master' || i >= max_attempts
       attempt_count += 1

--- a/test/support/cluster/orchestrator.rb
+++ b/test/support/cluster/orchestrator.rb
@@ -44,7 +44,7 @@ class ClusterOrchestrator
     master, slave = take_replication_pairs(@clients)
     master.shutdown
     attempt_count = 1
-    max_attempts = 200
+    max_attempts = 500
     attempt_count.step(max_attempts) do |i|
       return if slave.role == 'master' || i >= max_attempts
       attempt_count += 1


### PR DESCRIPTION
Currently, if a node fails permanently, the client will not recover even if an existing slave is promoted to replace the failed master. 
Only when the master rejoins the cluster (as a slave now) and responds with a `MOVED` response, will the client be able to serve requests again.

This PR refreshes the node-slot mapping on `CannotConnectError`, which will make the client route subsequent requests to the promoted slave of the failed master.

If `replica: true` is set, a new slave which replaces the old one will be able to serve requests. 