### PR TITLE
Support AUTH command for ACL

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ To connect to a password protected Redis instance, use:
 redis = Redis.new(password: "mysecret")
 ```
 
+To connect a Redis instance using [ACL](https://redis.io/topics/acl), use:
+
+```ruby
+redis = Redis.new(username: 'myname', password: 'mysecret')
+```
+
 The Redis class exports methods that are named identical to the commands
 they execute. The arguments these methods accept are often identical to
 the arguments specified on the [Redis website][redis-commands]. For

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -39,6 +39,7 @@ class Redis
   # @option options [String] :path path to server socket (overrides host and port)
   # @option options [Float] :timeout (5.0) timeout in seconds
   # @option options [Float] :connect_timeout (same as timeout) timeout for initial connect in seconds
+  # @option options [String] :username Username to authenticate against server
   # @option options [String] :password Password to authenticate against server
   # @option options [Integer] :db (0) Database to select after initial connect
   # @option options [Symbol] :driver Driver to use, currently supported: `:ruby`, `:hiredis`, `:synchrony`
@@ -143,12 +144,13 @@ class Redis
 
   # Authenticate to the server.
   #
-  # @param [String] password must match the password specified in the
-  #   `requirepass` directive in the configuration file
+  # @param [Array<String>] args includes both username and password
+  #   or only password
   # @return [String] `OK`
-  def auth(password)
+  # @see https://redis.io/commands/auth AUTH command
+  def auth(*args)
     synchronize do |client|
-      client.call([:auth, password])
+      client.call([:auth, *args])
     end
   end
 

--- a/lib/redis/cluster.rb
+++ b/lib/redis/cluster.rb
@@ -128,7 +128,7 @@ class Redis
     def send_command(command, &block)
       cmd = command.first.to_s.downcase
       case cmd
-      when 'auth', 'bgrewriteaof', 'bgsave', 'quit', 'save'
+      when 'acl', 'auth', 'bgrewriteaof', 'bgsave', 'quit', 'save'
         @node.call_all(command, &block).first
       when 'flushall', 'flushdb'
         @node.call_master(command, &block).first

--- a/test/cluster_client_internals_test.rb
+++ b/test/cluster_client_internals_test.rb
@@ -74,4 +74,23 @@ class TestClusterClientInternals < Minitest::Test
 
     assert_equal expected, redis.connection
   end
+
+  def test_acl_auth_success
+    target_version "6.0.0" do
+      with_acl do |username, password|
+        r = _new_client(cluster: DEFAULT_PORTS.map { |port| "redis://#{username}:#{password}@#{DEFAULT_HOST}:#{port}" })
+        assert_equal('PONG', r.ping)
+      end
+    end
+  end
+
+  def test_acl_auth_failure
+    target_version "6.0.0" do
+      with_acl do |username, _|
+        assert_raises(Redis::CannotConnectError) do
+          _new_client(cluster: DEFAULT_PORTS.map { |port| "redis://#{username}:wrongpassword@#{DEFAULT_HOST}:#{port}" })
+        end
+      end
+    end
+  end
 end

--- a/test/cluster_client_options_test.rb
+++ b/test/cluster_client_options_test.rb
@@ -20,10 +20,13 @@ class TestClusterClientOptions < Minitest::Test
     assert_equal false, option.use_replica?
 
     option = Redis::Cluster::Option.new(cluster: %w[rediss://johndoe:foobar@127.0.0.1:7000/1/namespace])
-    assert_equal({ '127.0.0.1:7000' => { scheme: 'rediss', password: 'foobar', host: '127.0.0.1', port: 7000, db: 1 } }, option.per_node_key)
+    assert_equal({ '127.0.0.1:7000' => { scheme: 'rediss', username: 'johndoe', password: 'foobar', host: '127.0.0.1', port: 7000, db: 1 } }, option.per_node_key)
 
     option = Redis::Cluster::Option.new(cluster: %w[rediss://127.0.0.1:7000], scheme: 'redis')
     assert_equal({ '127.0.0.1:7000' => { scheme: 'rediss', host: '127.0.0.1', port: 7000 } }, option.per_node_key)
+
+    option = Redis::Cluster::Option.new(cluster: %w[redis://bazzap:@127.0.0.1:7000], username: 'foobar')
+    assert_equal({ '127.0.0.1:7000' => { scheme: 'redis', username: 'bazzap', host: '127.0.0.1', port: 7000 } }, option.per_node_key)
 
     option = Redis::Cluster::Option.new(cluster: %w[redis://:bazzap@127.0.0.1:7000], password: 'foobar')
     assert_equal({ '127.0.0.1:7000' => { scheme: 'redis', password: 'bazzap', host: '127.0.0.1', port: 7000 } }, option.per_node_key)

--- a/test/cluster_commands_on_connection_test.rb
+++ b/test/cluster_commands_on_connection_test.rb
@@ -1,17 +1,13 @@
 # frozen_string_literal: true
 
 require_relative 'helper'
+require 'lint/authentication'
 
 # ruby -w -Itest test/cluster_commands_on_connection_test.rb
 # @see https://redis.io/commands#connection
 class TestClusterCommandsOnConnection < Minitest::Test
   include Helper::Cluster
-
-  def test_auth
-    redis_cluster_mock(auth: ->(*_) { '+OK' }) do |redis|
-      assert_equal 'OK', redis.auth('my-password-123')
-    end
-  end
+  include Lint::Authentication
 
   def test_echo
     assert_equal 'hogehoge', redis.echo('hogehoge')
@@ -36,5 +32,9 @@ class TestClusterCommandsOnConnection < Minitest::Test
     assert_raises(Redis::CommandError, 'ERR SWAPDB is not allowed in cluster mode') do
       redis.swapdb(1, 2)
     end
+  end
+
+  def mock(*args, &block)
+    redis_cluster_mock(*args, &block)
   end
 end

--- a/test/connection_handling_test.rb
+++ b/test/connection_handling_test.rb
@@ -1,20 +1,11 @@
 # frozen_string_literal: true
 
 require_relative "helper"
+require 'lint/authentication'
 
 class TestConnectionHandling < Minitest::Test
   include Helper::Client
-
-  def test_auth
-    commands = {
-      auth: ->(password) { @auth = password; "+OK" },
-      get: ->(_key) { @auth == "secret" ? "$3\r\nbar" : "$-1" }
-    }
-
-    redis_mock(commands, password: "secret") do |redis|
-      assert_equal "bar", redis.get("foo")
-    end
-  end
+  include Lint::Authentication
 
   def test_id
     commands = {

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -165,6 +165,16 @@ module Helper
     def version
       Version.new(redis.info['redis_version'])
     end
+
+    def with_acl
+      admin = _new_client
+      admin.acl('SETUSER', 'johndoe', 'on',
+                '+ping', '+select', '+command', '+cluster|slots', '+cluster|nodes',
+                '>mysecret')
+      yield('johndoe', 'mysecret')
+      admin.acl('DELUSER', 'johndoe')
+      admin.close
+    end
   end
 
   module Client

--- a/test/lint/authentication.rb
+++ b/test/lint/authentication.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Lint
+  module Authentication
+    def test_auth_with_password
+      mock(auth: ->(*_) { '+OK' }) do |r|
+        assert_equal 'OK', r.auth('mysecret')
+      end
+
+      mock(auth: ->(*_) { '-ERR some error' }) do |r|
+        assert_raises(Redis::BaseError) { r.auth('mysecret') }
+      end
+    end
+
+    def test_auth_for_acl
+      target_version "6.0.0" do
+        with_acl do |username, password|
+          assert_raises(Redis::BaseError) { redis.auth(username, 'wrongpassword') }
+          assert_equal 'OK', redis.auth(username, password)
+          assert_equal 'PONG', redis.ping
+          assert_raises(Redis::BaseError) { redis.echo('foo') }
+        end
+      end
+    end
+
+    def mock(*args, &block)
+      redis_mock(*args, &block)
+    end
+  end
+end

--- a/test/url_param_test.rb
+++ b/test/url_param_test.rb
@@ -134,4 +134,15 @@ class TestUrlParam < Minitest::Test
 
     assert_equal "127.0.0.1", redis._client.host
   end
+
+  def test_user_and_password
+    redis = Redis.new(url: 'redis://johndoe:mysecret@foo.com:999/2')
+
+    assert_equal('redis', redis._client.scheme)
+    assert_equal('johndoe', redis._client.username)
+    assert_equal('mysecret', redis._client.password)
+    assert_equal('foo.com', redis._client.host)
+    assert_equal(999, redis._client.port)
+    assert_equal(2, redis._client.db)
+  end
 end


### PR DESCRIPTION
Hello,

I think we can support AUTH command for ACL without any breaking changes until RESP2's EOL.
Do you have any other plans?

Related issues:
* resolve #867 
* resolve #956

Documents:
* https://redis.io/topics/acl
* https://redis.io/commands/auth

Affected features:
* Standalone mode
* Sentinel mode
* Cluster mode

New options:
* `username`

Usage:
```ruby
redis = Redis.new(username: 'myname', password: 'mysecret')
```

```ruby
redis = Redis.new(url: 'redis://myname:mysecret@127.0.0.1:6379/0')
```

```ruby
sentinels = [{ host: '127.0.0.1', port: 26380, username: 'myname', password: 'mysecret' },
             { host: '127.0.0.1', port: 26381, username: 'myname', password: 'mysecret' }]

redis = Redis.new(host: 'mymaster', sentinels: sentinels, role: :master, username: 'myname', password: 'mysecret')
```

```ruby
nodes = (7000..7005).map { |port| "redis://myname:mysecret@127.0.0.1:#{port}" }
redis = Redis.new(cluster: nodes)
```

```ruby
redis.auth('myname', 'mysecret')
```