### PR TITLE
Fix cluster node selection for SCAN, SSCAN, HSCAN, ZSCAN

### DIFF
--- a/lib/redis/cluster/command.rb
+++ b/lib/redis/cluster/command.rb
@@ -53,8 +53,6 @@ class Redis
         when 'object' then 2
         when 'memory'
           command[1].to_s.casecmp('usage').zero? ? 2 : 0
-        when 'scan', 'sscan', 'hscan', 'zscan'
-          determine_optional_key_position(command, 'match')
         when 'xread', 'xreadgroup'
           determine_optional_key_position(command, 'streams')
         else

--- a/test/cluster_client_key_hash_tags_test.rb
+++ b/test/cluster_client_key_hash_tags_test.rb
@@ -22,6 +22,12 @@ class TestClusterClientKeyHashTags < Minitest::Test
     assert_equal 'foo{}{bar}', described_class.extract_first_key(%w[get foo{}{bar}])
     assert_equal '{bar', described_class.extract_first_key(%w[get foo{{bar}}zap])
     assert_equal 'bar', described_class.extract_first_key(%w[get foo{bar}{zap}])
+    assert_equal 'dogs', described_class.extract_first_key([:sscan, 'dogs', 0])
+    assert_equal 'dogs', described_class.extract_first_key([:sscan, 'dogs', 0, 'MATCH', '/poodle/', 'COUNT', 10])
+    assert_equal 'dogs', described_class.extract_first_key([:hscan, 'dogs', 0])
+    assert_equal 'dogs', described_class.extract_first_key([:hscan, 'dogs', 0, 'MATCH', '/poodle/', 'COUNT', 10])
+    assert_equal 'dogs', described_class.extract_first_key([:zscan, 'dogs', 0])
+    assert_equal 'dogs', described_class.extract_first_key([:zscan, 'dogs', 0, 'MATCH', '/poodle/', 'COUNT', 10])
 
     assert_equal '', described_class.extract_first_key([:get, ''])
     assert_equal '', described_class.extract_first_key([:get, nil])
@@ -32,6 +38,8 @@ class TestClusterClientKeyHashTags < Minitest::Test
     assert_equal '', described_class.extract_first_key([:set])
 
     # Keyless commands
+    assert_equal '', described_class.extract_first_key([:scan, 0])
+    assert_equal '', described_class.extract_first_key([:scan, 0, 'MATCH', '/poodle/', 'COUNT', 10])
     assert_equal '', described_class.extract_first_key([:auth, 'password'])
     assert_equal '', described_class.extract_first_key(%i[client kill])
     assert_equal '', described_class.extract_first_key(%i[cluster addslots])


### PR DESCRIPTION
We found that while using `SSCAN` on a stable cluster (where no hash slots are being moved from one node to another) we were getting a lot of `MOVED` responses. 

Upon investigation we saw that for `SSCAN` the client was selecting a random writer node. I may be missing the original intent of the removed branch of the `case` statement but it seems like we shouldn't care about the position of the `match` option as the argument for it is a pattern not a key. Before this change `Cluster#find_node_key` was returning `nil` for all flavors of scan which was causing `Cluster#find_node` to select a [random node](https://github.com/redis/redis-rb/blob/9446688ab50386c4b05e9c2da9b1bdbe5a718aae/lib/redis/cluster.rb#L297). Tested out this branch and the `MOVED` responses went away while `SSCAN` continued to function normally.


