### PR TITLE
[Redis 6.2] Add EXAT/PXAT options to SET

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -834,14 +834,18 @@ class Redis
   # @param [Hash] options
   #   - `:ex => Integer`: Set the specified expire time, in seconds.
   #   - `:px => Integer`: Set the specified expire time, in milliseconds.
+  #   - `:exat => Integer` : Set the specified Unix time at which the key will expire, in seconds.
+  #   - `:pxat => Integer` : Set the specified Unix time at which the key will expire, in milliseconds.
   #   - `:nx => true`: Only set the key if it does not already exist.
   #   - `:xx => true`: Only set the key if it already exist.
   #   - `:keepttl => true`: Retain the time to live associated with the key.
   # @return [String, Boolean] `"OK"` or true, false if `:nx => true` or `:xx => true`
-  def set(key, value, ex: nil, px: nil, nx: nil, xx: nil, keepttl: nil)
+  def set(key, value, ex: nil, px: nil, exat: nil, pxat: nil, nx: nil, xx: nil, keepttl: nil)
     args = [:set, key, value.to_s]
     args << "EX" << ex if ex
     args << "PX" << px if px
+    args << "EXAT" << exat if exat
+    args << "PXAT" << pxat if pxat
     args << "NX" if nx
     args << "XX" if xx
     args << "KEEPTTL" if keepttl

--- a/test/lint/strings.rb
+++ b/test/lint/strings.rb
@@ -51,6 +51,20 @@ module Lint
       end
     end
 
+    def test_set_with_exat
+      target_version "6.2" do
+        r.set("foo", "bar", exat: Time.now.to_i + 2)
+        assert_in_range 0..2, r.ttl("foo")
+      end
+    end
+
+    def test_set_with_pxat
+      target_version "6.2" do
+        r.set("foo", "bar", pxat: (1000 * Time.now.to_i) + 2000)
+        assert_in_range 0..2, r.ttl("foo")
+      end
+    end
+
     def test_set_with_nx
       target_version "2.6.12" do
         r.set("foo", "qux", nx: true)


### PR DESCRIPTION
First PR here 👋🏼 For tests, I took inspiration from https://github.com/redis/redis-rb/pull/1024 as well as the existing tests for `SET` using `EX` / `PX`.
Documentation is copy-pasted from https://redis.io/commands/set#options