### PR TITLE
Disable SNI if SAN of certificate is a IP address

### DIFF
--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -6,6 +6,7 @@ require "redis/errors"
 
 require "socket"
 require "timeout"
+require 'resolv'
 
 begin
   require "openssl"
@@ -252,7 +253,7 @@ class Redis
           ctx.set_params(ssl_params || {})
 
           ssl_sock = new(tcp_sock, ctx)
-          ssl_sock.hostname = host
+          ssl_sock.hostname = host unless Resolv::AddressRegex.match?(host)
 
           begin
             # Initiate the socket connection in the background. If it doesn't fail


### PR DESCRIPTION
* #1074
  * According to the report, [redis-cli](https://redis.io/topics/rediscli) works fine but our redis-rb doesn't work yet.
  * This is a rare use case but a issue indeed.
* Server Name Indication
  * https://datatracker.ietf.org/doc/html/rfc3546#section-3.1
* Subject Alternative Name
  * https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6

```mermaid
sequenceDiagram
    participant Client
    participant Server Shard 1
    participant Server Shard 2
    participant Server Shard 3

    Client->>+Server Shard 1: send CLUSTER NODES to rediss://endpoint.example.com:6379
    Server Shard 1-->>-Client: reply 192.168.13.11:7000, 192.168.13.11:7001, 192.168.13.11:7002
    Note over Client,Server Shard 1: Maybe using virtual IP address internally or be running on single node

    Client->>+Server Shard 3: send GET key3 to rediss://192.168.13.11:7002
    Server Shard 3-->>-Client: reply value
    Note over Client,Server Shard 3: Client should be able to connect to IP address with SSL/TLS
```