### PR TITLE
[Redis 6.2] Add GEOSEARCH command

### DIFF
--- a/lib/redis/commands/geo.rb
+++ b/lib/redis/commands/geo.rb
@@ -51,6 +51,43 @@ class Redis
         send_command([:georadiusbymember, *geoarguments])
       end
 
+      # Query a sorted set representing a geospatial index to fetch members
+      # within the borders of the area specified by a given shape
+      # from a point or an already existing member
+      #
+      # @param [String] key
+      # @params [String, Array<String>] from use the position of a existing <member> in the sorted set,
+      #   or an array of longitude and latitude of a position
+      # @params [Array<String>] by depending on the query's shape, it can be an array of [radius, unit]
+      #   or an array of [width, height, unit(m|km|ft|mi)]
+      # @param ['asc', 'desc'] sort sort returned items from the nearest to the farthest
+      #   or the farthest to the nearest relative to the center
+      # @param [Integer] count limit the results to the first N matching items
+      # @param ['WITHDIST', 'WITHCOORD', 'WITHHASH'] options to return additional information
+      # @return [Array<String>] may be changed with `options`
+      def geosearch(key, from: nil, by: nil, **options)
+        args = [key]
+        if from.is_a? Array
+          args << ["FROMLONLAT", from[0], from[1]]
+        elsif from.is_a? String
+          args << ["FROMMEMBER", from]
+        else
+          raise ArgumentError, ":from should be an Array with longitude and latitude or a String of an already existing member's name"
+        end
+
+        if by.size == 2
+          args << ["BYRADIUS", by[0], by[1]]
+        elsif area.size == 3
+          args << ["BYBOX", by[0], by[1], by[2]]
+        else
+          raise ArgumentError, ":by should be an Array of [radius, unit] or [width, height, unit]"
+        end
+
+        geoarguments = _geoarguments(*args, **options)
+
+        send_command([:geosearch, *geoarguments])
+      end
+
       # Returns longitude and latitude of members of a geospatial index
       #
       # @param [String] key

--- a/test/cluster_commands_on_geo_test.rb
+++ b/test/cluster_commands_on_geo_test.rb
@@ -71,4 +71,18 @@ class TestClusterCommandsOnGeo < Minitest::Test
       assert_equal %w[Agrigento Palermo], redis.georadiusbymember('Sicily', 'Agrigento', 100, 'km')
     end
   end
+
+  def test_geosearch
+    target_version(MIN_REDIS_VERSION) do
+      add_sicily
+
+      # test with FROMLONLAT & BYRADIUS
+      expected = [%w[Palermo 190.4424], %w[Catania 56.4413]]
+      assert_equal expected, redis.geosearch('Sicily', from: [15, 37], by: [200, 'km'], 'WITHDIST')
+
+      # test with FROMMEMBER & BYBOX
+      redis.geoadd('Sicily', 13.583333, 37.316667, 'Agrigento')
+      assert_equal %w[Agrigento Palermo], redis.search('Sicily', from: 'Agrigento', by: [100, 100, 'km'])
+    end
+  end
 end

--- a/test/commands_on_geo_test.rb
+++ b/test/commands_on_geo_test.rb
@@ -77,6 +77,31 @@ class TestCommandsGeo < Minitest::Test
     end
   end
 
+  def test_geosearch_with_same_params
+    target_version "6.2.0" do
+      r.geoadd("Chad", 15, 15, "Kanem")
+      nearest_cities = r.georadius("Chad", 15, 15, 15, 'km', sort: 'asc')
+      assert_equal %w(Kanem), nearest_cities
+    end
+  end
+
+  def test_geosearch_with_sort
+    target_version "6.2.0" do
+      nearest_cities = r.geosearch("Sicily", from: [15, 37], by: [200, 'km'], sort: 'asc')
+      assert_equal %w(Catania Palermo), nearest_cities
+
+      farthest_cities = r.geosearch("Sicily", from: [15, 37], by: [200, 'km'], sort: 'desc')
+      assert_equal %w(Palermo Catania), farthest_cities
+    end
+  end
+
+  def test_geosearch_with_count
+    target_version "6.2.0" do
+      city = r.geosearch("Sicily", from: [15, 37], by: [200, 'km'], count: 1)
+      assert_equal %w(Catania), city
+    end
+  end
+
   def test_geopos
     target_version "3.2.0" do
       location = r.geopos("Sicily", "Catania")


### PR DESCRIPTION
Add support for [GEOSEARCH](https://redis.io/commands/geosearch) command, which is available since 6.2.0.

Reference: https://github.com/redis/redis-rb/issues/978