### PR TITLE
Extend SlotLoader to work with multiple slot ranges

### DIFF
--- a/lib/redis/cluster/slot.rb
+++ b/lib/redis/cluster/slot.rb
@@ -50,9 +50,12 @@ class Redis
         @node_flags[node_key] == ROLE_SLAVE
       end
 
+      # available_slots is mapping of node_key to list of slot ranges
       def build_slot_node_key_map(available_slots)
-        available_slots.each_with_object({}) do |(node_key, slots), acc|
-          slots.each { |slot| assign_node_key(acc, slot, node_key) }
+        available_slots.each_with_object({}) do |(node_key, slots_arr), acc|
+          slots_arr.each do |slots|
+            slots.each { |slot| assign_node_key(acc, slot, node_key) }
+          end
         end
       end
 

--- a/test/cluster_client_slots_test.rb
+++ b/test/cluster_client_slots_test.rb
@@ -7,7 +7,7 @@ class TestClusterClientSlots < Minitest::Test
   include Helper::Cluster
 
   def test_slot_class
-    slot = Redis::Cluster::Slot.new('127.0.0.1:7000' => 1..10)
+    slot = Redis::Cluster::Slot.new('127.0.0.1:7000' => [1..10])
 
     assert_equal false, slot.exists?(0)
     assert_equal true, slot.exists?(1)
@@ -26,8 +26,36 @@ class TestClusterClientSlots < Minitest::Test
     assert_nil slot.put(1, '127.0.0.1:7001')
   end
 
+  def test_slot_class_with_multiple_slot_ranges
+    slot = Redis::Cluster::Slot.new('127.0.0.1:7000' => [1..10, 30..40])
+
+    assert_equal false, slot.exists?(0)
+    assert_equal true, slot.exists?(1)
+    assert_equal true, slot.exists?(10)
+    assert_equal false, slot.exists?(11)
+    assert_equal true, slot.exists?(30)
+    assert_equal true, slot.exists?(40)
+    assert_equal false, slot.exists?(41)
+
+    assert_nil slot.find_node_key_of_master(0)
+    assert_nil slot.find_node_key_of_slave(0)
+    assert_equal '127.0.0.1:7000', slot.find_node_key_of_master(1)
+    assert_equal '127.0.0.1:7000', slot.find_node_key_of_slave(1)
+    assert_equal '127.0.0.1:7000', slot.find_node_key_of_master(10)
+    assert_equal '127.0.0.1:7000', slot.find_node_key_of_slave(10)
+    assert_equal '127.0.0.1:7000', slot.find_node_key_of_slave(30)
+    assert_equal '127.0.0.1:7000', slot.find_node_key_of_slave(40)
+    assert_nil slot.find_node_key_of_master(11)
+    assert_nil slot.find_node_key_of_slave(11)
+    assert_nil slot.find_node_key_of_master(41)
+    assert_nil slot.find_node_key_of_slave(41)
+
+    assert_nil slot.put(1, '127.0.0.1:7001')
+    assert_nil slot.put(30, '127.0.0.1:7001')
+  end
+
   def test_slot_class_with_node_flags_and_replicas
-    slot = Redis::Cluster::Slot.new({ '127.0.0.1:7000' => 1..10, '127.0.0.1:7001' => 1..10 },
+    slot = Redis::Cluster::Slot.new({ '127.0.0.1:7000' => [1..10], '127.0.0.1:7001' => [1..10] },
                                     { '127.0.0.1:7000' => 'master', '127.0.0.1:7001' => 'slave' },
                                     true)
 
@@ -48,8 +76,36 @@ class TestClusterClientSlots < Minitest::Test
     assert_nil slot.put(1, '127.0.0.1:7002')
   end
 
+  def test_slot_class_with_node_flags_replicas_and_slot_range
+    slot = Redis::Cluster::Slot.new({ '127.0.0.1:7000' => [1..10, 30..40], '127.0.0.1:7001' => [1..10, 30..40] },
+                                    { '127.0.0.1:7000' => 'master', '127.0.0.1:7001' => 'slave' },
+                                    true)
+
+    assert_equal false, slot.exists?(0)
+    assert_equal true, slot.exists?(1)
+    assert_equal true, slot.exists?(10)
+    assert_equal false, slot.exists?(11)
+    assert_equal true, slot.exists?(30)
+    assert_equal false, slot.exists?(41)
+
+    assert_nil slot.find_node_key_of_master(0)
+    assert_nil slot.find_node_key_of_slave(0)
+    assert_equal '127.0.0.1:7000', slot.find_node_key_of_master(1)
+    assert_equal '127.0.0.1:7001', slot.find_node_key_of_slave(1)
+    assert_equal '127.0.0.1:7000', slot.find_node_key_of_master(10)
+    assert_equal '127.0.0.1:7001', slot.find_node_key_of_slave(10)
+    assert_nil slot.find_node_key_of_master(11)
+    assert_nil slot.find_node_key_of_slave(11)
+    assert_equal '127.0.0.1:7000', slot.find_node_key_of_master(30)
+    assert_equal '127.0.0.1:7001', slot.find_node_key_of_slave(30)
+    assert_nil slot.find_node_key_of_master(41)
+    assert_nil slot.find_node_key_of_slave(41)
+
+    assert_nil slot.put(1, '127.0.0.1:7002')
+  end
+
   def test_slot_class_with_node_flags_and_without_replicas
-    slot = Redis::Cluster::Slot.new({ '127.0.0.1:7000' => 1..10, '127.0.0.1:7001' => 1..10 },
+    slot = Redis::Cluster::Slot.new({ '127.0.0.1:7000' => [1..10], '127.0.0.1:7001' => [1..10] },
                                     { '127.0.0.1:7000' => 'master', '127.0.0.1:7001' => 'slave' },
                                     false)
 


### PR DESCRIPTION
With multiple resharding, different slot ranges can be assigned to a
node. 
e.g. 
<img width="864" alt="Screenshot 2020-03-22 02 23 01" src="https://user-images.githubusercontent.com/1185955/77246406-1a871f80-6be4-11ea-991f-d2d2c5f0169d.png">

Current logic only preassigns the last slot range, causing errors & retries for unassigned slots. 
This commit makes it work with multiple slot ranges and assigning all slots.

I tested this locally, but couldn't figure how to add tests for this scenario.
**edit**: Added partial tests.