### PR TITLE
[Redis 6.2] Add GET option to SET command

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -841,8 +841,9 @@ class Redis
   #   - `:nx => true`: Only set the key if it does not already exist.
   #   - `:xx => true`: Only set the key if it already exist.
   #   - `:keepttl => true`: Retain the time to live associated with the key.
+  #   - `:get => true`: Return the old string stored at key, or nil if key did not exist.
   # @return [String, Boolean] `"OK"` or true, false if `:nx => true` or `:xx => true`
-  def set(key, value, ex: nil, px: nil, exat: nil, pxat: nil, nx: nil, xx: nil, keepttl: nil)
+  def set(key, value, ex: nil, px: nil, exat: nil, pxat: nil, nx: nil, xx: nil, keepttl: nil, get: nil)
     args = [:set, key, value.to_s]
     args << "EX" << ex if ex
     args << "PX" << px if px
@@ -851,6 +852,7 @@ class Redis
     args << "NX" if nx
     args << "XX" if xx
     args << "KEEPTTL" if keepttl
+    args << "GET" if get
 
     synchronize do |client|
       if nx || xx

--- a/test/lint/strings.rb
+++ b/test/lint/strings.rb
@@ -97,6 +97,18 @@ module Lint
       end
     end
 
+    def test_set_with_get
+      target_version "6.2" do
+        r.set("foo", "qux")
+
+        assert_equal "qux", r.set("foo", "bar", get: true)
+        assert_equal "bar", r.get("foo")
+
+        assert_nil r.set("baz", "bar", get: true)
+        assert_equal "bar", r.get("baz")
+      end
+    end
+
     def test_setex
       assert r.setex("foo", 1, "bar")
       assert_equal "bar", r.get("foo")


### PR DESCRIPTION
This adds `GET` option for [`SET`](https://redis.io/commands/set) command, [introduced](https://github.com/redis/redis/pull/7852) in Redis 6.2. This most probably will be a replacement for `GETSET` in the future Redis versions.

Ref: #978 