### PR TITLE
add ZINTER command, added to Redis in 6.2

### DIFF
--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -674,6 +674,13 @@ class Redis
       node_for(key).zcount(key, min, max)
     end
 
+    # Get the intersection of multiple sorted sets
+    def zinter(*keys, **options)
+      ensure_same_node(:zinter, keys) do |node|
+        node.zinter(*keys, **options)
+      end
+    end
+
     # Intersect multiple sorted sets and store the resulting sorted set in a new
     # key.
     def zinterstore(destination, keys, **options)

--- a/test/cluster_commands_on_sorted_sets_test.rb
+++ b/test/cluster_commands_on_sorted_sets_test.rb
@@ -9,6 +9,18 @@ class TestClusterCommandsOnSortedSets < Minitest::Test
   include Helper::Cluster
   include Lint::SortedSets
 
+  def test_zinter
+    assert_raises(Redis::CommandError) { super }
+  end
+
+  def test_zinter_with_aggregate
+    assert_raises(Redis::CommandError) { super }
+  end
+
+  def test_zinter_with_weights
+    assert_raises(Redis::CommandError) { super }
+  end
+
   def test_zinterstore
     assert_raises(Redis::CommandError) { super }
   end

--- a/test/distributed_commands_on_sorted_sets_test.rb
+++ b/test/distributed_commands_on_sorted_sets_test.rb
@@ -7,6 +7,18 @@ class TestDistributedCommandsOnSortedSets < Minitest::Test
   include Helper::Distributed
   include Lint::SortedSets
 
+  def test_zinter
+    assert_raises(Redis::Distributed::CannotDistribute) { super }
+  end
+
+  def test_zinter_with_aggregate
+    assert_raises(Redis::Distributed::CannotDistribute) { super }
+  end
+
+  def test_zinter_with_weights
+    assert_raises(Redis::Distributed::CannotDistribute) { super }
+  end
+
   def test_zinterstore
     assert_raises(Redis::Distributed::CannotDistribute) { super }
   end


### PR DESCRIPTION
This adds support for the [ZINTER](https://redis.io/commands/zinter) command, which was added in Redis 6.2.0.

I tried to imitate the API/wording of similar functions, let me know if there is anything I need to change

Ref: #978