### PR TITLE
README.md: Disable reconnecting which doubles the duration until unsubscribe

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ All timeout values are specified in seconds.
 When using pub/sub, you can subscribe to a channel using a timeout as well:
 
 ```ruby
+redis = Redis.new(reconnect_attempts: 0)
 redis.subscribe_with_timeout(5, "news") do |on|
   on.message do |channel, message|
     # ...


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11504/72689823-983a8c00-3aca-11ea-82c8-1d1c3f56a810.png)

---

* Problem: In the "Timeouts" section in README, it says "If no message is
  received after 5 seconds, the client will unsubscribe." but it actually
  unsubscribes after 10 seconds. It's because by default reconnect_attempts is
  1 and the client tries subscribing for 5 seconds twice.
* Solution: Explicitly set reconnect_attempts to 0
    * This can be tricky for first time readers since the "Reconnections"
      section comes after this "Timeouts" section.
    * Alternative solution: change the description that it will unsubscribe
      after 10 seconds.