### PR TITLE
Enable GitHub Actions to run the tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,112 @@
+---
+name: Test
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+jobs:
+  main:
+    name: Main
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        os: ["ubuntu-latest"]
+        redis: ["5.0"]
+        ruby: ["2.7", "2.6", "2.5", "2.4"]
+        driver: ["ruby", "hiredis", "synchrony"]
+    runs-on: ${{ matrix.os }}
+    env:
+      VERBOSE: true
+      TIMEOUT: 30
+      LOW_TIMEOUT: 0.01
+      DRIVER: ${{ matrix.driver }}
+      REDIS_BRANCH: ${{ matrix.redis }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Print environment variables
+        run: |
+          echo "TIMEOUT=${TIMEOUT}"
+          echo "LOW_TIMEOUT=${LOW_TIMEOUT}"
+          echo "DRIVER=${DRIVER}"
+          echo "REDIS_BRANCH=${REDIS_BRANCH}"
+      - name: Set up Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Cache dependent gems
+        uses: actions/cache@v1
+        with:
+          path: .bundle
+          key: "local-bundle-ruby-${{ matrix.ruby }}-on-${{ matrix.os }}-0001"
+      - name: Set up Gems
+        run: |
+          gem update --system --no-document
+          gem install bundler --no-document
+          bundle install --jobs 4 --retry 3 --path=.bundle
+      - name: Cache local temporary directory
+        uses: actions/cache@v1
+        with:
+          path: tmp
+          key: "local-tmp-redis-${{ matrix.redis }}-on-${{ matrix.os }}"
+      - name: Booting up Redis
+        run: make start_all
+      - name: Test
+        run: make test
+        env:
+          RUBYOPT: "--enable-frozen-string-literal"
+      - name: Shutting down Redis
+        run: make stop_all
+  sub:
+    name: Sub
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        os: ["ubuntu-latest"]
+        redis: ["5.0", "4.0", "3.2", "3.0"]
+        ruby: ["jruby-9.2.9.0", "2.3"]
+        driver: ["ruby"]
+    runs-on: ${{ matrix.os }}
+    env:
+      VERBOSE: true
+      TIMEOUT: 30
+      LOW_TIMEOUT: 0.03
+      DRIVER: ${{ matrix.driver }}
+      REDIS_BRANCH: ${{ matrix.redis }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Print environment variables
+        run: |
+          echo "TIMEOUT=${TIMEOUT}"
+          echo "LOW_TIMEOUT=${LOW_TIMEOUT}"
+          echo "DRIVER=${DRIVER}"
+          echo "REDIS_BRANCH=${REDIS_BRANCH}"
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Cache dependent gems
+        uses: actions/cache@v1
+        with:
+          path: .bundle
+          key: "local-bundle-ruby-${{ matrix.ruby }}-on-${{ matrix.os }}-0001"
+      - name: Set up Gems
+        run: |
+          gem update --system --no-document
+          gem install bundler --no-document
+          bundle install --jobs 4 --retry 3 --path=.bundle
+      - name: Cache local temporary directory
+        uses: actions/cache@v1
+        with:
+          path: tmp
+          key: "local-tmp-redis-${{ matrix.redis }}-on-${{ matrix.os }}"
+      - name: Booting up Redis
+        run: make start_all
+      - name: Test
+        run: make test
+      - name: Shutting down Redis
+        run: make stop_all

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# redis-rb [![Build Status][travis-image]][travis-link] [![Inline docs][inchpages-image]][inchpages-link]
+# redis-rb [![Build Status][travis-image]][travis-link] [![Inline docs][inchpages-image]][inchpages-link] ![](https://github.com/redis/redis-rb/workflows/Test/badge.svg?branch=master)
 
 A Ruby client that tries to match [Redis][redis-home]' API one-to-one, while still
 providing an idiomatic interface.


### PR DESCRIPTION
Hello,

This pull-request is a proposal. It is faster than current CI. Why don't we try to use it for a while?

| CI | concurrent jobs | approximately elapsed time |
| --- | ---: | ---: |
| current | 3 | 20min|
| GitHub Actions | 20 | 5min |

Result samples:
https://github.com/supercaracal/redis-rb/actions

Additionally, I think it will be easier to pull request because GitHub Actions are run each contributor's forked repository too.

I divided the workflow into two jobs. The differences between main and sub job are here.

```diff
@@ -14,14 +14,14 @@
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        redis: ["5.0"]
-        ruby: ["2.7", "2.6", "2.5", "2.4"]
-        driver: ["ruby", "hiredis", "synchrony"]
+        redis: ["5.0", "4.0", "3.2", "3.0"]
+        ruby: ["jruby-9.2.9.0", "2.3"]
+        driver: ["ruby"]
     runs-on: ${{ matrix.os }}
     env:
       VERBOSE: true
       TIMEOUT: 30
-      LOW_TIMEOUT: 0.01
+      LOW_TIMEOUT: 0.03
       DRIVER: ${{ matrix.driver }}
       REDIS_BRANCH: ${{ matrix.redis }}
     steps:
@@ -34,7 +34,7 @@
           echo "DRIVER=${DRIVER}"
           echo "REDIS_BRANCH=${REDIS_BRANCH}"
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Cache dependent gems
@@ -56,7 +56,5 @@
         run: make start_all
       - name: Test
         run: make test
-        env:
-          RUBYOPT: "--enable-frozen-string-literal"
       - name: Shutting down Redis
         run: make stop_all
```