### PR TITLE
[Redis 6.2] Add SMISMEMBER command

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -1524,6 +1524,19 @@ class Redis
     end
   end
 
+  # Determine if multiple values are members of a set.
+  #
+  # @param [String] key
+  # @param [String, Array<String>] members
+  # @return [Array<Boolean>]
+  def smismember(key, *members)
+    synchronize do |client|
+      client.call([:smismember, key, *members]) do |reply|
+        reply.map(&Boolify)
+      end
+    end
+  end
+
   # Get all the members in a set.
   #
   # @param [String] key

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -552,6 +552,11 @@ class Redis
       node_for(key).sismember(key, member)
     end
 
+    # Determine if multiple values are members of a set.
+    def smismember(key, *members)
+      node_for(key).smismember(key, *members)
+    end
+
     # Get all the members in a set.
     def smembers(key)
       node_for(key).smembers(key)

--- a/test/lint/sets.rb
+++ b/test/lint/sets.rb
@@ -88,6 +88,18 @@ module Lint
       assert_equal false, r.sismember("foo", "s2")
     end
 
+    def test_smismember
+      target_version("6.2") do
+        assert_equal [false], r.smismember("foo", "s1")
+
+        r.sadd "foo", "s1"
+        assert_equal [true], r.smismember("foo", "s1")
+
+        r.sadd "foo", "s3"
+        assert_equal [true, false, true], r.smismember("foo", "s1", "s2", "s3")
+      end
+    end
+
     def test_smembers
       assert_equal [], r.smembers("foo")
 


### PR DESCRIPTION
This adds support for the [SMISMEMBER](https://redis.io/commands/smismember) command, which was added in Redis 6.2.

Reference: #978