### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/redis.gemspec
+++ b/redis.gemspec
@@ -32,6 +32,14 @@ Gem::Specification.new do |s|
 
   s.email = ["redis-db@googlegroups.com"]
 
+  s.metadata = {
+    "bug_tracker_uri" => "#{s.homepage}/issues",
+    "changelog_uri" => "#{s.homepage}/blob/master/CHANGELOG.md",
+    "documentation_uri" => "https://www.rubydoc.info/gems/redis/#{s.version}",
+    "homepage_uri" => s.homepage,
+    "source_code_uri" => "#{s.homepage}/tree/v#{s.version}"
+  }
+
   s.files         = Dir["CHANGELOG.md", "LICENSE", "README.md", "lib/**/*"]
   s.executables   = `git ls-files -- exe/*`.split("\n").map { |f| File.basename(f) }
 


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `homepage_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/redis), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.