### PR TITLE
Fix a option parsing bug for cluster mode that percent encoded string is passed to server unintended

### DIFF
--- a/lib/redis/cluster/option.rb
+++ b/lib/redis/cluster/option.rb
@@ -64,8 +64,10 @@ class Redis
         raise InvalidClientOptionError, "Invalid uri scheme #{addr}" unless VALID_SCHEMES.include?(uri.scheme)
 
         db = uri.path.split('/')[1]&.to_i
+        username = uri.user ? URI.decode_www_form_component(uri.user) : nil
+        password = uri.password ? URI.decode_www_form_component(uri.password) : nil
 
-        { scheme: uri.scheme, username: uri.user, password: uri.password, host: uri.host, port: uri.port, db: db }
+        { scheme: uri.scheme, username: username, password: password, host: uri.host, port: uri.port, db: db }
           .reject { |_, v| v.nil? || v == '' }
       rescue URI::InvalidURIError => err
         raise InvalidClientOptionError, err.message


### PR DESCRIPTION
This PR fixes #1074 .

We can pass server URI strings as option to client like this:

```ruby
r = Redis.new(cluster: %w[redis://username:password@127.0.0.1:7000])
```

The `username` and `password` may include special characters such that `! & # $ ^ < > -`. It needs percent encoding in that case. The URI strings are converted to hash objects and they are  passed to internal client object. However, the strings remain escaped. It has to be unescaped before it is passed.

```
irb(main):001:0> require 'uri'
=> true

irb(main):002:0> URI("redis://foobar:#{URI.encode_www_form_component('!&<123-abc>')}@127.0.0.1:6379").password
=> "%21%26%3C123-abc%3E"
```

https://github.com/redis/redis-rb/blob/13c7a8e4fdb23d0fde8534ea974fdf089c8d11bc/lib/redis/cluster/option.rb#L62-L72
https://github.com/redis/redis-rb/blob/13c7a8e4fdb23d0fde8534ea974fdf089c8d11bc/lib/redis/cluster/node.rb#L87-L98