### PR TITLE
Add several test cases for built-in TLS server feature

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -131,3 +131,56 @@ jobs:
         run: make test
       - name: Shutting down Redis
         run: make stop_all
+  tls:
+    name: TLS
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        redis: ["6.0"]
+        ruby: ["3.0"]
+        driver: ["ruby"]
+    runs-on: ${{ matrix.os }}
+    env:
+      VERBOSE: true
+      TIMEOUT: 30
+      LOW_TIMEOUT: 0.01
+      DRIVER: ${{ matrix.driver }}
+      REDIS_BRANCH: ${{ matrix.redis }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Print environment variables
+        run: |
+          echo "TIMEOUT=${TIMEOUT}"
+          echo "LOW_TIMEOUT=${LOW_TIMEOUT}"
+          echo "DRIVER=${DRIVER}"
+          echo "REDIS_BRANCH=${REDIS_BRANCH}"
+      - name: Set up Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Cache dependent gems
+        uses: actions/cache@v1
+        with:
+          path: .bundle
+          key: "local-bundle-ruby-${{ matrix.ruby }}-on-${{ matrix.os }}-0001"
+      - name: Set up Gems
+        run: |
+          gem update --system --no-document
+          gem install bundler --no-document
+          bundle install --jobs 4 --retry 3 --path=.bundle
+      - name: Cache local temporary directory
+        uses: actions/cache@v1
+        with:
+          path: tmp
+          key: "local-tmp-redis-${{ matrix.redis }}-on-${{ matrix.os }}-with-tls"
+      - name: Booting up Redis
+        run: make start BUILD_TLS=yes
+      - name: Test
+        run: env BUILD_TLS=yes bundle exec rake test test/ssl_test.rb
+        env:
+          RUBYOPT: "--enable-frozen-string-literal"
+      - name: Shutting down Redis
+        run: make stop_all

--- a/bin/build
+++ b/bin/build
@@ -45,7 +45,11 @@ class Builder
     FileUtils.mkdir_p(@build_dir)
     command!('tar', 'xf', tarball_path, '-C', File.expand_path('../', @build_dir))
     Dir.chdir(@build_dir) do
-      command!('make')
+      if ENV['BUILD_TLS'] == 'yes'
+        command!('make BUILD_TLS=yes')
+      else
+        command!('make')
+      end
     end
   end
 

--- a/test/ssl_test.rb
+++ b/test/ssl_test.rb
@@ -57,23 +57,58 @@ class SslTest < Minitest::Test
     end
   end
 
+  if ENV['BUILD_TLS'] == 'yes'
+    driver(:ruby) do
+      NON_TLS_PORT = 6381
+      TLS_PORT = 6383
+
+      def test_verified_ssl_connection_between_client_and_server
+        redis = Redis.new(port: TLS_PORT, ssl: true, ssl_params: client_ssl_params_for_mutual_tls('trusted'))
+        assert_equal redis.ping, 'PONG'
+        redis.quit
+      end
+
+      def test_unverified_ssl_client
+        assert_raises(OpenSSL::SSL::SSLError) do
+          redis = Redis.new(port: TLS_PORT, ssl: true, ssl_params: client_ssl_params_for_mutual_tls('untrusted'))
+          redis.ping
+        end
+      end
+
+      def test_connection_to_non_ssl_port
+        assert_raises(Redis::CannotConnectError) do
+          redis = Redis.new(port: NON_TLS_PORT, ssl: true, ssl_params: client_ssl_params_for_mutual_tls('trusted'), timeout: LOW_TIMEOUT)
+          redis.ping
+        end
+      end
+
+      def test_verified_ssl_connection_with_blocking
+        redis = Redis.new(port: TLS_PORT, ssl: true, ssl_params: client_ssl_params_for_mutual_tls('trusted'))
+        assert_equal redis.set('boom', 'a' * 10_000_000), 'OK'
+        redis.quit
+      end
+    end
+  end
+
   private
 
   def ssl_server_opts(prefix)
-    ssl_cert = File.join(cert_path, "#{prefix}-cert.crt")
-    ssl_key  = File.join(cert_path, "#{prefix}-cert.key")
-
-    {
-      ssl: true,
-      ssl_params: {
-        cert: OpenSSL::X509::Certificate.new(File.read(ssl_cert)),
-        key: OpenSSL::PKey::RSA.new(File.read(ssl_key))
-      }
-    }
+    { ssl: true, ssl_params: load_cert_files(prefix) }
   end
 
-  def ssl_ca_file
-    File.join(cert_path, "trusted-ca.crt")
+  def client_ssl_params_for_mutual_tls(prefix)
+    load_cert_files(prefix).merge(ca_file: ssl_ca_file(prefix))
+  end
+
+  def load_cert_files(prefix)
+    cert = File.join(cert_path, "#{prefix}-cert.crt")
+    key  = File.join(cert_path, "#{prefix}-cert.key")
+    { cert: OpenSSL::X509::Certificate.new(File.read(cert)),
+      key: OpenSSL::PKey::RSA.new(File.read(key)) }
+  end
+
+  def ssl_ca_file(prefix = 'trusted')
+    File.join(cert_path, "#{prefix}-ca.crt")
   end
 
   def cert_path


### PR DESCRIPTION
Hello,

Redis 6 supports SSL/TLS connection optionally, so I would say that it would be better to test it in this repository.
Howerver, since the feature is optional, I added the cases to CI workflow as a additional job.

I hope this will help. But I will close the PR if the test cases are neither useful nor meaningful.

* https://redis.io/topics/encryption
* https://github.com/redis/redis/blob/unstable/TLS.md
* https://github.com/redis/redis-rb#ssltls-support

ref: #972