### PR TITLE
Support single endpoint architecture with SSL/TLS in cluster mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,21 @@ redis.mget('{key}1', '{key}2')
 * The client support permanent node failures, and will reroute requests to promoted slaves.
 * The client supports `MOVED` and `ASK` redirections transparently.
 
+## Cluster mode with SSL/TLS
+Since Redis can return FQDN of nodes in reply to client since `7.*` with CLUSTER commands, we can use cluster feature with SSL/TLS connection like this:
+
+```ruby
+Redis.new(cluster: %w[rediss://foo.example.com:6379])
+```
+
+On the other hand, in Redis versions prior to `6.*`, you can specify options like the following if cluster mode is enabled and client has to connect to nodes via single endpoint with SSL/TLS.
+
+```ruby
+Redis.new(cluster: %w[rediss://foo-endpoint.example.com:6379], fixed_hostname: 'foo-endpoint.example.com')
+```
+
+In case of the above architecture, if you don't pass the `fixed_hostname` option to the client and servers return IP addresses of nodes, the client may fail to verify certificates.
+
 ## Storing objects
 
 Redis "string" types can be used to store serialized Ruby objects, for

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -74,6 +74,8 @@ class Redis
   # @option options [Symbol] :role (:master) Role to fetch via Sentinel, either `:master` or `:slave`
   # @option options [Array<String, Hash{Symbol => String, Integer}>] :cluster List of cluster nodes to contact
   # @option options [Boolean] :replica Whether to use readonly replica nodes in Redis Cluster or not
+  # @option options [String] :fixed_hostname Specify a FQDN if cluster mode enabled and
+  #   client has to connect nodes via single endpoint with SSL/TLS
   # @option options [Class] :connector Class of custom connector
   #
   # @return [Redis] a new client instance

--- a/test/cluster_client_options_test.rb
+++ b/test/cluster_client_options_test.rb
@@ -44,6 +44,12 @@ class TestClusterClientOptions < Minitest::Test
     option = Redis::Cluster::Option.new(cluster: [{ host: '127.0.0.1', port: 7000 }])
     assert_equal({ '127.0.0.1:7000' => { host: '127.0.0.1', port: 7000 } }, option.per_node_key)
 
+    option = Redis::Cluster::Option.new(cluster: %w[redis://127.0.0.1:7000], fixed_hostname: 'foo-endpoint.example.com')
+    assert_equal({ '127.0.0.1:7000' => { scheme: 'redis', host: 'foo-endpoint.example.com', port: 7000 } }, option.per_node_key)
+
+    option = Redis::Cluster::Option.new(cluster: %w[redis://127.0.0.1:7000], fixed_hostname: '')
+    assert_equal({ '127.0.0.1:7000' => { scheme: 'redis', host: '127.0.0.1', port: 7000 } }, option.per_node_key)
+
     assert_raises(Redis::InvalidClientOptionError) do
       Redis::Cluster::Option.new(cluster: nil)
     end


### PR DESCRIPTION
## Description

This PR will solve the following issue.

* #1074

The issue is an error the client fails to verify the certificate of nodes. It is caused in a case which we use cluster feature with SSL/TLS connection. Since the client relies and depends on [CLUSTER NODES](https://redis.io/commands/cluster-nodes) and [CLUSTER SLOTS](https://redis.io/commands/cluster-slots), the client may fail to verify certificates if servers return IP addresses of nodes in reply to the client.

AWS ElastiCache and Redis versions since `7.*` possess an ability to be able to reply FQDN of nodes by the following directives of configuration. They were added by AWS folks and have been available since Redis `7.*`.

* [cluster-announce-hostname](https://github.com/redis/redis/blob/1dc89e2d0230f4bcadf21ee8185b79a12b001cf0/redis.conf#L1678-L1685)
* [cluster-preferred-endpoint-type](https://github.com/redis/redis/blob/1dc89e2d0230f4bcadf21ee8185b79a12b001cf0/redis.conf#L1687-L1702)

On the other hand, other architectures for cluster mode with SSL/TLS may use proxy servers such that [stunnel](https://www.stunnel.org/) or something like that for SSL/TLS termination. In that case, the client has to connect to the nodes via the FQDN of a single endpoint.

So this PR adds a `fixed_hostname` option to the client and modifying to be able to pass it to internal connector.

```ruby
Redis.new(cluster: %w[rediss://foo-endpoint.example.com:6379], fixed_hostname: 'foo-endpoint.example.com')
```

## How does cluster client work?
```mermaid
sequenceDiagram
    participant Client
    participant Server Shard 1
    participant Server Shard 2
    participant Server Shard 3
    Note over Client,Server Shard 3: Redis.new(cluster: %w[redis://node1:6379])
    Client->>+Server Shard 1: CLUSTER SLOTS
    Server Shard 1-->>-Client: nodes and slots data
    Client->>+Server Shard 1: GET key1
    Server Shard 1-->>-Client: value1
    Client->>+Server Shard 2: GET key2
    Server Shard 2-->>-Client: value2
    Client->>+Server Shard 3: GET key3
    Server Shard 3-->>-Client: value3
    Client->>+Server Shard 3: GET key1
    Server Shard 3-->>-Client: MOVED Server Shard 1
    Note over Client,Server Shard 3: Client needs to redirect to correct node
    Client->>+Server Shard 2: MGET key2 key3
    Server Shard 2-->>-Client: CROSSSLOTS
    Note over Client,Server Shard 2: Cannot command across shards
```
## Architectures of Redis cluster with SSL/TLS as I can imagine
### AWS
The client can connect to the nodes directly. The endpoint is just a CNAME record of DNS. It is as simple as that.
```mermaid
graph TB
  client(Cluster Client)

  subgraph Amazon ElastiCache for Redis
    node0(Node0)
    node1(Node1)
    node2(Node2)
  end

  node0-.-node1-.-node2-.-node0
  client--rediss://node0.example.com:6379-->node0
  client--rediss://node1.example.com:6379-->node1
  client--rediss://node2.example.com:6379-->node2
```

### Microsoft Azure
The service provides a single IP address and multiple ports mapped to each node. The endpoint doesn't support redirection. It does only SSL/TLS termination.
```mermaid
graph TB
  client(Cluster Client)

  subgraph Azure Cache for Redis
    subgraph Endpoint
      endpoint(Active)
      endpoint_sb(Standby)
    end

    subgraph Cluster
      node0(Node0)
      node1(Node1)
      node2(Node2)
    end
  end

  endpoint-.-endpoint_sb
  node0-.-node1-.-node2-.-node0
  client--rediss://endpoint.example.com:15000-->endpoint--redis://node0:6379-->node0
  client--rediss://endpoint.example.com:15001-->endpoint--redis://node1:6379-->node1
  client--rediss://endpoint.example.com:15002-->endpoint--redis://node2:6379-->node2
```