### PR TITLE
Fix a bug for cross-slot validation in pipelining

### DIFF
--- a/test/cluster_client_pipelining_test.rb
+++ b/test/cluster_client_pipelining_test.rb
@@ -56,4 +56,26 @@ class TestClusterClientPipelining < Minitest::Test
       end
     end
   end
+
+  def test_pipelining_with_multiple_replicas
+    rc = build_another_client(replica: true)
+    rc.instance_variable_get(:@client).instance_variable_get(:@slot).instance_variable_get(:@map).each do |_, v|
+      v[:slaves] << v[:master] if v[:slaves].size < 2 # reproducing multiple replicas
+    end
+
+    rc.pipelined do |r|
+      r.get('key1')
+      r.get('key1')
+      r.get('key1')
+      r.get('key1')
+      r.get('key1')
+      r.get('key1')
+      r.get('key1')
+      r.get('key1')
+      r.get('key1')
+      r.get('key1')
+    end
+
+    rc.close
+  end
 end

--- a/test/cluster_client_pipelining_test.rb
+++ b/test/cluster_client_pipelining_test.rb
@@ -64,16 +64,7 @@ class TestClusterClientPipelining < Minitest::Test
     end
 
     rc.pipelined do |r|
-      r.get('key1')
-      r.get('key1')
-      r.get('key1')
-      r.get('key1')
-      r.get('key1')
-      r.get('key1')
-      r.get('key1')
-      r.get('key1')
-      r.get('key1')
-      r.get('key1')
+      10.times { r.get('key1') }
     end
 
     rc.close


### PR DESCRIPTION
This PR will close #1019.

The bug can be reproduced when we use multiple replicas in a cluster.