### PR TITLE
fix: Redis#exists(key) returns Integer as the default behaviour

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -578,7 +578,9 @@ class Redis
   # @param [String, Array<String>] keys
   # @return [Integer]
   def exists(*keys)
-    if !Redis.exists_returns_integer && keys.size == 1
+    if Redis.exists_returns_integer == false && keys.size == 1
+      exists?(*keys)
+    else
       if Redis.exists_returns_integer.nil?
         message = "`Redis#exists(key)` will return an Integer in redis-rb 4.3. `exists?` returns a boolean, you " \
           "should use it instead. To opt-in to the new behavior now you can set Redis.exists_returns_integer =  " \
@@ -589,8 +591,6 @@ class Redis
         ::Kernel.warn(message)
       end
 
-      exists?(*keys)
-    else
       _exists(*keys)
     end
   end

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -177,7 +177,9 @@ class Redis
 
     # Determine if a key exists.
     def exists(*args)
-      if !Redis.exists_returns_integer && args.size == 1
+      if Redis.exists_returns_integer == false && args.size == 1
+        exists?(*args)
+      else
         message = "`Redis#exists(key)` will return an Integer in redis-rb 4.3, if you want to keep the old behavior, " \
           "use `exists?` instead. To opt-in to the new behavior now you can set Redis.exists_returns_integer = true. " \
           "(#{::Kernel.caller(1, 1).first})\n"
@@ -187,8 +189,7 @@ class Redis
         else
           warn(message)
         end
-        exists?(*args)
-      else
+
         keys_per_node = args.group_by { |key| node_for(key) }
         keys_per_node.inject(0) do |sum, (node, keys)|
           sum + node._exists(*keys)

--- a/test/lint/value_types.rb
+++ b/test/lint/value_types.rb
@@ -3,11 +3,11 @@
 module Lint
   module ValueTypes
     def test_exists
-      assert_equal false, r.exists("foo")
+      assert_equal 0, r.exists("foo")
 
       r.set("foo", "s1")
 
-      assert_equal true,  r.exists("foo")
+      assert_equal 1, r.exists("foo")
     end
 
     def test_exists_integer
@@ -18,6 +18,18 @@ module Lint
       r.set("foo", "s1")
 
       assert_equal 1,  r.exists("foo")
+    ensure
+      Redis.exists_returns_integer = previous_exists_returns_integer
+    end
+
+    def test_exists_boolean
+      previous_exists_returns_integer = Redis.exists_returns_integer
+      Redis.exists_returns_integer = false
+      assert_equal false, r.exists("foo")
+
+      r.set("foo", "s1")
+
+      assert_equal true, r.exists("foo")
     ensure
       Redis.exists_returns_integer = previous_exists_returns_integer
     end


### PR DESCRIPTION
# Description

https://github.com/redis/redis-rb/blob/c97360b6c81f6d4d2d3e12732042b75ce0a2d004/lib/redis.rb#L576-L596

> `Redis#exists(key)` will return an Integer in redis-rb 4.3. `exists?` returns a boolean, you " \ 
         "should use it instead. To opt-in to the new behavior now you can set Redis.exists_returns_integer =  " \ 
         "true. To disable this message and keep the current (boolean) behaviour of 'exists' you can set " \ 
         "`Redis.exists_returns_integer = false`, but this option will be removed in 5.0. 

After reading the error message, I interpreted it as follows. (The text in parentheses is my own completion)

- version 4.3 or later, `Redis#exists(key)` is supposed to return integer.
- Use `Redis#exists?(key)` instead (if you want to return a boolean in version 4.3 or later).
- Set `Redis.exists_returns_integer = true` if you want to use the "new" behaviour (for users of version 4.3 or earlier)


However, in my environment using redis-rb 4.4, when `Redis.exists_returns_integer = nil` (default setting), `Redis#exists(key)` returns `boolean` with the above error message. I suspect that this is a bug.

When this message was added, the version was prior to 4.3 ([4.2.1](https://github.com/redis/redis-rb/compare/v4.2.0...v4.2.1)).
So it would have returned the previous behavior (boolean) when `Redis.exists_returns_integer = nil` or `Redis.exists_returns_integer = false`.
However, now (or later) it returns the previous behavior (boolean) only when `Redis.exists_returns_integer = false`, and not when
I think it should return `integer` if `Redis.exists_returns_integer = nil` (default) or `Redis.exists_returns_integer = true`.

Perhaps `Redis.exists_returns_boolean` will be more suitable and simpler for opt-in/opt-out applications.


Actually, this is my first pull request, so I may have the wrong way to contribute!
Please let me know if I'm wrong.
Thank you!:blush: