### PR TITLE
fix driver failover

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -516,7 +516,7 @@ class Redis
           require_relative "connection/#{driver}"
         rescue LoadError, NameError
           begin
-            require "connection/#{driver}"
+            require "redis/connection/#{driver}"
           rescue LoadError, NameError => error
             raise "Cannot load driver #{driver.inspect}: #{error.message}"
           end


### PR DESCRIPTION
The failover code seems to be incorrect if the driver is not found in require_relative.

ref: https://github.com/redis/redis-rb/commit/f3bc68f4305792a14c86556832627e13c9bbd6b0#diff-5bc007010e6c2e0aa70b64d6f87985c20986ee1b2882b63a89b52659ee9c91f8L520