### PR TITLE
Preallocate a buffer for reading from a socket

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -106,6 +106,9 @@ Lint/EndAlignment:
 Layout/ElseAlignment:
   Enabled: false
 
+Layout/RescueEnsureAlignment:
+  Enabled: false
+
 Naming/HeredocDelimiterNaming:
   Enabled: false
 


### PR DESCRIPTION
closes https://github.com/redis/redis-rb/issues/935 cc  @Joas1988

We encountered the same issue described in https://github.com/redis/redis-rb/issues/935 - fetching large (2 - 5 megabyte) values from Redis with SSL performed much slower than expected. We applied the patch from the issue to our production systems and saw a dramatic increase in performance.

As described in the issue the root cause of the performance degradation is:

> It boils down to that Ruby OpenSSL is reading 1400 bytes and without using buffer it [allocates buffer internally](https://github.com/ruby/openssl/blob/41587f69e17b9f0983c1f2a37b8661599119fc0e/ext/openssl/ossl_ssl.c#L1834) for length provided as argument to def [read_nonblock](https://github.com/ruby/openssl/blob/master/lib/openssl/buffering.rb#L214)

I further confirmed this by logging `nbytes` inside of `Redis::Connection::SocketMixin#_read_from_socket`. The interesting part of the logs looked like this:

```
13635520
13619136
13602752
13586368
```

Where `nbytes` starts around the full size of the payload and is decreasing by 16384 until it is finished reading. As described in the issue the call to `read_nonblock` allocates a new string based on the length provided resulting in many large allocations.

We experienced one other oddity during this investigation: the issue was not reproducible from a plain Ruby script, only from Rails. To dig into this I was able to reproduce the performance difference using only string allocations:

```ruby
def alloc_loop
  initial_size = 13650000
  chunk_size = 16384

  size = initial_size
  while size > 0 do
    size -= chunk_size
    buffer = String.new(capacity: size, encoding: Encoding::ASCII_8BIT)
  end
end

def timeit(name, &block)
  start = Time.now
  block.call
  puts "#{name} took: #{Time.now - start}"
end

timeit "alloc_loop" do
  alloc_loop
end
```

In plain Ruby I got `alloc_loop took: 0.054234` while in Rails I was getting `alloc_loop took: 1.622729` which very closely matched the difference we were seeing when comparing the Redis reads.

After ruling out patches and gems I compared to a new Rails app and I got somewhere in between the two. This led me to a new theory that the issue was more prominent in larger applications. I was able to confirm this by running this function before the string allocation test.

```ruby
def bloat
  100000.times do |i|
    eval "class BloatClass#{i}; end"
  end
end
```

What appears to be happening is that larger programs have a higher memory baseline causing the garbage collector to be more active. The output of `GC.stat` shows that it is a lot more active during the string allocations when the program memory space is higher.

I figured this was worth sharing in case someone wants to confirm the change and does so with a plain Ruby script.

This PR applies the patch from the issue. We’ve been running it on production for around a week and haven’t had any issues. There didn’t seem to be an obvious place to test this but the SocketMixin would be implicitly covered by the existing tests. Let me know if there is anything else you’d like to see in order to get this merged! 