### PR TITLE
Fix #950

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -415,7 +415,7 @@ class Redis
       end
 
       url = options[:url]
-      url = defaults[:url] if url.nil?
+      url = defaults[:url] if url.nil? && options.empty?
 
       # Override defaults from URL if given
       if url


### PR DESCRIPTION
This is an attempt to address #950.

It's probably not a good idea to grep pieces of the default REDIS_URL when it's present. The REDIS_URL could be used when no options are given: `Redis::Client.new({})`

Thoughts?