### PR TITLE
Deprecate ==  and != from Redis::Future

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -5,6 +5,10 @@ require_relative "redis/errors"
 
 class Redis
 
+  def self.deprecate(message, trace = caller[0])
+    $stderr.puts "\n#{message} (in #{trace})"
+  end
+
   def self.current
     @current ||= Redis.new
   end

--- a/lib/redis/pipeline.rb
+++ b/lib/redis/pipeline.rb
@@ -132,14 +132,18 @@ class Redis
 
     attr_reader :timeout
 
-    # Avoid allowing people to use == inside a pipelined
-    undef :==
-
     def initialize(command, transformation, timeout)
       @command = command
       @transformation = transformation
       @timeout = timeout
       @object = FutureNotReady
+    end
+
+    def ==(*)
+      message = "The method == and != is deprecated for Redis::Future and will be removed in 4.2.0"
+      message << " - You probably meant to call .value == or .value !="
+      ::Redis.deprecate(message)
+      super
     end
 
     def inspect

--- a/lib/redis/pipeline.rb
+++ b/lib/redis/pipeline.rb
@@ -132,6 +132,9 @@ class Redis
 
     attr_reader :timeout
 
+    # Avoid allowing people to use == inside a pipelined
+    undef :==
+
     def initialize(command, transformation, timeout)
       @command = command
       @transformation = transformation

--- a/test/pipelining_commands_test.rb
+++ b/test/pipelining_commands_test.rb
@@ -126,14 +126,6 @@ class TestPipeliningCommands < Minitest::Test
     end
   end
 
-  def test_futures_raise_when_trying_to_compare_their_value_too_early
-    r.pipelined do
-      assert_raises(NoMethodError) do
-        r.sadd("foo", 1) == 1
-      end
-    end
-  end
-
   def test_futures_raise_when_command_errors_and_needs_transformation
     assert_raises(Redis::CommandError) do
       r.pipelined do

--- a/test/pipelining_commands_test.rb
+++ b/test/pipelining_commands_test.rb
@@ -126,6 +126,14 @@ class TestPipeliningCommands < Minitest::Test
     end
   end
 
+  def test_futures_raise_when_trying_to_compare_their_value_too_early
+    r.pipelined do
+      assert_raises(NoMethodError) do
+        r.sadd("foo", 1) == 1
+      end
+    end
+  end
+
   def test_futures_raise_when_command_errors_and_needs_transformation
     assert_raises(Redis::CommandError) do
       r.pipelined do


### PR DESCRIPTION
For more information please check https://github.com/redis/redis-rb/pull/875

Most developers when using `==` after calling a redis command they expect to compare the result returned from Redis.

Inside a pipelined, we are operating with `Redis::Future` instances that are `BasicObject`

`BasicObject#==` is doing identity comparison instead of value comparison which is less intuitive for developers.

Example:

```ruby
result = nil

redis.pipelined do 
  result = redis.set('foo', 'bar') == "OK"
end

puts result 
# => false
```


By removing the ability to use `==` with a redis future developers would get NoMethodError and this helps to have more consistent errors when operating with `Redis::Future` inside a pipelined block