### PR TITLE
Fix build command! child status global

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -4,6 +4,7 @@
 TARBALL = ARGV[0]
 
 require 'digest/sha1'
+require 'English'
 require 'fileutils'
 
 class Builder


### PR DESCRIPTION
**Description**

`$CHILD_STATUS` cannot be used because `English` module has not been required.

**Actual result:**
```
$ wget -q https://github.com/antirez/redis/archive/6.0.tar.gz -O tmp/redis-6.0.tar.gz
Traceback (most recent call last):
	3: from bin/build:76:in `<main>'
	2: from bin/build:19:in `run'
	1: from bin/build:32:in `download_tarball_if_needed'
bin/build:72:in `command!': undefined method `exitstatus' for nil:NilClass (NoMethodError)
```
**Expected result:**
```
$ wget -q https://github.com/antirez/redis/archive/6.0.tar.gz -O tmp/redis-6.0.tar.gz
Traceback (most recent call last):
	3: from bin/build:76:in `<main>'
	2: from bin/build:19:in `run'
	1: from bin/build:32:in `download_tarball_if_needed'
bin/build:72:in `command!': Command failed with status 127 (RuntimeError)
```

**Environment**
Tested on ruby 2.7.2.