### PR TITLE
Increase timeout value for unstable test cases which use blocking command with JRuby.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,7 +73,7 @@ jobs:
     env:
       VERBOSE: true
       TIMEOUT: 30
-      LOW_TIMEOUT: 0.03
+      LOW_TIMEOUT: 0.07
       DRIVER: ${{ matrix.driver }}
       REDIS_BRANCH: ${{ matrix.redis }}
     steps:


### PR DESCRIPTION
Hello,

It looks like the following CI failures are lately occurred.

```
TestDistributedBlockingCommands#test_blpop_timeout:
Redis::TimeoutError: Connection timed out
   /home/runner/work/redis-rb/redis-rb/test/lint/blocking_commands.rb:65:in `test_blpop_timeout'

TestDistributedBlockingCommands#test_brpoplpush_timeout_with_old_prototype:
Redis::TimeoutError: Connection timed out
    /home/runner/work/redis-rb/redis-rb/test/lint/blocking_commands.rb:147:in `test_brpoplpush_timeout_with_old_prototype'
```

It seems that it tends to raise `Redis::TimeoutError` when matrix test is JRuby.

It doesn't add up why the failures were only occurred on GitHub Actions, but I think that increasing timeout is worth a shot.