### PR TITLE
Improve error message for initial setup of cluster mode

### DIFF
--- a/lib/redis/cluster/command_loader.rb
+++ b/lib/redis/cluster/command_loader.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../errors'
+require 'redis/errors'
 
 class Redis
   class Cluster
@@ -10,15 +10,15 @@ class Redis
       module_function
 
       def load(nodes)
-        nodes.each do |node|
+        errors = nodes.map do |node|
           begin
             return fetch_command_details(node)
-          rescue CannotConnectError, ConnectionError, CommandError
-            next # can retry on another node
+          rescue CannotConnectError, ConnectionError, CommandError => error
+            error
           end
         end
 
-        raise CannotConnectError, 'Redis client could not connect to any cluster nodes'
+        raise InitialSetupError, errors
       end
 
       def fetch_command_details(node)

--- a/lib/redis/errors.rb
+++ b/lib/redis/errors.rb
@@ -46,6 +46,15 @@ class Redis
 
   class Cluster
     # Raised when client connected to redis as cluster mode
+    # and failed to fetch cluster state information by commands.
+    class InitialSetupError < BaseError
+      # @param errors [Array<Redis::BaseError>]
+      def initialize(errors)
+        super("Redis client could not fetch cluster information: #{errors.map(&:message).uniq.join(',')}")
+      end
+    end
+
+    # Raised when client connected to redis as cluster mode
     # and some cluster subcommands were called.
     class OrchestrationCommandNotSupported < BaseError
       def initialize(command, subcommand = '')

--- a/test/cluster_abnormal_state_test.rb
+++ b/test/cluster_abnormal_state_test.rb
@@ -49,7 +49,7 @@ class TestClusterAbnormalState < Minitest::Test
   end
 
   def test_raising_error_when_nodes_are_not_cluster_mode
-    assert_raises(Redis::CannotConnectError, 'Redis client could not connect to any cluster nodes') do
+    assert_raises(Redis::Cluster::InitialSetupError) do
       build_another_client(cluster: %W[redis://127.0.0.1:#{PORT}])
     end
   end

--- a/test/cluster_client_internals_test.rb
+++ b/test/cluster_client_internals_test.rb
@@ -87,7 +87,7 @@ class TestClusterClientInternals < Minitest::Test
   def test_acl_auth_failure
     target_version "6.0.0" do
       with_acl do |username, _|
-        assert_raises(Redis::CannotConnectError) do
+        assert_raises(Redis::Cluster::InitialSetupError) do
           _new_client(cluster: DEFAULT_PORTS.map { |port| "redis://#{username}:wrongpassword@#{DEFAULT_HOST}:#{port}" })
         end
       end

--- a/test/cluster_client_key_hash_tags_test.rb
+++ b/test/cluster_client_key_hash_tags_test.rb
@@ -95,7 +95,7 @@ class TestClusterClientKeyHashTags < Minitest::Test
   end
 
   def test_cannot_build_details_from_bad_urls
-    assert_raises(Redis::CannotConnectError) do
+    assert_raises(Redis::Cluster::InitialSetupError) do
       build_described_class(['redis://127.0.0.1:7006'])
     end
   end

--- a/test/cluster_client_options_test.rb
+++ b/test/cluster_client_options_test.rb
@@ -79,11 +79,11 @@ class TestClusterClientOptions < Minitest::Test
   end
 
   def test_client_does_not_accept_db_specified_url
-    assert_raises(Redis::CannotConnectError, 'Could not connect to any nodes') do
+    assert_raises(Redis::Cluster::InitialSetupError) do
       build_another_client(cluster: ['redis://127.0.0.1:7000/1/namespace'])
     end
 
-    assert_raises(Redis::CannotConnectError, 'Could not connect to any nodes') do
+    assert_raises(Redis::Cluster::InitialSetupError) do
       build_another_client(cluster: [{ host: '127.0.0.1', port: '7000' }], db: 1)
     end
   end
@@ -91,7 +91,7 @@ class TestClusterClientOptions < Minitest::Test
   def test_client_does_not_accept_unconnectable_node_url_only
     nodes = ['redis://127.0.0.1:7006']
 
-    assert_raises(Redis::CannotConnectError, 'Could not connect to any nodes') do
+    assert_raises(Redis::Cluster::InitialSetupError) do
       build_another_client(cluster: nodes)
     end
   end


### PR DESCRIPTION
We are currently hard to find out causes when error occured while fetching cluster state information. So this PR adds a specific error class and messages.

current message:
```
Redis Client could not connect to any cluster nodes (Redis::CannotConnectError)
```

improved messages:
```
Redis client could not fetch cluster information: ERR SELECT is not allowed in cluster mode (Redis::Cluster::InitialSetupError)
Redis client could not fetch cluster information: ERR This instance has cluster support disabled (Redis::Cluster::InitialSetupError)
Redis client could not fetch cluster information: Error connecting to Redis on 127.0.0.1:7006 (Errno::ECONNREFUSED) (Redis::Cluster::InitialSetupError)
Redis client could not fetch cluster information: NOPERM this user has no permissions to run the 'cluster' command or its subcommand (Redis::Cluster::InitialSetupError)
```

related issues:
* #1054
* #1074