### PR TITLE
Fix Typo in Doc for redis#mget()

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -924,7 +924,7 @@ class Redis
   # Get the values of all the given keys.
   #
   # @example
-  #   redis.mget("key1", "key1")
+  #   redis.mget("key1", "key2")
   #     # => ["v1", "v2"]
   #
   # @param [Array<String>] keys


### PR DESCRIPTION
There seems to be typo in `lib/redis.rb:927` (see below). So I went ahead and corrected the args in the example method to `redis.mget("key1", "key2").

```ruby
# @example
#   redis.mget("key1", "key1")
#     # => ["v1", "v2"]
```