### PR TITLE
[Redis 6.2] Add ZMSCORE command

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -1821,6 +1821,23 @@ class Redis
     end
   end
 
+  # Get the scores associated with the given members in a sorted set.
+  #
+  # @example Get the scores for members "a" and "b"
+  #   redis.zmscore("zset", "a", "b")
+  #     # => [32.0, 48.0]
+  #
+  # @param [String] key
+  # @param [String, Array<String>] members
+  # @return [Array<Float>] scores of the members
+  def zmscore(key, *members)
+    synchronize do |client|
+      client.call([:zmscore, key, *members]) do |reply|
+        reply.map(&Floatify)
+      end
+    end
+  end
+
   # Return a range of members in a sorted set, by index.
   #
   # @example Retrieve all members from a sorted set

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -641,6 +641,11 @@ class Redis
       node_for(key).zscore(key, member)
     end
 
+    # Get the scores associated with the given members in a sorted set.
+    def zmscore(key, *members)
+      node_for(key).zmscore(key, *members)
+    end
+
     # Return a range of members in a sorted set, by index.
     def zrange(key, start, stop, **options)
       node_for(key).zrange(key, start, stop, **options)

--- a/test/lint/sorted_sets.rb
+++ b/test/lint/sorted_sets.rb
@@ -293,6 +293,20 @@ module Lint
       assert_equal(+Float::INFINITY, r.zscore("bar", "s2"))
     end
 
+    def test_zmscore
+      target_version("6.2") do
+        r.zadd "foo", 1, "s1"
+
+        assert_equal [1.0], r.zmscore("foo", "s1")
+        assert_equal [nil], r.zmscore("foo", "s2")
+
+        r.zadd "foo", "-inf", "s2"
+        r.zadd "foo", "+inf", "s3"
+        assert_equal [1.0, nil], r.zmscore("foo", "s1", "s4")
+        assert_equal [-Float::INFINITY, +Float::INFINITY], r.zmscore("foo", "s2", "s3")
+      end
+    end
+
     def test_zremrangebyrank
       r.zadd "foo", 10, "s1"
       r.zadd "foo", 20, "s2"


### PR DESCRIPTION
This adds support for the [ZMSCORE](https://redis.io/commands/zmscore) command, which was added in Redis 6.2.

Reference: #978