### PR TITLE
Deprecate `Redis#queue`, `Redis#commit` and `Redis#pipelined` without block.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -132,3 +132,7 @@ Metrics/BlockNesting:
 
 Style/HashTransformValues:
   Enabled: false
+
+Style/SymbolProc:
+  Exclude:
+    - 'test/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Unreleased
 
+* Deprecate calling commands on `Redis` inside `Redis#pipelined`. See #1059.
+  ```ruby
+  redis.pipelined do
+    redis.get("key")
+  end
+  ```
+
+  should be replaced by:
+
+  ```ruby
+  redis.pipelined do |pipeline|
+    pipeline.get("key")
+  end
+  ```
+* Deprecate `Redis#queue` and `Redis#commit`. See #1059.
 * Add `Redis.silence_deprecations=` to turn off deprecation warnings.
   If you don't wish to see warnings yet, you can set `Redis.silence_deprecations = false`.
   It is however heavily recommended to fix them instead when possible. 

--- a/README.md
+++ b/README.md
@@ -184,9 +184,9 @@ commands to Redis and gathers their replies. These replies are returned
 by the `#pipelined` method.
 
 ```ruby
-redis.pipelined do
-  redis.set "foo", "bar"
-  redis.incr "baz"
+redis.pipelined do |pipeline|
+  pipeline.set "foo", "bar"
+  pipeline.incr "baz"
 end
 # => ["OK", 1]
 ```
@@ -210,15 +210,15 @@ end
 ### Futures
 
 Replies to commands in a pipeline can be accessed via the *futures* they
-emit (since redis-rb 3.0). All calls inside a pipeline block return a
+emit (since redis-rb 3.0). All calls on the pipeline object return a
 `Future` object, which responds to the `#value` method. When the
 pipeline has successfully executed, all futures are assigned their
 respective replies and can be used.
 
 ```ruby
-redis.pipelined do
-  @set = redis.set "foo", "bar"
-  @incr = redis.incr "baz"
+redis.pipelined do |pipeline|
+  @set = pipeline.set "foo", "bar"
+  @incr = pipeline.incr "baz"
 end
 
 @set.value


### PR DESCRIPTION
All theses make a lot of assumptions on the threading model and are barely thread safe.

The new favored API is:

```ruby
redis.pipelined do |pipeline|
  pipeline.get("foo")
  pipeline.del("bar")
end
```

This API allow multiple threads to build pipelines concurrently on the same connection, and is more friendly to Fiber based concurrency.

Fix: https://github.com/redis/redis-rb/pull/1057

The same should be applied to `Redis#multi`, and we might want to add an easy way to turn off deprecation warnings.

FYI: @machty 