### PR TITLE
Remove note about writing keys in Redis Cluster replica mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ You can also specify only a subset of the nodes, and the client will discover th
 Redis.new(cluster: %w[redis://127.0.0.1:7000])
 ```
 
-If you want [the connection to be able to read from any replica](https://redis.io/commands/readonly), you must pass the `replica: true`. Note that this connection won't be usable to write keys.
+If you want [the connection to be able to read from any replica](https://redis.io/commands/readonly), you must pass the `replica: true`.
 
 ```ruby
 Redis.new(cluster: nodes, replica: true)


### PR DESCRIPTION
I don't think `replica: true` prevents writes from working in Cluster mode. This works fine for us in production and the code seems to explicitly direct writes to the master node.