### PR TITLE
Alias the disconnect method as close

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -250,6 +250,7 @@ class Redis
     def disconnect
       connection.disconnect if connected?
     end
+    alias_method :close, :disconnect
 
     def reconnect
       disconnect


### PR DESCRIPTION
The connection_pool gem is implementing  automatic reaping of idle connections. In order to do this generically, clients need to provide a `close` method that the pool can call on reaped connections in order to close the network connection cleanly.

mysql2 and dalli already provide `close`. This PR adds this convention to redis-rb.