### PR TITLE
add XAUTOCLAIM command, added to Redis in 6.2

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-REDIS_BRANCH       ?= 6.0
+REDIS_BRANCH       ?= 6.2
 TMP                := tmp
 BUILD_DIR          := ${TMP}/cache/redis-${REDIS_BRANCH}
 TARBALL            := ${TMP}/redis-${REDIS_BRANCH}.tar.gz


### PR DESCRIPTION
This adds support for the [XAUTOCLAIM](https://redis.io/commands/xautoclaim) command, which was added in Redis 6.2.0.

I tried to imitate the API/wording and hashifying of similar functions, let me know if there is anything I need to change

Ref: #978