### PR TITLE
Fix SSL/TLS support issue for cluster mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ redis = Redis.new(
 [ghostunnel]: https://github.com/square/ghostunnel
 [OpenSSL::SSL::SSLContext documentation]: http://ruby-doc.org/stdlib-2.3.0/libdoc/openssl/rdoc/OpenSSL/SSL/SSLContext.html
 
-*NOTE:* SSL is only supported by the default "Ruby" driver
+*NOTE:* SSL is only supported by the default "Ruby" driver and [hiredis](https://github.com/redis/hiredis)
 
 
 ## Expert-Mode Options

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -75,6 +75,7 @@ class Redis
   # @option options [Array<String, Hash{Symbol => String, Integer}>] :cluster List of cluster nodes to contact
   # @option options [Boolean] :replica Whether to use readonly replica nodes in Redis Cluster or not
   # @option options [Class] :connector Class of custom connector
+  # @option options [Boolean] :ssl Whether to enable SSL/TLS support or not
   #
   # @return [Redis] a new client instance
   def initialize(options = {})

--- a/lib/redis/cluster/option.rb
+++ b/lib/redis/cluster/option.rb
@@ -17,7 +17,7 @@ class Redis
         node_addrs = options.delete(:cluster)
         @node_opts = build_node_options(node_addrs)
         @replica = options.delete(:replica) == true
-        add_common_node_option_if_needed(options, @node_opts, :scheme)
+        add_common_node_option_if_needed(options, @node_opts, :ssl)
         add_common_node_option_if_needed(options, @node_opts, :username)
         add_common_node_option_if_needed(options, @node_opts, :password)
         @options = options
@@ -67,8 +67,8 @@ class Redis
         username = uri.user ? URI.decode_www_form_component(uri.user) : nil
         password = uri.password ? URI.decode_www_form_component(uri.password) : nil
 
-        { scheme: uri.scheme, username: username, password: password, host: uri.host, port: uri.port, db: db }
-          .reject { |_, v| v.nil? || v == '' }
+        { ssl: uri.scheme == SECURE_SCHEME, username: username, password: password,
+          host: uri.host, port: uri.port, db: db }.reject { |_, v| v.nil? || v == '' }
       rescue URI::InvalidURIError => err
         raise InvalidClientOptionError, err.message
       end
@@ -84,7 +84,7 @@ class Redis
 
       # Redis cluster node returns only host and port information.
       # So we should complement additional information such as:
-      #   scheme, username, password and so on.
+      #   ssl, username, password and so on.
       def add_common_node_option_if_needed(options, node_opts, key)
         return options if options[key].nil? && node_opts.first[key].nil?
 

--- a/test/cluster_client_options_test.rb
+++ b/test/cluster_client_options_test.rb
@@ -9,37 +9,37 @@ class TestClusterClientOptions < Minitest::Test
 
   def test_option_class
     option = Redis::Cluster::Option.new(cluster: %w[redis://127.0.0.1:7000], replica: true)
-    assert_equal({ '127.0.0.1:7000' => { scheme: 'redis', host: '127.0.0.1', port: 7000 } }, option.per_node_key)
+    assert_equal({ '127.0.0.1:7000' => { ssl: false, host: '127.0.0.1', port: 7000 } }, option.per_node_key)
     assert_equal true, option.use_replica?
 
     option = Redis::Cluster::Option.new(cluster: %w[redis://127.0.0.1:7000], replica: false)
-    assert_equal({ '127.0.0.1:7000' => { scheme: 'redis', host: '127.0.0.1', port: 7000 } }, option.per_node_key)
+    assert_equal({ '127.0.0.1:7000' => { ssl: false, host: '127.0.0.1', port: 7000 } }, option.per_node_key)
     assert_equal false, option.use_replica?
 
     option = Redis::Cluster::Option.new(cluster: %w[redis://127.0.0.1:7000])
-    assert_equal({ '127.0.0.1:7000' => { scheme: 'redis', host: '127.0.0.1', port: 7000 } }, option.per_node_key)
+    assert_equal({ '127.0.0.1:7000' => { ssl: false, host: '127.0.0.1', port: 7000 } }, option.per_node_key)
     assert_equal false, option.use_replica?
 
     option = Redis::Cluster::Option.new(cluster: %w[rediss://johndoe:foobar@127.0.0.1:7000/1/namespace])
-    assert_equal({ '127.0.0.1:7000' => { scheme: 'rediss', username: 'johndoe', password: 'foobar', host: '127.0.0.1', port: 7000, db: 1 } }, option.per_node_key)
+    assert_equal({ '127.0.0.1:7000' => { ssl: true, username: 'johndoe', password: 'foobar', host: '127.0.0.1', port: 7000, db: 1 } }, option.per_node_key)
 
-    option = Redis::Cluster::Option.new(cluster: %w[rediss://127.0.0.1:7000], scheme: 'redis')
-    assert_equal({ '127.0.0.1:7000' => { scheme: 'rediss', host: '127.0.0.1', port: 7000 } }, option.per_node_key)
+    option = Redis::Cluster::Option.new(cluster: %w[rediss://127.0.0.1:7000], ssl: false)
+    assert_equal({ '127.0.0.1:7000' => { ssl: true, host: '127.0.0.1', port: 7000 } }, option.per_node_key)
 
     option = Redis::Cluster::Option.new(cluster: %w[redis://bazzap:@127.0.0.1:7000], username: 'foobar')
-    assert_equal({ '127.0.0.1:7000' => { scheme: 'redis', username: 'bazzap', host: '127.0.0.1', port: 7000 } }, option.per_node_key)
+    assert_equal({ '127.0.0.1:7000' => { ssl: false, username: 'bazzap', host: '127.0.0.1', port: 7000 } }, option.per_node_key)
 
     option = Redis::Cluster::Option.new(cluster: %w[redis://:bazzap@127.0.0.1:7000], password: 'foobar')
-    assert_equal({ '127.0.0.1:7000' => { scheme: 'redis', password: 'bazzap', host: '127.0.0.1', port: 7000 } }, option.per_node_key)
+    assert_equal({ '127.0.0.1:7000' => { ssl: false, password: 'bazzap', host: '127.0.0.1', port: 7000 } }, option.per_node_key)
 
     option = Redis::Cluster::Option.new(cluster: %W[redis://#{URI.encode_www_form_component('!&<123-abc>')}:@127.0.0.1:7000])
-    assert_equal({ '127.0.0.1:7000' => { scheme: 'redis', username: '!&<123-abc>', host: '127.0.0.1', port: 7000 } }, option.per_node_key)
+    assert_equal({ '127.0.0.1:7000' => { ssl: false, username: '!&<123-abc>', host: '127.0.0.1', port: 7000 } }, option.per_node_key)
 
     option = Redis::Cluster::Option.new(cluster: %W[redis://:#{URI.encode_www_form_component('!&<123-abc>')}@127.0.0.1:7000])
-    assert_equal({ '127.0.0.1:7000' => { scheme: 'redis', password: '!&<123-abc>', host: '127.0.0.1', port: 7000 } }, option.per_node_key)
+    assert_equal({ '127.0.0.1:7000' => { ssl: false, password: '!&<123-abc>', host: '127.0.0.1', port: 7000 } }, option.per_node_key)
 
     option = Redis::Cluster::Option.new(cluster: %w[redis://127.0.0.1:7000/0], db: 1)
-    assert_equal({ '127.0.0.1:7000' => { scheme: 'redis', host: '127.0.0.1', port: 7000, db: 0 } }, option.per_node_key)
+    assert_equal({ '127.0.0.1:7000' => { ssl: false, host: '127.0.0.1', port: 7000, db: 0 } }, option.per_node_key)
 
     option = Redis::Cluster::Option.new(cluster: [{ host: '127.0.0.1', port: 7000 }])
     assert_equal({ '127.0.0.1:7000' => { host: '127.0.0.1', port: 7000 } }, option.per_node_key)


### PR DESCRIPTION
At this moment, since there is a bug, we cannot use SSL/TLS support for cluster mode. [Internal client](https://github.com/redis/redis-rb/blob/master/lib/redis/client.rb) accepts `ssl` option but cluster client is passing `scheme` option . `scheme` option has no effect in internal client if `url` option isn't passed. This PR will fix it.

ref:
* #1074
* [TLS Support - Redis](https://redis.io/topics/encryption)