### PR TITLE
Add `Redis#hset` change to the 4.2.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Optimized initialization of Redis::Cluster. See #912.
 * Accept sentinel options even with string key. See #599.
 * Verify TLS connections by default. See #900.
+* Make `Redis#hset` variadic. It now returns an integer, not a boolean. See #910.
 
 # 4.1.4
 


### PR DESCRIPTION
Since https://github.com/redis/redis-rb/commit/ad7191f3a1ff8170bac6f61555ec8cf67fca4047, `Redis#hset` now returns an integer indicating the number of fields added to the hash. Previously, it would return a boolean. 

This PR adds this change of behaviour to the 4.2.0 changelog.