### PR TITLE
Add ability to silence `exists` warning message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Setting `Redis.exists_returns_integer = false` disables warning message about new behaviour.
+
 # 4.2.0
 
 * Convert commands to accept keyword arguments rather than option hashes. This both help catching typos, and reduce needless allocations.


### PR DESCRIPTION
Related to #698.

The warning message can be disabled by setting `exists_returns_integer` to `false`.  You will receive a single warning message when this is set.