### PR TITLE
[Redis 6.2] Add LMOVE/BLMOVE commands

### DIFF
--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -403,6 +403,21 @@ class Redis
       node_for(key).llen(key)
     end
 
+    # Remove the first/last element in a list, append/prepend it to another list and return it.
+    def lmove(source, destination, where_source, where_destination)
+      ensure_same_node(:lmove, [source, destination]) do |node|
+        node.lmove(source, destination, where_source, where_destination)
+      end
+    end
+
+    # Remove the first/last element in a list and append/prepend it
+    # to another list and return it, or block until one is available.
+    def blmove(source, destination, where_source, where_destination, timeout: 0)
+      ensure_same_node(:lmove, [source, destination]) do |node|
+        node.blmove(source, destination, where_source, where_destination, timeout: timeout)
+      end
+    end
+
     # Prepend one or more values to a list.
     def lpush(key, value)
       node_for(key).lpush(key, value)

--- a/test/blocking_commands_test.rb
+++ b/test/blocking_commands_test.rb
@@ -21,6 +21,14 @@ class TestBlockingCommands < Minitest::Test
     end
   end
 
+  def test_blmove_disable_client_timeout
+    target_version "6.2" do
+      assert_takes_longer_than_client_timeout do |r|
+        assert_equal '0', r.blmove('foo', 'bar', 'LEFT', 'RIGHT')
+      end
+    end
+  end
+
   def test_blpop_disable_client_timeout
     assert_takes_longer_than_client_timeout do |r|
       assert_equal %w[foo 0], r.blpop('foo')

--- a/test/cluster_commands_on_lists_test.rb
+++ b/test/cluster_commands_on_lists_test.rb
@@ -9,6 +9,12 @@ class TestClusterCommandsOnLists < Minitest::Test
   include Helper::Cluster
   include Lint::Lists
 
+  def test_lmove
+    target_version "6.2" do
+      assert_raises(Redis::CommandError) { super }
+    end
+  end
+
   def test_rpoplpush
     assert_raises(Redis::CommandError) { super }
   end

--- a/test/distributed_blocking_commands_test.rb
+++ b/test/distributed_blocking_commands_test.rb
@@ -7,6 +7,14 @@ class TestDistributedBlockingCommands < Minitest::Test
   include Helper::Distributed
   include Lint::BlockingCommands
 
+  def test_blmove_raises
+    target_version "6.2" do
+      assert_raises(Redis::Distributed::CannotDistribute) do
+        r.blmove('foo', 'bar', 'LEFT', 'RIGHT')
+      end
+    end
+  end
+
   def test_blpop_raises
     assert_raises(Redis::Distributed::CannotDistribute) do
       r.blpop(%w[foo bar])

--- a/test/distributed_commands_on_lists_test.rb
+++ b/test/distributed_commands_on_lists_test.rb
@@ -7,6 +7,14 @@ class TestDistributedCommandsOnLists < Minitest::Test
   include Helper::Distributed
   include Lint::Lists
 
+  def test_lmove
+    target_version "6.2" do
+      assert_raises Redis::Distributed::CannotDistribute do
+        r.lmove('foo', 'bar', 'LEFT', 'RIGHT')
+      end
+    end
+  end
+
   def test_rpoplpush
     assert_raises Redis::Distributed::CannotDistribute do
       r.rpoplpush('foo', 'bar')

--- a/test/distributed_commands_requiring_clustering_test.rb
+++ b/test/distributed_commands_requiring_clustering_test.rb
@@ -23,6 +23,19 @@ class TestDistributedCommandsRequiringClustering < Minitest::Test
     assert_equal "s2", r.get("{qux}bar")
   end
 
+  def test_lmove
+    target_version "6.2" do
+      r.rpush("{qux}foo", "s1")
+      r.rpush("{qux}foo", "s2")
+      r.rpush("{qux}bar", "s3")
+      r.rpush("{qux}bar", "s4")
+
+      assert_equal "s1", r.lmove("{qux}foo", "{qux}bar", "LEFT", "RIGHT")
+      assert_equal ["s2"], r.lrange("{qux}foo", 0, -1)
+      assert_equal ["s3", "s4", "s1"], r.lrange("{qux}bar", 0, -1)
+    end
+  end
+
   def test_brpoplpush
     r.rpush "{qux}foo", "s1"
     r.rpush "{qux}foo", "s2"

--- a/test/lint/lists.rb
+++ b/test/lint/lists.rb
@@ -2,6 +2,33 @@
 
 module Lint
   module Lists
+    def test_lmove
+      target_version "6.2" do
+        r.lpush("foo", "s1")
+        r.lpush("foo", "s2") # foo = [s2, s1]
+        r.lpush("bar", "s3")
+        r.lpush("bar", "s4") # bar = [s4, s3]
+
+        assert_nil r.lmove("nonexistent", "foo", "LEFT", "LEFT")
+
+        assert_equal "s2", r.lmove("foo", "foo", "LEFT", "RIGHT") # foo = [s1, s2]
+        assert_equal "s1", r.lmove("foo", "foo", "LEFT", "LEFT") # foo = [s1, s2]
+
+        assert_equal "s1", r.lmove("foo", "bar", "LEFT", "RIGHT") # foo = [s2], bar = [s4, s3, s1]
+        assert_equal ["s2"], r.lrange("foo", 0, -1)
+        assert_equal ["s4", "s3", "s1"], r.lrange("bar", 0, -1)
+
+        assert_equal "s2", r.lmove("foo", "bar", "LEFT", "LEFT") # foo = [], bar = [s2, s4, s3, s1]
+        assert_nil r.lmove("foo", "bar", "LEFT", "LEFT") # foo = [], bar = [s2, s4, s3, s1]
+        assert_equal ["s2", "s4", "s3", "s1"], r.lrange("bar", 0, -1)
+
+        error = assert_raises(ArgumentError) do
+          r.lmove("foo", "bar", "LEFT", "MIDDLE")
+        end
+        assert_equal "where_destination must be 'LEFT' or 'RIGHT'", error.message
+      end
+    end
+
     def test_lpush
       r.lpush "foo", "s1"
       r.lpush "foo", "s2"


### PR DESCRIPTION
This adds support for the [LMOVE](https://redis.io/commands/lmove) and [BLMOVE](https://redis.io/commands/blmove) commands, which [were added](https://github.com/redis/redis/pull/6929) in Redis 6.2 and are intended as a future replacement for RPOPLPUSH/BRPOPLPUSH.

Reference: #978