### PR TITLE
[Redis 6.2] Add ZRANDMEMBER command

### DIFF
--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -656,6 +656,11 @@ class Redis
       node_for(key).zscore(key, member)
     end
 
+    # Get one or more random members from a sorted set.
+    def zrandmember(key, count = nil, **options)
+      node_for(key).zrandmember(key, count, **options)
+    end
+
     # Get the scores associated with the given members in a sorted set.
     def zmscore(key, *members)
       node_for(key).zmscore(key, *members)

--- a/test/lint/sorted_sets.rb
+++ b/test/lint/sorted_sets.rb
@@ -358,6 +358,34 @@ module Lint
       end
     end
 
+    def test_zrandmember
+      target_version("6.2") do
+        assert_nil r.zrandmember("foo")
+
+        r.zadd "foo", 1.0, "s1"
+        r.zrem "foo", "s1"
+        assert_nil r.zrandmember("foo")
+        assert_equal [], r.zrandmember("foo", 1)
+
+        r.zadd "foo", 1.0, "s1"
+        r.zadd "foo", 2.0, "s2"
+        r.zadd "foo", 3.0, "s3"
+
+        3.times do
+          assert ["s1", "s2", "s3"].include?(r.zrandmember("foo"))
+        end
+
+        assert_equal 2, r.zrandmember("foo", 2).size
+        assert_equal 3, r.zrandmember("foo", 4).size
+        assert_equal 5, r.zrandmember("foo", -5).size
+
+        r.zrandmember("foo", 2, with_scores: true).each do |(member, score)|
+          assert ["s1", "s2", "s3"].include?(member)
+          assert_instance_of Float, score
+        end
+      end
+    end
+
     def test_zremrangebyrank
       r.zadd "foo", 10, "s1"
       r.zadd "foo", 20, "s2"


### PR DESCRIPTION
This adds support for [ZRANDMEMBER](https://redis.io/commands/zrandmember) command, introduced in Redis 6.2

Ref: #978 