### PR TITLE
Ensure command details are populated for Cluster clients

### DIFF
--- a/lib/redis/cluster/command_loader.rb
+++ b/lib/redis/cluster/command_loader.rb
@@ -10,22 +10,21 @@ class Redis
       module_function
 
       def load(nodes)
-        details = {}
-
         nodes.each do |node|
-          details = fetch_command_details(node)
-          details.empty? ? next : break
+          begin
+            return fetch_command_details(node)
+          rescue CannotConnectError, ConnectionError, CommandError
+            next # can retry on another node
+          end
         end
 
-        details
+        raise CannotConnectError, 'Redis client could not connect to any cluster nodes'
       end
 
       def fetch_command_details(node)
         node.call(%i[command]).map do |reply|
           [reply[0], { arity: reply[1], flags: reply[2], first: reply[3], last: reply[4], step: reply[5] }]
         end.to_h
-      rescue CannotConnectError, ConnectionError, CommandError
-        {} # can retry on another node
       end
 
       private_class_method :fetch_command_details


### PR DESCRIPTION
I recently stumbled over a corner case in the clustered client which is sort of interesting:

## Background

If the Redis nodes that the client is connecting to are degraded when `CommandLoader` is called, the command details hash returned will be `{}` - the client essentially doesn't understand what any of the commands' syntax is. 

https://github.com/redis/redis-rb/blob/688ac958082d36f461f036cf62a96f213a11cbe7/lib/redis/cluster/command_loader.rb#L13-L20

(This is pretty rare in practice. The queries made by `SlotLoader` and `NodeLoader` immediately prior to this need to have worked - otherwise those will raise - but then all nodes must be unreachable when we're running `CommandLoader`.)

These command details are later used by `Command` to process a command into a key, so that the command can be routed to the right node. If the command details are empty and we don't understand the command syntax, `Command.determine_first_key_position` doesn't know which command argument to get the hash from, so `Command.extract_first_key` returns `''`:
https://github.com/redis/redis-rb/blob/688ac958082d36f461f036cf62a96f213a11cbe7/lib/redis/cluster/command.rb#L50-L61
https://github.com/redis/redis-rb/blob/688ac958082d36f461f036cf62a96f213a11cbe7/lib/redis/cluster/command.rb#L14-L16

...and that means that `Cluster.find_node_key` returns `nil`, because we don't know where the command needs to be routed. This is handled relatively gracefully - `find_node` routes to a random node if we don't have a specific node to route to.

https://github.com/redis/redis-rb/blob/688ac958082d36f461f036cf62a96f213a11cbe7/lib/redis/cluster.rb#L258-L260
https://github.com/redis/redis-rb/blob/688ac958082d36f461f036cf62a96f213a11cbe7/lib/redis/cluster.rb#L272-L273

However, routing commands randomly means most commands are incurring an extra hop, because the randomly selected node is most likely wrong, and will need to redirect the client to the correct node. This _works_, but is a bit slower, and unnecessarily takes a dependency on an extra node (ie: if _either_ of the random node or the node our data is on is degraded, the command will fail). The client gets wedged in this wonky state for its entire lifetime, because there's no mechanism to later update the command details. Because clients are intended to be long-lived, for most use cases, this means until the process is restarted.

## Change Summary

This patch changes the client to require that the initial fetch of command details succeeds, and raises a `CannotConnectError` if that's not possible. Users should already handle this error, and retry creating the client later, or use some other suitable failure handling mechanism. Since `SlotLoader` and `NodeLoader` can already raise `CannotConnectError`, this shouldn't be a breaking change to the gem's external interface.