### PR TITLE
match appropriate error message in Client.connect rescue CommandError

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -119,8 +119,12 @@ class Redis
           if username
             begin
               call [:auth, username, password]
-            rescue CommandError # Likely on Redis < 6
-              call [:auth, password]
+            rescue CommandError => err # Likely on Redis < 6
+              if err.message.match?(/ERR wrong number of arguments for \'auth\' command/)
+                call [:auth, password]
+              else
+                raise
+              end
             end
           else
             call [:auth, password]


### PR DESCRIPTION
Following https://github.com/redis/redis-rb/pull/990 all CommandErrors are being rescued here, including max connections resulting in `Redis::CommandError: ERR max number of clients reached` being rescued here and eventually rasied as `Redis::ConnectionError: Connection lost (ECONNRESET)`.

 It is my understanding that https://github.com/redis/redis-rb/pull/990 was a fix to https://github.com/redis/redis-rb/issues/989 and specifically `Redis::CommandError: ERR wrong number of arguments for 'auth' command`.  We should instead match on this error message, and otherwise raise.

