### PR TITLE
Fix flaky test case for synchrony driver

### DIFF
--- a/test/sentinel_test.rb
+++ b/test/sentinel_test.rb
@@ -30,7 +30,7 @@ class SentinelTest < Minitest::Test
       end
     }
     RedisMock.start(commands) do |port|
-      redis = build_slave_role_client(sentinels: [{ host: 'localhost', port: port }])
+      redis = build_slave_role_client(sentinels: [{ host: '127.0.0.1', port: port }])
       assert_equal 'PONG', redis.ping
     end
   end
@@ -45,7 +45,7 @@ class SentinelTest < Minitest::Test
       end
     }
     RedisMock.start(commands) do |port|
-      redis = build_slave_role_client(sentinels: [{ host: 'localhost', port: port }])
+      redis = build_slave_role_client(sentinels: [{ host: '127.0.0.1', port: port }])
       assert_raises(Redis::CannotConnectError) { redis.ping }
     end
   end


### PR DESCRIPTION
This PR will resolve #943.

https://github.com/redis/redis-rb/blob/cf44d716aa36f92556de7be1c2f4af4c6d750c92/lib/redis/connection/synchrony.rb#L92-L94

* eventmachine/eventmachine#885
* [It seems that the implementation using only socket(2) is not enough.](https://github.com/eventmachine/eventmachine/blob/e29ccdefbf4b753dfec513c2df17b3bf1b827425/ext/em.cpp#L35-L58)
* [EventMachine::DNS::Resolver](https://github.com/eventmachine/eventmachine/blob/master/lib/em/resolver.rb)

#### on GitHub Actions

```
$ cat /etc/hosts
127.0.0.1 localhost
---snip---
```

```
$ cat /etc/resolv.conf
---snip---
nameserver 127.0.0.53
options edns0
search equ4xg1rbhmubnhv1dj5iatrre.bx.internal.cloudapp.net
```

```
$ cat /etc/nsswitch.conf
---snip---
hosts:          files dns
---snip---
```