### PR TITLE
fix: do not allocate empty string

### DIFF
--- a/lib/redis/connection/command_helper.rb
+++ b/lib/redis/connection/command_helper.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
 class Redis
   module Connection
     module CommandHelper
 
-      COMMAND_DELIMITER = "\r\n"
+      COMMAND_DELIMITER = "\r\n".freeze
+      TRAILING_DELIMITER = "".freeze
 
       def build_command(args)
         command = [nil]
@@ -24,7 +26,7 @@ class Redis
         command[0] = "*#{(command.length - 1) / 2}"
 
         # Trailing delimiter
-        command << ""
+        command << TRAILING_DELIMITER
         command.join(COMMAND_DELIMITER)
       end
 


### PR DESCRIPTION
Hello!

Here is my report:

Before:
```
Allocated String Report
-----------------------------------
    268824  ""
     38906  /bundle/2.2-0.9.0/gems/redis-4.1.3/lib/redis/connection/command_helper.rb:27
````

After my change:
```
Allocated String Report
-----------------------------------
    229421  ""
     77740  /localgems/redis-rb/lib/redis/connection/ruby.rb:43
     38906  /localgems/redis-rb/lib/redis/connection/ruby.rb:396
     38906  /localgems/redis-rb/lib/redis/connection/ruby.rb:59
```

As shown above difference is 39403 empty strings )