### PR TITLE
Test against redis 6.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        redis: ["5.0"]
+        redis: ["6.0"]
         ruby: ["2.7", "2.6", "2.5", "2.4"]
         driver: ["ruby", "hiredis", "synchrony"]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
After https://github.com/redis/redis-rb/pull/914, the default redis version on tests was set to 6.0.
But this PR only changed the redis version only for tests using travis, not for tests using github actions.

After https://github.com/redis/redis-rb/commit/287276c2633d97aef476ae2939cc6ae04e4a4d3f, travis was disabled.

We should run test with redis 6.0 again.
