### PR TITLE
[Redis 6.2] Add ZDIFFSTORE command

### DIFF
--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -750,6 +750,14 @@ class Redis
       end
     end
 
+    # Compute the difference between the first and all successive input sorted sets
+    # and store the resulting sorted set in a new key.
+    def zdiffstore(destination, keys, **options)
+      ensure_same_node(:zdiffstore, [destination] + keys) do |node|
+        node.zdiffstore(destination, keys, **options)
+      end
+    end
+
     # Get the number of fields in a hash.
     def hlen(key)
       node_for(key).hlen(key)

--- a/test/cluster_commands_on_sorted_sets_test.rb
+++ b/test/cluster_commands_on_sorted_sets_test.rb
@@ -60,4 +60,8 @@ class TestClusterCommandsOnSortedSets < Minitest::Test
   def test_zdiff
     assert_raises(Redis::CommandError) { super }
   end
+
+  def test_zdiffstore
+    assert_raises(Redis::CommandError) { super }
+  end
 end

--- a/test/distributed_commands_on_sorted_sets_test.rb
+++ b/test/distributed_commands_on_sorted_sets_test.rb
@@ -86,4 +86,8 @@ class TestDistributedCommandsOnSortedSets < Minitest::Test
   def test_zdiff
     assert_raises(Redis::Distributed::CannotDistribute) { super }
   end
+
+  def test_zdiffstore
+    assert_raises(Redis::Distributed::CannotDistribute) { super }
+  end
 end

--- a/test/lint/sorted_sets.rb
+++ b/test/lint/sorted_sets.rb
@@ -586,6 +586,22 @@ module Lint
       end
     end
 
+    def test_zdiffstore
+      target_version("6.2") do
+        r.zadd 'foo', 1, 's1'
+        r.zadd 'foo', 2, 's2'
+        r.zadd 'bar', 3, 's1'
+        r.zadd 'bar', 5, 's3'
+
+        assert_equal 0, r.zdiffstore('baz', ['foo', 'foo'])
+        assert_equal 2, r.zdiffstore('baz', ['foo'])
+        assert_equal ['s1', 's2'], r.zrange('baz', 0, -1)
+
+        assert_equal 1, r.zdiffstore('baz', ['foo', 'bar'])
+        assert_equal ['s2'], r.zrange('baz', 0, -1)
+      end
+    end
+
     def test_zinter
       target_version("6.2") do
         r.zadd 'foo', 1, 's1'


### PR DESCRIPTION
Adds support for [ZDIFFSTORE](https://redis.io/commands/zdiffstore) from redis 6.2.
Ref: #978