### PR TITLE
Handle empty stream responses

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -3423,7 +3423,12 @@ class Redis
     end
   }
 
+  EMPTY_STREAM_RESPONSE = [nil].freeze
+  private_constant :EMPTY_STREAM_RESPONSE
+
   HashifyStreamEntries = lambda { |reply|
+    return [] if reply == EMPTY_STREAM_RESPONSE
+
     reply.map do |entry_id, values|
       [entry_id, values.each_slice(2).to_h]
     end


### PR DESCRIPTION
Fix: #905
Ref: #906

See [the provided repro script](https://github.com/redis/redis-rb/issues/905#issuecomment-646537386) I wasn't able to convert it into a test case as this empty response is only returned 


```ruby
call: redis.xgroup(:create, "58h4o7g", "a", "$", {:mkstream=>true})
done: redis.xgroup(:create, "58h4o7g", "a", "$", {:mkstream=>true})
call: redis.xadd("58h4o7g", {:test=>"0"})
done: redis.xadd("58h4o7g", {:test=>"0"})
call: redis.xadd("58h4o7g", {:test=>"1"})
done: redis.xadd("58h4o7g", {:test=>"1"})
call: redis.xadd("58h4o7g", {:test=>"2"})
done: redis.xadd("58h4o7g", {:test=>"2"})
call: redis.xadd("58h4o7g", {:test=>"3"})
done: redis.xadd("58h4o7g", {:test=>"3"})
call: redis.xadd("58h4o7g", {:test=>"4"})
done: redis.xadd("58h4o7g", {:test=>"4"})
call: redis.xadd("58h4o7g", {:test=>"5"})
done: redis.xadd("58h4o7g", {:test=>"5"})
call: redis.xadd("58h4o7g", {:test=>"6"})
done: redis.xadd("58h4o7g", {:test=>"6"})
call: redis.xadd("58h4o7g", {:test=>"7"})
done: redis.xadd("58h4o7g", {:test=>"7"})
call: redis.xadd("58h4o7g", {:test=>"8"})
done: redis.xadd("58h4o7g", {:test=>"8"})
call: redis.xadd("58h4o7g", {:test=>"9"})
done: redis.xadd("58h4o7g", {:test=>"9"})
call: redis2.xreadgroup(:a, 8, "58h4o7g", ">", {:count=>8})
call: redis3.multi()
call: redis3.xack("58h4o7g", :c, "1592564769910-1")
done: redis3.xack("58h4o7g", :c, "1592564769910-1")
call: redis3.xdel("58h4o7g", "1592564769910-1")
done: redis3.xdel("58h4o7g", "1592564769910-1")
call: redis4.xclaim("58h4o7g", :a, :a, 8, "1592564769909-2")
done: redis2.xreadgroup(:a, 8, "58h4o7g", ">", {:count=>8})
call: redis2.xreadgroup(:a, 4, "58h4o7g", ">", {:count=>1})
done: redis3.multi()
done: redis2.xreadgroup(:a, 4, "58h4o7g", ">", {:count=>1})
call: redis3.multi()
call: redis3.xack("58h4o7g", :c, "1592564769909-0")
done: redis3.xack("58h4o7g", :c, "1592564769909-0")
call: redis3.xdel("58h4o7g", "1592564769909-0")
done: redis3.xdel("58h4o7g", "1592564769909-0")
done: redis4.xclaim("58h4o7g", :a, :a, 8, "1592564769909-2")
done: redis3.multi()
call: redis4.xclaim("58h4o7g", :a, :b, 4, "1592564769911-1")
call: redis2.xreadgroup(:a, 8, "58h4o7g", ">", {:count=>8})
done: redis4.xclaim("58h4o7g", :a, :b, 4, "1592564769911-1")
done: redis2.xreadgroup(:a, 8, "58h4o7g", ">", {:count=>8})
call: redis4.xclaim("58h4o7g", :a, :a, 8, "1592564769910-2")
call: redis2.xreadgroup(:a, 1, "58h4o7g", ">", {:count=>1})
call: redis3.multi()
call: redis3.xack("58h4o7g", :c, "1592564769910-1")
done: redis3.xack("58h4o7g", :c, "1592564769910-1")
call: redis3.xdel("58h4o7g", "1592564769910-1")
done: redis3.xdel("58h4o7g", "1592564769910-1")
done: redis2.xreadgroup(:a, 1, "58h4o7g", ">", {:count=>1})
done: redis4.xclaim("58h4o7g", :a, :a, 8, "1592564769910-2")
call: redis2.xreadgroup(:a, 4, "58h4o7g", ">", {:count=>4})
done: redis3.multi()
call: redis4.xclaim("58h4o7g", :a, :b, 8, "1592564769910-0")
done: redis2.xreadgroup(:a, 4, "58h4o7g", ">", {:count=>4})
call: redis3.multi()
call: redis3.xack("58h4o7g", :c, "1592564769909-0")
done: redis3.xack("58h4o7g", :c, "1592564769909-0")
call: redis2.xreadgroup(:a, 4, "58h4o7g", ">", {:count=>1})
done: redis4.xclaim("58h4o7g", :a, :b, 8, "1592564769910-0")
call: redis3.xdel("58h4o7g", "1592564769909-0")
done: redis3.xdel("58h4o7g", "1592564769909-0")
call: redis4.xclaim("58h4o7g", :a, :b, 1, "1592564769911-0")
done: redis3.multi()
done: redis2.xreadgroup(:a, 4, "58h4o7g", ">", {:count=>1})
call: redis3.multi()
call: redis3.xack("58h4o7g", :a, "1592564769911-2")
done: redis3.xack("58h4o7g", :a, "1592564769911-2")
done: redis4.xclaim("58h4o7g", :a, :b, 1, "1592564769911-0")
call: redis2.xreadgroup(:a, 1, "58h4o7g", ">", {:count=>4})
call: redis3.xdel("58h4o7g", "1592564769911-2")
done: redis3.xdel("58h4o7g", "1592564769911-2")
done: redis2.xreadgroup(:a, 1, "58h4o7g", ">", {:count=>4})
done: redis3.multi()
call: redis4.xclaim("58h4o7g", :a, :b, 1, "1592564769909-0")
call: redis3.multi()
call: redis2.xreadgroup(:a, 1, "58h4o7g", ">", {:count=>8})
done: redis4.xclaim("58h4o7g", :a, :b, 1, "1592564769909-0") # get [nil] and fails
```

If you replay the same scenario but serially, that last `xclaim` will receive and empty array (`[]`) rather an array with a single nil entry (`[nil]`).

I couldn't locate this behavior anywhere in the doc, I can't say for sure it's a bug, but neither can I say it's a deliberate feature. I can only assume `xclaim` response is affected by another in flight command.

The original repo was done on Redis 5, but I was able to repo with Redis `6.0.5`
