### PR TITLE
Fix support for transaction inside pippelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix the block form of `multi` called inside `pipelined`. Previously the `MUTLI/EXEC` wouldn't be sent. See #1073.
+
 # 4.6.0
 
 * Deprecate `Redis.current`.


### PR DESCRIPTION
Fix: https://github.com/redis/redis-rb/issues/1069

This actually never really worked.

```ruby
redis.pipelined do
  redis.mutli do
    redis.get("foo")
    redis.get("bar")
  end
end
```

Was actually skipping the transaction:

```
GET foo
GET bar
```

Instead of:

```
MULTI
GET foo
GET bar
EXEC
```

It now properly wrap the commands inside `MULTI/EXEC`.

cc @collimarco