### PR TITLE
Support KEEPTTL option in SET command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Increase buffer size in the ruby connector. See #880.
 * Fix thread safety of `Redis.queue`. See #878.
 * Deprecate `Redis::Future#==` as it's likely to be a mistake. See #876.
+* Support `KEEPTTL` option for SET command. See #913.
 
 # 4.1.3
 

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -786,6 +786,7 @@ class Redis
   #   - `:px => Integer`: Set the specified expire time, in milliseconds.
   #   - `:nx => true`: Only set the key if it does not already exist.
   #   - `:xx => true`: Only set the key if it already exist.
+  #   - `:keepttl => true`: Retain the time to live associated with the key.
   # @return [String, Boolean] `"OK"` or true, false if `:nx => true` or `:xx => true`
   def set(key, value, options = {})
     args = []
@@ -801,6 +802,9 @@ class Redis
 
     xx = options[:xx]
     args.concat(["XX"]) if xx
+
+    keepttl = options[:keepttl]
+    args.concat(["KEEPTTL"]) if keepttl
 
     synchronize do |client|
       if nx || xx

--- a/test/lint/strings.rb
+++ b/test/lint/strings.rb
@@ -74,6 +74,15 @@ module Lint
       end
     end
 
+    def test_set_with_keepttl
+      target_version "6.0.0" do
+        r.set("foo", "qux", :ex => 2)
+        assert_in_range 0..2, r.ttl("foo")
+        r.set("foo", "bar", :keepttl => true)
+        assert_in_range 0..2, r.ttl("foo")
+      end
+    end
+
     def test_setex
       assert r.setex("foo", 1, "bar")
       assert_equal "bar", r.get("foo")


### PR DESCRIPTION
This option was added in Redis 6.0.0. See https://redis.io/commands/set for documentation.