### PR TITLE
Correct deprecation warning for Redis.current

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -37,7 +37,7 @@ class Redis
     end
 
     def current
-      deprecate!("`Redis.current=` is deprecated and will be removed in 5.0. (called from: #{caller(1, 1).first})")
+      deprecate!("`Redis.current` is deprecated and will be removed in 5.0. (called from: #{caller(1, 1).first})")
       @current ||= Redis.new
     end
 


### PR DESCRIPTION
I've been trying to figure out why I'm seeing `Redis.current=` deprecation warning when I'm not doing assignment anywhere. Then I noticed that assignment message is being invoked on getter method.