### PR TITLE
Add _read_from_socket extra argument support for JRuby

### DIFF
--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -133,7 +133,9 @@ class Redis
           # says it is readable (1.6.6, in both 1.8 and 1.9 mode).
           # Use the blocking #readpartial method instead.
 
-          def _read_from_socket(nbytes)
+          def _read_from_socket(nbytes, _buffer = nil)
+            # JRuby: Throw away the buffer as we won't need it
+            # but still need to support the max arity of 2
             readpartial(nbytes)
           rescue EOFError
             raise Errno::ECONNRESET


### PR DESCRIPTION
Recently we have been seeing errors in our production JRuby environment starting with `4.5.0+`
```
warning: thread "Ruby-0-Thread-1828: :1" terminated with exception (report_on_exception is true):
ArgumentError: wrong number of arguments (given 2, expected 1)
                     read at /app/shared/bundle/jruby/2.5.0/gems/redis-4.5.1/lib/redis/connection/ruby.rb:39
        format_bulk_reply at /app/shared/bundle/jruby/2.5.0/gems/redis-4.5.1/lib/redis/connection/ruby.rb:413
             format_reply at /app/shared/bundle/jruby/2.5.0/gems/redis-4.5.1/lib/redis/connection/ruby.rb:391
                     read at /app/shared/bundle/jruby/2.5.0/gems/redis-4.5.1/lib/redis/connection/ruby.rb:381
  format_multi_bulk_reply at /app/shared/bundle/jruby/2.5.0/gem
```

I was able to track down that there is an arity mismatch when calling `_read_from_socket` when using JRuby, because the JRuby method had an arity of 1 but it needs to support the extra `buffer` parameter even though it won't use it.

Should I add an additional method to check whether or not to skip creating the buffer in the first place? 

For now I believe this would be an adequate patch for JRuby to support 4.5.2+ etc.