### PR TITLE
Retry once to many on `MOVED` error at cluster

### DIFF
--- a/lib/redis/cluster.rb
+++ b/lib/redis/cluster.rb
@@ -216,7 +216,10 @@ class Redis
       node.public_send(method_name, *args, &block)
     rescue CommandError => err
       if err.message.start_with?('MOVED')
-        assign_redirection_node(err.message).public_send(method_name, *args, &block)
+        raise if retry_count <= 0
+        node = assign_redirection_node(err.message)
+        retry_count -= 1
+        retry
       elsif err.message.start_with?('ASK')
         raise if retry_count <= 0
         node = assign_asking_node(err.message)


### PR DESCRIPTION
Fix for the cluster sending recursive MOVED error in very short time.

In my load test (N million times) I had the following behavior.
When I send SET, REM, SADD and SREM to redis cluster on AWS Elastic Cache Redis cluster, sometime  I detect a MOVED error on my code.
Maybe this is because redis slots/node mapping was updated in a very short time. Anyway, I changed retry once to many time on MOVED error and it solved the problem.