### PR TITLE
Use the exception: false API of read/write nonblock

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,6 +57,9 @@ Style/ParallelAssignment:
 Style/NumericPredicate:
   Enabled: false
 
+Style/IfUnlessModifier:
+  Enabled: false
+
 Style/SignalException:
   Exclude:
     - 'lib/redis/connection/synchrony.rb'

--- a/test/internals_test.rb
+++ b/test/internals_test.rb
@@ -244,7 +244,7 @@ class TestInternals < Minitest::Test
       else
         raise "Expected SELECT"
       end
-      unless seq.include?(n) # rubocop:disable Style/IfUnlessModifier
+      unless seq.include?(n)
         session.write("+#{n}\r\n") while read_command.call(session)
       end
     end


### PR DESCRIPTION
Should be a nice optimization, just need to make sure it doesn't break anything (`Errno::EAGAIN` ,`Errno::EWOULDBLOCK` in connect is fishy).