### PR TITLE
Raise FutureNotReady when trying to compare Redis::Future when the pipeline hasn't finsih executing

### DIFF
--- a/lib/redis/pipeline.rb
+++ b/lib/redis/pipeline.rb
@@ -129,6 +129,7 @@ class Redis
 
   class Future < BasicObject
     FutureNotReady = ::Redis::FutureNotReady.new
+    COMPARISON_METHODS = %i(== != >= <=)
 
     attr_reader :timeout
 
@@ -155,6 +156,12 @@ class Redis
     def value
       ::Kernel.raise(@object) if @object.kind_of?(::RuntimeError)
       @object
+    end
+
+    COMPARISON_METHODS.each do |method|
+      define_method(method) do |other|
+        value.send(method, other)
+      end
     end
 
     def is_a?(other)

--- a/test/pipelining_commands_test.rb
+++ b/test/pipelining_commands_test.rb
@@ -126,6 +126,32 @@ class TestPipeliningCommands < Minitest::Test
     end
   end
 
+  def test_futures_raise_when_trying_to_compare_their_values_too_early
+    r.pipelined do
+      assert_raises(Redis::FutureNotReady) do
+        r.sadd("foo", 1) == 1
+      end
+    end
+
+    r.pipelined do
+      assert_raises(Redis::FutureNotReady) do
+        r.sadd("foo", 1) != 1
+      end
+    end
+
+    r.pipelined do
+      assert_raises(Redis::FutureNotReady) do
+        r.sadd("foo", 1) <= 1
+      end
+    end
+
+    r.pipelined do
+      assert_raises(Redis::FutureNotReady) do
+        r.sadd("foo", 1) >= 1
+      end
+    end
+  end
+
   def test_futures_raise_when_command_errors_and_needs_transformation
     assert_raises(Redis::CommandError) do
       r.pipelined do


### PR DESCRIPTION
When opening a pipeline and trying to compare the value of the command we get different behaviour depending on the comparison method we use.

This is happening because `Redis::Future` inherit from [`BasicObject`](https://ruby-doc.org/core-2.5.0/BasicObject.htm)

Here is a little script that proves it [gist](https://gist.github.com/GustavoCaso/8305eef685725a02bb547e4e7e1f291e)

I think the solution would be to raise `FutureNotReady`  when trying to compare a `Redis::Future` that hasn't resolved yet