### PR TITLE
Drop old IRC link from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ client and evangelized Redis in Rubyland. Thank you, Ezra.
 ## Contributing
 
 [Fork the project](https://github.com/redis/redis-rb) and send pull
-requests. You can also ask for help at `#redis-rb` on Freenode.
+requests.
 
 
 [inchpages-image]: https://inch-ci.org/github/redis/redis-rb.svg


### PR DESCRIPTION
#redis-rb on Freenode is unmoderated+empty, does not seem to be a good place for help.