### PR TITLE
Optimized initialization of Redis::Cluster

### DIFF
--- a/benchmarking/cluster_slot.rb
+++ b/benchmarking/cluster_slot.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'redis'
+require 'benchmark'
+
+N = (ARGV.first || 100000).to_i
+
+available_slots = {
+  "127.0.0.1:7000" => [0..5460],
+  "127.0.0.1:7003" => [0..5460],
+  "127.0.0.1:7001" => [5461..10922],
+  "127.0.0.1:7004" => [5461..10922],
+  "127.0.0.1:7002" => [10923..16383],
+  "127.0.0.1:7005" => [10923..16383]
+}
+
+node_flags = {
+  "127.0.0.1:7000" => "master",
+  "127.0.0.1:7002" => "master",
+  "127.0.0.1:7001" => "master",
+  "127.0.0.1:7005" => "slave",
+  "127.0.0.1:7004" => "slave",
+  "127.0.0.1:7003" => "slave"
+}
+
+Benchmark.bmbm do |bm|
+  bm.report('Slot.new') do
+    allocs = GC.stat(:total_allocated_objects)
+
+    N.times do
+      Redis::Cluster::Slot.new(available_slots, node_flags, false)
+    end
+
+    puts GC.stat(:total_allocated_objects) - allocs
+  end
+end


### PR DESCRIPTION
We were noticing that initializing a Redis Cluster client was fairly slow, and after a coworker dug into it, it turned out to come primarily from `build_slot_node_key_map`. Since the current implementation does heavy amount of allocation/work, when you consider that each node in a cluster has the slots iterated over, which leads to about 16,384 iterations * nodes.

Using the redis-rb cluster configuration as an example, it takes about 17ms to initialize and 49k objects, we saw significantly higher in production, but we're also running a lot more nodes. The PR gets it down to about ~1.5ms and 9 allocations.

The optimization works by building up the primary/secondary node configuration off of `slots_arr` instead. My understanding, is secondaries are always mirroring the slot configuration of a primary, so this trick is fine.

After we have that, we simply load up the slot configuration by adding our existing hash, which ensures we don't have to allocate a new object for every single slot. When we call `put` (from `MOVED`), we duplicate the map to ensure only that slot is changed.

I dropped the use of `Set`, since Ruby sets are inefficient as they're just wrappers around hashes, and the number of secondaries is sufficiently low enough that checking `include?` is not the end of the world.

It also means that you no longer have to call `to_a` each time you call `find_node_key_of_slave`. If you somehow had a configuration where you had tens of thousands of secondaries, your `find_node_key_of_slave` call would be slow anyway, and now only your initialization is slow.

Let me know if I'm misunderstanding about the Redis Cluster setup that makes this not work though.

My understanding is the existing Redis tests should cover this, and so it doesn't need additional tests, but happy to add something if you want.