### PR TITLE
DEV: add test case covering partial writes

### DIFF
--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -68,6 +68,7 @@ class Redis
       end
 
       def _write_to_socket(data)
+        data = data.b
         total_bytes_written = 0
         loop do
           case bytes_written = write_nonblock(data, exception: false)
@@ -95,7 +96,6 @@ class Redis
       def write(data)
         return super(data) unless @write_timeout
 
-        data = data.b
         length = data.bytesize
         total_count = 0
         loop do

--- a/test/internals_test.rb
+++ b/test/internals_test.rb
@@ -12,6 +12,16 @@ class TestInternals < Minitest::Test
     assert log.string =~ /\[Redis\] call_time=\d+\.\d+ ms/
   end
 
+  def test_large_payload
+    # see: https://github.com/redis/redis-rb/issues/962
+    # large payloads will trigger write_nonblock to write a portion
+    # of the payload in connection/ruby.rb _write_to_socket
+    large = "\u3042" * 4_000_000
+    r.setex("foo", 10, large)
+    result = r.get("foo")
+    assert_equal result, large
+  end
+
   def test_logger_with_pipelining
     r.pipelined do
       r.set "foo", "bar"


### PR DESCRIPTION
This moves the responsibility of copying data into write_to_socket. The
caller never mutates the string, this is cleaner cause we do no longer
mutate the string we pass in.
