### PR TITLE
Fix `Redis#exists?` to return boolean value for multiple key match.

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -584,7 +584,9 @@ class Redis
   # @return [Boolean]
   def exists?(*keys)
     synchronize do |client|
-      client.call([:exists, *keys], &Boolify)
+      client.call([:exists, *keys]) do |value|
+        value > 0
+      end
     end
   end
 

--- a/test/lint/value_types.rb
+++ b/test/lint/value_types.rb
@@ -40,6 +40,10 @@ module Lint
       r.set("{1}foo", "s1")
 
       assert_equal true, r.exists?("{1}foo")
+
+      r.set("{1}bar", "s1")
+
+      assert_equal true, r.exists?("{1}foo", "{1}bar")
     end
 
     def test_type


### PR DESCRIPTION
```
$ bin/console
irb(main):001:0> redis = Redis.new
irb(main):002:0> redis.exists?("test", "test5", "test2")
=> 2
```