### PR TITLE
Fix unstable test cases

### DIFF
--- a/test/distributed_remote_server_control_commands_test.rb
+++ b/test/distributed_remote_server_control_commands_test.rb
@@ -28,11 +28,13 @@ class TestDistributedRemoteServerControlCommands < Minitest::Test
 
   def test_info_commandstats
     target_version "2.5.7" do
-      r.nodes.each { |n| n.config(:resetstat) }
-      r.ping # Executed on every node
+      r.nodes.each do |n|
+        n.config(:resetstat)
+        n.config(:get, :port)
+      end
 
       r.info(:commandstats).each do |info|
-        assert_equal "1", info["ping"]["calls"]
+        assert_equal '2', info['config']['calls'] # CONFIG RESETSTAT + CONFIG GET = twice
       end
     end
   end

--- a/test/remote_server_control_commands_test.rb
+++ b/test/remote_server_control_commands_test.rb
@@ -27,10 +27,10 @@ class TestRemoteServerControlCommands < Minitest::Test
   def test_info_commandstats
     target_version "2.5.7" do
       r.config(:resetstat)
-      r.ping
+      r.config(:get, :port)
 
       result = r.info(:commandstats)
-      assert_equal "1", result["ping"]["calls"]
+      assert_equal '2', result['config']['calls']
     end
   end
 


### PR DESCRIPTION
The following test case have been becoming unstable since I added several replica and Sentinel nodes for test. (ref: #816 #895)

https://github.com/redis/redis-rb/blob/7127f3b1cb3b6b0088b208f583a2611a21b171ac/test/distributed_remote_server_control_commands_test.rb#L29-L38

Sentinels keep pinging to the node for monitoring. So the stats was unintentionally incremented. I modified as not using PING stats.

```
irb(main):032:0> r.info(:commandstats).keys
=> ["publish", "ping", "info", "replconf", "config"]
```

```
irb(main):033:0> r.info(:commandstats)['ping']
=> {"calls"=>"51", "usec"=>"109", "usec_per_call"=>"2.14"}

irb(main):034:0> r.info(:commandstats)['ping']
=> {"calls"=>"56", "usec"=>"116", "usec_per_call"=>"2.07"}

irb(main):035:0> r.info(:commandstats)['ping']
=> {"calls"=>"63", "usec"=>"127", "usec_per_call"=>"2.02"}
```

```
irb(main):057:0> r.config :resetstat
=> "OK"

irb(main):058:0> r.info(:commandstats)['config']
=> {"calls"=>"1", "usec"=>"18", "usec_per_call"=>"18.00"}

irb(main):059:0> r.info(:commandstats)['config']
=> {"calls"=>"1", "usec"=>"18", "usec_per_call"=>"18.00"}

irb(main):060:0> r.config :get, 'port'
=> {"port"=>"6381"}

irb(main):061:0> r.info(:commandstats)['config']
=> {"calls"=>"2", "usec"=>"46", "usec_per_call"=>"23.00"}
```