### PR TITLE
When working with redis streams and xreadgroup

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -3428,7 +3428,7 @@ class Redis
 
   HashifyStreamEntries = lambda { |reply|
     reply.compact.map do |entry_id, values|
-      [entry_id, values&.each_slice(2)&.to_h||{}]
+      [entry_id, values&.each_slice(2)&.to_h || {}]
     end
   }
 

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -3428,7 +3428,7 @@ class Redis
 
   HashifyStreamEntries = lambda { |reply|
     reply.compact.map do |entry_id, values|
-      [entry_id, values.each_slice(2).to_h]
+      [entry_id, values&.each_slice(2)&.to_h||{}]
     end
   }
 


### PR DESCRIPTION
```
NoMethodError: undefined method `each_slice' for nil:NilClass
 redis.rb:3389 block (2 levels) in <class:Redis>(...)
[GEM_ROOT]/gems/redis-4.1.3/lib/redis.rb:3389:in `block (2 levels) in <class:Redis>'
3387   HashifyStreamEntries = lambda { |reply|
3388     reply.map do |entry_id, values|
3389       [entry_id, values.each_slice(2).to_h]
3390     end
3391   }
```

Our code has been running with streams for at least a year without issue until this last week. when this exception started... it looks like somehow the stream values are coming out with a nil and causing this code in redis.rb to crash... i think it's safer if we return an empty hash {} instead of crashing...


```
  HashifyStreamEntries = lambda { |reply|
    reply.map do |entry_id, values|
      [entry_id, values&.each_slice(2)&.to_h||{}]
    end
  }
```

the & might not be safe for older versions of ruby ?