### PR TITLE
Add TruffleRuby to GitHub Actions tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         redis: ["6.2"]
-        ruby: ["3.0", "2.7", "2.6", "2.5", "2.4"]
+        ruby: ["3.0", "2.7", "2.6", "2.5", "2.4", "truffleruby-head"]
         driver: ["ruby", "hiredis", "synchrony"]
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
**Description**
Adds TruffleRuby to GitHub Actions ruby versions to test for compatibility.