### PR TITLE
Implement variadic hset and mapped_hset

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -2101,16 +2101,36 @@ class Redis
     end
   end
 
-  # Set the string value of a hash field.
+  # Set one or more hash values.
+  #
+  # @example
+  #   redis.hset("hash", "f1", "v1", "f2", "v2")
+  #     # => 2
   #
   # @param [String] key
-  # @param [String] field
-  # @param [String] value
-  # @return [Boolean] whether or not the field was **added** to the hash
-  def hset(key, field, value)
+  # @param [Array<String>] attrs array of fields and values
+  # @return [Integer] The number of fields that were added to the hash
+  #
+  # @see #mapped_hset
+  def hset(key, *attrs)
     synchronize do |client|
-      client.call([:hset, key, field, value], &Boolify)
+      client.call([:hset, key, *attrs])
     end
+  end
+
+  # Set one or more hash values.
+  #
+  # @example
+  #   redis.mapped_hset("hash", { "f1" => "v1", "f2" => "v2" })
+  #     # => 2
+  #
+  # @param [String] key
+  # @param [Hash] hash a non-empty hash with fields mapping to values
+  # @return [Integer] The number of fields that were added to the hash
+  #
+  # @see #hset
+  def mapped_hset(key, hash)
+    hset(key, hash.to_a.flatten)
   end
 
   # Set the value of a hash field, only if the field does not exist.

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -669,9 +669,13 @@ class Redis
       node_for(key).hlen(key)
     end
 
-    # Set the string value of a hash field.
-    def hset(key, field, value)
-      node_for(key).hset(key, field, value)
+    # Set multiple hash fields to multiple values.
+    def hset(key, *attrs)
+      node_for(key).hset(key, *attrs)
+    end
+
+    def mapped_hset(key, hash)
+      node_for(key).hset(key, *hash.to_a.flatten)
     end
 
     # Set the value of a hash field, only if the field does not exist.

--- a/test/lint/hashes.rb
+++ b/test/lint/hashes.rb
@@ -4,9 +4,27 @@ module Lint
   module Hashes
 
     def test_hset_and_hget
-      r.hset("foo", "f1", "s1")
+      assert_equal 1, r.hset("foo", "f1", "s1")
 
       assert_equal "s1", r.hget("foo", "f1")
+    end
+
+    def test_variadic_hset
+      target_version "4.0.0" do
+        assert_equal 2, r.hset("foo", "f1", "s1", "f2", "s2")
+
+        assert_equal "s1", r.hget("foo", "f1")
+        assert_equal "s2", r.hget("foo", "f2")
+      end
+    end
+
+    def test_mapped_hset
+      target_version "4.0.0" do
+        assert_equal 2, r.mapped_hset("foo", :f1 => "s1", :f2 => "s2")
+
+        assert_equal "s1", r.hget("foo", "f1")
+        assert_equal "s2", r.hget("foo", "f2")
+      end
     end
 
     def test_hsetnx


### PR DESCRIPTION
Because `HMSET` is deprecated and `HSET` is variadic, I added support variadic parameters to `hset`, and added `mapped_hset` for convenience