### PR TITLE
Support multiple keys for `Redis#exists`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+  * Support multiple keys for `Redis#exists`. See #911.
+
 # 4.1.4
 
 * Alias `Redis#disconnect` as `#close`. See #901.

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -550,13 +550,15 @@ class Redis
     end
   end
 
-  # Determine if a key exists.
+  # Determine if one or more keys exists.
   #
-  # @param [String] key
+  # @param [String, Array<String>] key
   # @return [Boolean]
-  def exists(key)
+  def exists(*keys)
     synchronize do |client|
-      client.call([:exists, key], &Boolify)
+      client.call([:exists, *keys]) do |value|
+        value > 0
+      end
     end
   end
 

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -170,9 +170,24 @@ class Redis
       end
     end
 
-    # Determine if a key exists.
-    def exists(key)
-      node_for(key).exists(key)
+    # Determine if one or more keys exists
+    def exists(*keys)
+      if keys.length == 1
+        key = keys[0]
+        node_for(key).exists(key)
+      else
+        nodes = {}
+
+        keys.each do |key|
+          node = node_for(key)
+          nodes[node] ||= []
+          nodes[node] << key
+        end
+
+        nodes.any? do |node, keys|
+          node.exists(keys)
+        end
+      end
     end
 
     # Find all keys matching the given pattern.

--- a/makefile
+++ b/makefile
@@ -34,7 +34,7 @@ ${TMP}:
 ${BINARY}: ${TMP}
 	@bin/build ${REDIS_BRANCH} $<
 
-test: 
+test:
 	@env SOCKET_PATH=${SOCKET_PATH} bundle exec rake test
 
 stop:

--- a/test/commands_on_value_types_test.rb
+++ b/test/commands_on_value_types_test.rb
@@ -220,4 +220,21 @@ class TestCommandsOnValueTypes < Minitest::Test
       assert_equal expected, actual
     end
   end
+
+  def test_exists_with_multiple_arguements
+    target_version "3.0.3" do
+      assert_equal false, r.exists("foo")
+
+      r.set("foo", "s1")
+
+      assert_equal true,  r.exists("foo")
+      assert_equal true, r.exists("foo", "foo2")
+
+      r.set("foo2", "s1")
+
+      assert_equal true, r.exists("foo", "foo2")
+      assert_equal true, r.exists("foo", "foo2", "foo3")
+      assert_equal false, r.exists("foo3", "foo4")
+    end
+  end
 end

--- a/test/distributed_commands_on_value_types_test.rb
+++ b/test/distributed_commands_on_value_types_test.rb
@@ -127,4 +127,21 @@ class TestDistributedCommandsOnValueTypes < Minitest::Test
       r.migrate("foo", {})
     end
   end
+
+  def test_exists_with_multiple_arguements
+    target_version "3.0.3" do
+      assert_equal false, r.exists("foo")
+
+      r.set("foo", "s1")
+
+      assert_equal true,  r.exists("foo")
+      assert_equal true, r.exists("foo", "foo2")
+
+      r.set("foo2", "s1")
+
+      assert_equal true, r.exists("foo", "foo2")
+      assert_equal true, r.exists("foo", "foo2", "foo3")
+      assert_equal false, r.exists("foo3", "foo4")
+    end
+  end
 end


### PR DESCRIPTION
Since Redis 3.0.3, exists supports multiple keys and would return a
count of the keys that exists.