### PR TITLE
[Redis 6.2] Add new options to ZRANGE and implement new ZRANGESTORE command

### DIFF
--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -673,9 +673,17 @@ class Redis
       node_for(key).zmscore(key, *members)
     end
 
-    # Return a range of members in a sorted set, by index.
+    # Return a range of members in a sorted set, by index, score or lexicographical ordering.
     def zrange(key, start, stop, **options)
       node_for(key).zrange(key, start, stop, **options)
+    end
+
+    # Select a range of members in a sorted set, by index, score or lexicographical ordering
+    # and store the resulting sorted set in a new key.
+    def zrangestore(dest_key, src_key, start, stop, **options)
+      ensure_same_node(:zrangestore, [dest_key, src_key]) do |node|
+        node.zrangestore(dest_key, src_key, start, stop, **options)
+      end
     end
 
     # Return a range of members in a sorted set, by index, with scores ordered

--- a/test/cluster_commands_on_sorted_sets_test.rb
+++ b/test/cluster_commands_on_sorted_sets_test.rb
@@ -9,6 +9,10 @@ class TestClusterCommandsOnSortedSets < Minitest::Test
   include Helper::Cluster
   include Lint::SortedSets
 
+  def test_zrangestore
+    assert_raises(Redis::CommandError) { super }
+  end
+
   def test_zinter
     assert_raises(Redis::CommandError) { super }
   end

--- a/test/distributed_commands_on_sorted_sets_test.rb
+++ b/test/distributed_commands_on_sorted_sets_test.rb
@@ -7,6 +7,10 @@ class TestDistributedCommandsOnSortedSets < Minitest::Test
   include Helper::Distributed
   include Lint::SortedSets
 
+  def test_zrangestore
+    assert_raises(Redis::Distributed::CannotDistribute) { super }
+  end
+
   def test_zinter
     assert_raises(Redis::Distributed::CannotDistribute) { super }
   end


### PR DESCRIPTION
Redis 6.2 introduced new options to [`ZRANGE`](https://redis.io/commands/zrange) and a new command [`ZRANGESTORE`](https://redis.io/commands/zrangestore) as a future replacement for several existing commands like `ZREVRANGE`, `ZREVRANGEBYLEX`, `ZRANGEBYSCORE` etc.

Refrence #978