### PR TITLE
[Redis 6.2] Add ZUNION command

### DIFF
--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -729,6 +729,13 @@ class Redis
       end
     end
 
+    # Return the union of multiple sorted sets.
+    def zunion(*keys, **options)
+      ensure_same_node(:zunion, keys) do |node|
+        node.zunion(*keys, **options)
+      end
+    end
+
     # Add multiple sorted sets and store the resulting sorted set in a new key.
     def zunionstore(destination, keys, **options)
       ensure_same_node(:zunionstore, [destination] + keys) do |node|

--- a/test/cluster_commands_on_sorted_sets_test.rb
+++ b/test/cluster_commands_on_sorted_sets_test.rb
@@ -33,6 +33,18 @@ class TestClusterCommandsOnSortedSets < Minitest::Test
     assert_raises(Redis::CommandError) { super }
   end
 
+  def test_zunion
+    assert_raises(Redis::CommandError) { super }
+  end
+
+  def test_zunion_with_aggregate
+    assert_raises(Redis::CommandError) { super }
+  end
+
+  def test_zunion_with_weights
+    assert_raises(Redis::CommandError) { super }
+  end
+
   def test_zunionstore
     assert_raises(Redis::CommandError) { super }
   end

--- a/test/distributed_commands_on_sorted_sets_test.rb
+++ b/test/distributed_commands_on_sorted_sets_test.rb
@@ -59,6 +59,18 @@ class TestDistributedCommandsOnSortedSets < Minitest::Test
     # Not implemented yet
   end
 
+  def test_zunion
+    assert_raises(Redis::Distributed::CannotDistribute) { super }
+  end
+
+  def test_zunion_with_aggregate
+    assert_raises(Redis::Distributed::CannotDistribute) { super }
+  end
+
+  def test_zunion_with_weights
+    assert_raises(Redis::Distributed::CannotDistribute) { super }
+  end
+
   def test_zunionstore
     assert_raises(Redis::Distributed::CannotDistribute) { super }
   end


### PR DESCRIPTION
Adds [ZUNION](https://redis.io/commands/zunion) command from redis 6.2.
I decided to extract a private helper method for both `zinter` and `zunion` to remove duplication.

Reference: #978