### PR TITLE
Handle OpenSSL v3 EOF errors

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -302,7 +302,7 @@ class Redis
       e2 = TimeoutError.new("Connection timed out")
       e2.set_backtrace(e1.backtrace)
       raise e2
-    rescue Errno::ECONNRESET, Errno::EPIPE, Errno::ECONNABORTED, Errno::EBADF, Errno::EINVAL => e
+    rescue Errno::ECONNRESET, Errno::EPIPE, Errno::ECONNABORTED, Errno::EBADF, Errno::EINVAL, EOFError => e
       raise ConnectionError, "Connection lost (%s)" % [e.class.name.split("::").last]
     end
 

--- a/lib/redis/connection/ruby.rb
+++ b/lib/redis/connection/ruby.rb
@@ -384,6 +384,12 @@ class Redis
         format_reply(reply_type, line)
       rescue Errno::EAGAIN
         raise TimeoutError
+      rescue OpenSSL::SSL::SSLError => ssl_error
+        if ssl_error.message.match?(/SSL_read: unexpected eof while reading/i)
+          raise EOFError, ssl_error.message
+        else
+          raise
+        end
       end
 
       def format_reply(reply_type, line)


### PR DESCRIPTION
Fix: https://github.com/redis/redis-rb/issues/1106

When Ruby is compiled against OpenSSL V3, if an SSL connection is closed without sending a `close_notify`, a `OpenSSL::SSL::SSLError` will be raised.

I tested this manually, it works s expected. Unfortunately we don't have SSL setup on CI, and it's a big pain to do (I did it for `redis-client`), so I'm tempted to ship with just a manual test, or maybe just a mock? 😞 