### PR TITLE
fix: corruption of client during interrupt

### DIFF
--- a/test/pipelining_commands_test.rb
+++ b/test/pipelining_commands_test.rb
@@ -252,4 +252,11 @@ class TestPipeliningCommands < Minitest::Test
 
     assert_equal 3, r._client.db
   end
+
+  def test_pipeline_interrupt_preserves_client
+    original = r._client
+    Redis::Pipeline.stubs(:new).raises(Interrupt)
+    assert_raises(Interrupt) { r.pipelined {} }
+    assert_equal r._client, original
+  end
 end

--- a/test/transactions_test.rb
+++ b/test/transactions_test.rb
@@ -196,6 +196,13 @@ class TestTransactions < Minitest::Test
     assert_equal "s1", r.get("foo")
   end
 
+  def test_multi_with_interrupt_preserves_client
+    original = r._client
+    Redis::Pipeline.stubs(:new).raises(Interrupt)
+    assert_raises(Interrupt) { r.multi {} }
+    assert_equal r._client, original
+  end
+
   def test_raise_command_error_when_exec_fails
     redis_mock(exec: ->(*_) { "-ERROR" }) do |redis|
       assert_raises(Redis::CommandError) do


### PR DESCRIPTION
Due to the fact that `original` is hoisted to nil and its assignment
is not the first operation interrupts can corrupt the redis client
pointer.

This commit addresses issue by using a reference guaranteed to
be set correctly to reassign the client in the ensure block

### Steps to reproduce

1. Connect to redis via client 
2. Raise interrupt during either `pipelined` or `multi` (Timeout.timeout, sigint, etc, pick your poison)
3. Ensure the interrupt happens before the assignment of `original = @client` (see test cases for example)

### Expected behavior
The library is resilient to interrupts and the redis client can continue to accept commands afterwards

### Actual behavior
The underlying `client` is net to nil and is corrupted forever after that raising undefined method calls 

### System configuration
**Ruby version**: 2.7.1
**Gem version**: 4.2.1