### PR TITLE
Update the command info test for Redis 6.2

### DIFF
--- a/test/cluster_commands_on_server_test.rb
+++ b/test/cluster_commands_on_server_test.rb
@@ -81,7 +81,7 @@ class TestClusterCommandsOnServer < Minitest::Test
 
   def test_command_info
     eval_command_flags = if version >= '6.2'
-      %w[noscript may_replicate movablekeys]
+      %w[noscript skip_monitor may_replicate movablekeys]
     else
       %w[noscript movablekeys]
     end


### PR DESCRIPTION
Fixes the broken test on master:

```
TestClusterCommandsOnServer#test_command_info [/home/runner/work/redis-rb/redis-rb/test/cluster_commands_on_server_test.rb:99]:
--- expected
+++ actual
@@ -1 +1 @@
-[["get", 2, ["readonly", "fast"], 1, 1, 1, ["@read", "@string", "@fast"]], ["set", -3, ["write", "denyoom"], 1, 1, 1, ["@write", "@string", "@slow"]], ["eval", -3, ["noscript", "may_replicate", "movablekeys"], 0, 0, 0, ["@slow", "@scripting"]]]
+[["get", 2, ["readonly", "fast"], 1, 1, 1, ["@read", "@string", "@fast"]], ["set", -3, ["write", "denyoom"], 1, 1, 1, ["@write", "@string", "@slow"]], ["eval", -3, ["noscript", "skip_monitor", "may_replicate", "movablekeys"], 0, 0, 0, ["@slow", "@scripting"]]]
```