### PR TITLE
Reflect scheme of URI in client ID instead of hard coding

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -150,7 +150,7 @@ class Redis
     end
 
     def id
-      @options[:id] || "redis://#{location}/#{db}"
+      @options[:id] || "#{@options[:ssl] ? 'rediss' : @options[:scheme]}://#{location}/#{db}"
     end
 
     def location

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -49,19 +49,24 @@ class TestConnection < Minitest::Test
     assert_equal "redis://host:1234/0", redis.connection.fetch(:id)
   end
 
+  def test_default_id_with_host_and_port_and_ssl
+    redis = Redis.new(OPTIONS.merge(host: 'host', port: '1234', db: 0, ssl: true))
+    assert_equal "rediss://host:1234/0", redis.connection.fetch(:id)
+  end
+
   def test_default_id_with_host_and_port_and_explicit_scheme
     redis = Redis.new(OPTIONS.merge(host: "host", port: "1234", db: 0, scheme: "foo"))
-    assert_equal "redis://host:1234/0", redis.connection.fetch(:id)
+    assert_equal "foo://host:1234/0", redis.connection.fetch(:id)
   end
 
   def test_default_id_with_path
     redis = Redis.new(OPTIONS.merge(path: "/tmp/redis.sock", db: 0))
-    assert_equal "redis:///tmp/redis.sock/0", redis.connection.fetch(:id)
+    assert_equal "unix:///tmp/redis.sock/0", redis.connection.fetch(:id)
   end
 
   def test_default_id_with_path_and_explicit_scheme
     redis = Redis.new(OPTIONS.merge(path: "/tmp/redis.sock", db: 0, scheme: "foo"))
-    assert_equal "redis:///tmp/redis.sock/0", redis.connection.fetch(:id)
+    assert_equal "unix:///tmp/redis.sock/0", redis.connection.fetch(:id)
   end
 
   def test_override_id


### PR DESCRIPTION
We can see the client ID in inspection but scheme part is hard coded. I'd say that it might cause a bit confusion.

```
irb(main):001:0> Redis.new(port: 6381)
=> #<Redis client v4.6.0 for redis://127.0.0.1:6381/0>

irb(main):002:0> Redis.new(path: '/tmp/redis.sock')
=> #<Redis client v4.6.0 for redis:///tmp/redis.sock/0>

irb(main):003:0> Redis.new(port: 6381, ssl: true)
=> #<Redis client v4.6.0 for redis://127.0.0.1:6381/0>
```

https://github.com/redis/redis-rb/blob/399ebde2b79819f03e957e4729b0efdf11d08107/lib/redis/client.rb#L152-L154

It seems that the ID method was added since 2010 for client side consistent hashing feature. This PR will effect the hashing logic but users of the feature might be few. It might cause decrease of cache hit retio but it turns back to normal in time.

0487eed762727023cfa39b0ead7b7a65a565befd

```
$ grep '\.id' lib -rI
lib/redis.rb:    @original_client.id
lib/redis.rb:      id: @original_client.id,
lib/redis/cluster.rb:          id: client.id,
lib/redis/hash_ring.rb:        key = Zlib.crc32("#{node.id}:#{i}")
lib/redis/hash_ring.rb:      @nodes.reject! { |n| n.id == node.id }
lib/redis/hash_ring.rb:        key = Zlib.crc32("#{node.id}:#{i}")
```

So this PR fixes the ID method to reflect scheme of URI in client ID instead of hard coding.