### PR TITLE
Remove error caused by hiredis ssl not supported

### DIFF
--- a/lib/redis/connection/hiredis.rb
+++ b/lib/redis/connection/hiredis.rb
@@ -15,8 +15,6 @@ class Redis
 
         if config[:scheme] == "unix"
           connection.connect_unix(config[:path], connect_timeout)
-        elsif config[:scheme] == "rediss" || config[:ssl]
-          raise NotImplementedError, "SSL not supported by hiredis driver"
         else
           connection.connect(config[:host], config[:port], connect_timeout)
         end

--- a/test/ssl_test.rb
+++ b/test/ssl_test.rb
@@ -46,17 +46,6 @@ class SslTest < Minitest::Test
     end
   end
 
-  driver(:hiredis, :synchrony) do
-    def test_ssl_not_implemented_exception
-      assert_raises(NotImplementedError) do
-        RedisMock.start({ ping: proc { "+PONG" } }, ssl_server_opts("trusted")) do |port|
-          redis = Redis.new(port: port, ssl: true, ssl_params: { ca_file: ssl_ca_file })
-          redis.ping
-        end
-      end
-    end
-  end
-
   private
 
   def ssl_server_opts(prefix)


### PR DESCRIPTION
SSL support in hiredis was merged three years ago. So no need for ssl error anymore.
https://github.com/redis/redis-rb/issues/828