### PR TITLE
Use new API in benchmarking/speed.rb

### DIFF
--- a/benchmarking/speed.rb
+++ b/benchmarking/speed.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-# Run with
-#
-#   $ ruby -Ilib benchmarking/speed.rb
-#
+$LOAD_PATH.push File.join(__dir__, 'lib')
 
 require "benchmark"
 require "redis"
@@ -15,8 +12,8 @@ elapsed = Benchmark.realtime do
   # n sets, n gets
   n.times do |i|
     key = "foo#{i}"
-    r[key] = key * 10
-    r[key]
+    r.set(key, key * 10)
+    r.get(key)
   end
 end
 


### PR DESCRIPTION
```
$ ruby -Ilib benchmarking/speed.rb
Traceback (most recent call last):
	11: from benchmarking/speed.rb:14:in `<main>'
	10: from /Users/fatkodima/.rbenv/versions/2.7.0/lib/ruby/2.7.0/benchmark.rb:308:in `realtime'
	 9: from benchmarking/speed.rb:16:in `block in <main>'
	 8: from benchmarking/speed.rb:16:in `times'
	 7: from benchmarking/speed.rb:18:in `block (2 levels) in <main>'
	 6: from /Users/fatkodima/Desktop/oss/redis-rb/lib/redis.rb:3347:in `method_missing'
	 5: from /Users/fatkodima/Desktop/oss/redis-rb/lib/redis.rb:69:in `synchronize'
	 4: from /Users/fatkodima/.rbenv/versions/2.7.0/lib/ruby/2.7.0/monitor.rb:202:in `mon_synchronize'
	 3: from /Users/fatkodima/.rbenv/versions/2.7.0/lib/ruby/2.7.0/monitor.rb:202:in `synchronize'
	 2: from /Users/fatkodima/Desktop/oss/redis-rb/lib/redis.rb:69:in `block in synchronize'
	 1: from /Users/fatkodima/Desktop/oss/redis-rb/lib/redis.rb:3348:in `block in method_missing'
/Users/fatkodima/Desktop/oss/redis-rb/lib/redis/client.rb:132:in `call': ERR unknown command `[]=`, with args beginning with: `foo0`, `foo0foo0foo0foo0foo0foo0foo0foo0foo0foo0`, (Redis::CommandError)
```