### PR TITLE
Symbolize all the option keys at Redis::Client#initialize(option)

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -404,14 +404,13 @@ class Redis
       return options if options[:_parsed]
 
       defaults = DEFAULTS.dup
-      options = options.dup
+      options = options.each_with_object({}) do |(key, value), new_option|
+        new_option[key.to_sym] = value # Dup and symbolize keys
+      end
 
       defaults.keys.each do |key|
         # Fill in defaults if needed
         defaults[key] = defaults[key].call if defaults[key].respond_to?(:call)
-
-        # Symbolize only keys that are needed
-        options[key] = options[key.to_s] if options.key?(key.to_s)
       end
 
       url = options[:url]


### PR DESCRIPTION
Symbolize all the option keys at Redis::Client#initialize(option)

Previously, a limited portion of options are symbolized at
`Redis::Client#initialize(option)`. Specifically, only those defined at
`Redis::Client::DEFAULTS` are symbolized.

This invoked confusing behavior and increased maintenance cost.
For example, specifying timeout was a little bit tricky as follows.

```ruby
Redis::Client.new('timeout' => 10.0).options[:timeout]
# => 10.0
Redis::Client.new('read_timeout' => 10.0).options[:read_timeout]
# => 5.0
```

Now, all the keys of options are symbolized, and consistent
external behavior is achieved.

```ruby
Redis::Client.new('timeout' => 10.0).options[:timeout]
# => 10.0
Redis::Client.new('read_timeout' => 10.0).options[:read_timeout]
# => 10.0
```

This can also reduce maintenance cost of `Redis::Client::DEFAULTS`.

-----

This idea was rejected because of memory leak at #256 in 2012.

However, in 2020, I believe we can safely symbolize keys because of the following reasons.

* Rational developers won't pass hashes containing a large number of unsupported keys to external libraries as their options, especially on environments where memory leak is a problem.
* In most cases, unintentionally inserted keys in options will not change dynamically until the program ends, which means unintentionally used memory size by converted symbols is limited (fixed).
* Even if some developers pass the options containing a large number of dynamically-changing unsupported keys, currently (November, 2020) supported ruby versions in gemspec, which is 2.3 and later, have Symbol GC functionality and memory leak is restrained to some extent.

Also, nobody has been interested in the previous style Pull Request at #689, which I created 3 years ago.
I assume that it is about time to change our strategy to symbolize keys.