### PR TITLE
Fix TLS connections not verified by default

### DIFF
--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -263,7 +263,9 @@ class Redis
           tcp_sock = TCPSocket.connect(host, port, timeout)
 
           ctx = OpenSSL::SSL::SSLContext.new
-          ctx.set_params(ssl_params) if ssl_params && !ssl_params.empty?
+
+          # The provided parameters are merged into OpenSSL::SSL::SSLContext::DEFAULT_PARAMS
+          ctx.set_params(ssl_params || {})
 
           ssl_sock = new(tcp_sock, ctx)
           ssl_sock.hostname = host

--- a/test/ssl_test.rb
+++ b/test/ssl_test.rb
@@ -30,6 +30,15 @@ class SslTest < Minitest::Test
       end
     end
 
+    def test_verify_certificates_by_default
+      assert_raises(OpenSSL::SSL::SSLError) do
+        RedisMock.start({ :ping => proc { "+PONG" } }, ssl_server_opts("untrusted")) do |port|
+          redis = Redis.new(:port => port, :ssl => true)
+          redis.ping
+        end
+      end
+    end
+
     def test_ssl_blocking
       RedisMock.start({}, ssl_server_opts("trusted")) do |port|
         redis = Redis.new(:port => port, :ssl => true, :ssl_params => { :ca_file => ssl_ca_file })


### PR DESCRIPTION
If you specify an SSL URL for your client but do not specify some values in `ssl_params`, you'll end up with a connection that does not actually verify the certificate. This is surprising: usually network clients using TLS would use VERIFY_PEER with a system certificate store. This probably went undetected because domain verification still happens by default - it's just the certificate chain that is skipped.

`SSLContext#set_params` is the step in SSL connection establishment that
merges user-provided SSL parameters with "saner defaults".

Previously `SSLContext#set_params` was only being called when
`ssl_params` was provided to the SSLConnection, so the SSLContexet was
left unconfigured. This leads to the surprising default `verify_mode` of
`nil`, resulting in SSL connections verifying hostnames but never
verifying certificate trust.