### PR TITLE
Refactor deprecation warnings and add `Redis.silence_deprecations=`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+* Add `Redis.silence_deprecations=` to turn off deprecation warnings.
+  If you don't wish to see warnings yet, you can set `Redis.silence_deprecations = false`.
+  It is however heavily recommended to fix them instead when possible. 
 * Add new options to ZRANGE. See #1053.
 * Add ZRANGESTORE command. See #1053.
 * Add SCAN support for `Redis::Cluster`. See #1049.

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -9,17 +9,22 @@ class Redis
 
   class << self
     attr_reader :exists_returns_integer
+    attr_accessor :silence_deprecations
 
     def exists_returns_integer=(value)
       unless value
-        message = "`Redis#exists(key)` will return an Integer by default in redis-rb 4.3. The option to explicitly " \
+        deprecate!(
+          "`Redis#exists(key)` will return an Integer by default in redis-rb 4.3. The option to explicitly " \
           "disable this behaviour via `Redis.exists_returns_integer` will be removed in 5.0. You should use " \
           "`exists?` instead."
-
-        ::Kernel.warn(message)
+        )
       end
 
       @exists_returns_integer = value
+    end
+
+    def deprecate!(message)
+      ::Kernel.warn(message) unless silence_deprecations
     end
 
     attr_writer :current

--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -127,9 +127,9 @@ class Redis
                 rescue CommandError
                   raise err
                 end
-                ::Kernel.warn(
+                ::Redis.deprecate!(
                   "[redis-rb] The Redis connection was configured with username #{username.inspect}, but" \
-                  " the provided password was for the default user. This will start failing in redis-rb 4.6."
+                  " the provided password was for the default user. This will start failing in redis-rb 5.0.0."
                 )
               else
                 raise

--- a/lib/redis/commands/keys.rb
+++ b/lib/redis/commands/keys.rb
@@ -210,10 +210,10 @@ class Redis
             message = "`Redis#exists(key)` will return an Integer in redis-rb 4.3. `exists?` returns a boolean, you " \
               "should use it instead. To opt-in to the new behavior now you can set Redis.exists_returns_integer =  " \
               "true. To disable this message and keep the current (boolean) behaviour of 'exists' you can set " \
-              "`Redis.exists_returns_integer = false`, but this option will be removed in 5.0. " \
+              "`Redis.exists_returns_integer = false`, but this option will be removed in 5.0.0. " \
               "(#{::Kernel.caller(1, 1).first})\n"
 
-            ::Kernel.warn(message)
+            ::Redis.deprecate!(message)
           end
 
           exists?(*keys)

--- a/lib/redis/connection/synchrony.rb
+++ b/lib/redis/connection/synchrony.rb
@@ -6,8 +6,8 @@ require_relative "../errors"
 require "em-synchrony"
 require "hiredis/reader"
 
-Kernel.warn(
-  "The redis synchrony driver is deprecated and will be removed in redis-rb 5.0. " \
+::Redis.deprecate!(
+  "The redis synchrony driver is deprecated and will be removed in redis-rb 5.0.0. " \
   "We're looking for people to maintain it as a separate gem, see https://github.com/redis/redis-rb/issues/915"
 )
 

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -178,15 +178,11 @@ class Redis
     # Determine if a key exists.
     def exists(*args)
       if !Redis.exists_returns_integer && args.size == 1
-        message = "`Redis#exists(key)` will return an Integer in redis-rb 4.3, if you want to keep the old behavior, " \
+        ::Redis.deprecate!(
+          "`Redis#exists(key)` will return an Integer in redis-rb 4.3, if you want to keep the old behavior, " \
           "use `exists?` instead. To opt-in to the new behavior now you can set Redis.exists_returns_integer = true. " \
           "(#{::Kernel.caller(1, 1).first})\n"
-
-        if defined?(::Warning)
-          ::Warning.warn(message)
-        else
-          warn(message)
-        end
+        )
         exists?(*args)
       else
         keys_per_node = args.group_by { |key| node_for(key) }

--- a/lib/redis/pipeline.rb
+++ b/lib/redis/pipeline.rb
@@ -143,11 +143,11 @@ class Redis
     end
 
     def ==(_other)
-      message = +"The methods == and != are deprecated for Redis::Future and will be removed in 4.2.0"
+      message = +"The methods == and != are deprecated for Redis::Future and will be removed in 5.0.0"
       message << " - You probably meant to call .value == or .value !="
       message << " (#{::Kernel.caller(1, 1).first})\n"
 
-      ::Kernel.warn(message)
+      ::Redis.deprecate!(message)
 
       super
     end

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -30,7 +30,6 @@ class TestConnection < Minitest::Test
   def test_connection_with_wrong_user_and_password
     target_version "6.0" do
       with_default_user_password do |_username, password|
-        Kernel.expects(:warn).once
         redis = Redis.new(OPTIONS.merge(username: "does-not-exist", password: password))
         assert_equal "PONG", redis.ping
       end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -10,6 +10,8 @@ $VERBOSE = true
 ENV["DRIVER"] ||= "ruby"
 
 require_relative "../lib/redis"
+Redis.silence_deprecations = true
+
 require_relative "../lib/redis/distributed"
 require_relative "../lib/redis/connection/#{ENV['DRIVER']}"
 

--- a/test/pipelining_commands_test.rb
+++ b/test/pipelining_commands_test.rb
@@ -140,9 +140,8 @@ class TestPipeliningCommands < Minitest::Test
       @result = r.sadd("foo", 1)
     end
 
-    assert_output(nil, /deprecated/) do
-      @result == 1
-    end
+    Redis.expects(:deprecate!).once
+    @result == 1
   end
 
   def test_futures_can_be_identified


### PR DESCRIPTION
Some warnings can be quite noisy, and in some situation like the deprecated call being in a dependency, it might take a while to be fixed. 