### PR TITLE
[Redis 6.2] Add ZDIFF command

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -2346,6 +2346,30 @@ class Redis
     end
   end
 
+  # Return the difference between the first and all successive input sorted sets
+  #
+  # @example
+  #   redis.zadd("zsetA", [[1.0, "v1"], [2.0, "v2"]])
+  #   redis.zadd("zsetB", [[3.0, "v2"], [2.0, "v3"]])
+  #   redis.zdiff("zsetA", "zsetB")
+  #     => ["v1"]
+  # @example With scores
+  #   redis.zadd("zsetA", [[1.0, "v1"], [2.0, "v2"]])
+  #   redis.zadd("zsetB", [[3.0, "v2"], [2.0, "v3"]])
+  #   redis.zdiff("zsetA", "zsetB", :with_scores => true)
+  #     => [["v1", 1.0]]
+  #
+  # @param [String, Array<String>] keys one or more keys to compute the difference
+  # @param [Hash] options
+  #   - `:with_scores => true`: include scores in output
+  #
+  # @return [Array<String>, Array<[String, Float]>]
+  #   - when `:with_scores` is not specified, an array of members
+  #   - when `:with_scores` is specified, an array with `[member, score]` pairs
+  def zdiff(*keys, with_scores: false)
+    _zsets_operation(:zdiff, *keys, with_scores: with_scores)
+  end
+
   # Get the number of fields in a hash.
   #
   # @param [String] key

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -743,6 +743,13 @@ class Redis
       end
     end
 
+    # Return the difference between the first and all successive input sorted sets.
+    def zdiff(*keys, **options)
+      ensure_same_node(:zdiff, keys) do |node|
+        node.zdiff(*keys, **options)
+      end
+    end
+
     # Get the number of fields in a hash.
     def hlen(key)
       node_for(key).hlen(key)

--- a/test/cluster_commands_on_sorted_sets_test.rb
+++ b/test/cluster_commands_on_sorted_sets_test.rb
@@ -56,4 +56,8 @@ class TestClusterCommandsOnSortedSets < Minitest::Test
   def test_zunionstore_with_weights
     assert_raises(Redis::CommandError) { super }
   end
+
+  def test_zdiff
+    assert_raises(Redis::CommandError) { super }
+  end
 end

--- a/test/distributed_commands_on_sorted_sets_test.rb
+++ b/test/distributed_commands_on_sorted_sets_test.rb
@@ -82,4 +82,8 @@ class TestDistributedCommandsOnSortedSets < Minitest::Test
   def test_zunionstore_with_weights
     assert_raises(Redis::Distributed::CannotDistribute) { super }
   end
+
+  def test_zdiff
+    assert_raises(Redis::Distributed::CannotDistribute) { super }
+  end
 end

--- a/test/lint/sorted_sets.rb
+++ b/test/lint/sorted_sets.rb
@@ -571,6 +571,21 @@ module Lint
       assert_equal 5, r.zunionstore('{1}baz', %w[{1}foo {1}bar])
     end
 
+    def test_zdiff
+      target_version("6.2") do
+        r.zadd 'foo', 1, 's1'
+        r.zadd 'foo', 2, 's2'
+        r.zadd 'bar', 3, 's1'
+        r.zadd 'bar', 5, 's3'
+
+        assert_equal [], r.zdiff('foo', 'foo')
+        assert_equal ['s1', 's2'], r.zdiff('foo')
+
+        assert_equal ['s2'], r.zdiff('foo', 'bar')
+        assert_equal [['s2', 2.0]], r.zdiff('foo', 'bar', with_scores: true)
+      end
+    end
+
     def test_zinter
       target_version("6.2") do
         r.zadd 'foo', 1, 's1'


### PR DESCRIPTION
Adds support for [ZDIFF](https://redis.io/commands/zdiff) command from redis 6.2.

There is also [ZDIFFSTORE](https://redis.io/commands/zdiffstore). But would be better to add it in a separate PR, because it needs a small refactoring.

Reference #978