### PR TITLE
Fix zpopmax zpopmin in pipelines

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -1834,8 +1834,10 @@ class Redis
   # @return [Array<Array<String, Float>>] list of popped elements and scores
   def zpopmax(key, count = nil)
     synchronize do |client|
-      members = client.call([:zpopmax, key, count].compact, &FloatifyPairs)
-      count.to_i > 1 ? members : members.first
+      client.call([:zpopmax, key, count].compact) do |members|
+        members = FloatifyPairs.call(members)
+        count.to_i > 1 ? members : members.first
+      end
     end
   end
 
@@ -1855,8 +1857,10 @@ class Redis
   # @return [Array<Array<String, Float>>] list of popped elements and scores
   def zpopmin(key, count = nil)
     synchronize do |client|
-      members = client.call([:zpopmin, key, count].compact, &FloatifyPairs)
-      count.to_i > 1 ? members : members.first
+      client.call([:zpopmin, key, count].compact) do |members|
+        members = FloatifyPairs.call(members)
+        count.to_i > 1 ? members : members.first
+      end
     end
   end
 

--- a/test/pipelining_commands_test.rb
+++ b/test/pipelining_commands_test.rb
@@ -199,6 +199,17 @@ class TestPipeliningCommands < Minitest::Test
     assert_equal result.first, { "field" => "value" }
   end
 
+  def test_zpopmax_in_a_pipeline_produces_future
+    r.zadd("sortedset", 1.0, "value")
+    future = nil
+    result = r.pipelined do
+      future = r.zpopmax("sortedset")
+    end
+
+    assert_equal [["value", 1.0]], result
+    assert_equal ["value", 1.0], future.value
+  end
+
   def test_keys_in_a_pipeline
     r.set("key", "value")
     result = r.pipelined do


### PR DESCRIPTION
ZPOPMAX/ZPOPMIN cause an exception when used within a pipeline:

```
NoMethodError: undefined method `first' for <Redis::Future [:zpopmax, "sortedset"]>:Redis::Future
```

This is caused by attempting to modify the return value directly rather than within a transform block.

PR includes two commits:
 * first is an addition to the test suite to demonstrate the bug.
 * second is a fix for the bug, that passes the test suite.