### PR TITLE
Provide `on_disconnect` hook for connectors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* `Redis::Client#disconnect` provides a `on_disconnect` connector hook.
+
 # 4.1.4
 
 * Alias `Redis#disconnect` as `#close`. See #901.

--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -248,7 +248,11 @@ class Redis
     end
 
     def disconnect
-      connection.disconnect if connected?
+      if connected?
+        result = connection.disconnect
+        @connector.on_disconnect(self)
+        result
+      end
     end
     alias_method :close, :disconnect
 
@@ -530,6 +534,9 @@ class Redis
       end
 
       def check(client)
+      end
+
+      def on_disconnect(client)
       end
 
       class Sentinel < Connector

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -173,8 +173,11 @@ module Helper
   end
 
   module Client
-
     include Generic
+
+    def new_client(options = {})
+      _new_client(options)
+    end
 
     private
 


### PR DESCRIPTION
When a [custom connector](https://github.com/redis/redis-rb/blob/f597f21a6b954b685cf939febbc638f6c803e3a7/lib/redis/client.rb#L94-L95) is provided, it has access to the client instance on connect by overriding the `Connector#check` instance method. In certain cases, knowing when a client has disconnected can also be useful. In particular, I'm building out a custom failover connector such that it `Connector#resolve` to the replica Redis config if it fails to connect to the master Redis server. As part of my connector, I'm keeping track of all Redis clients that are connected so that I can disconnect them when the master Redis server is back up. Disconnecting Redis clients will result in the [Redis client reconnecting](https://github.com/redis/redis-rb/blob/f597f21a6b954b685cf939febbc638f6c803e3a7/lib/redis/client.rb#L231) the next time it has to process a command. As I'm keeping track all Redis clients, I need a way to not track those clients once they have been disconnected so that the client object can be GC-ed. 