### PR TITLE
Resolve new sentinels ips if cloud nodes changed

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -567,12 +567,15 @@ class Redis
       def check(client); end
 
       class Sentinel < Connector
+        attr_reader :sentinels_resolver
+
         def initialize(options)
           super(options)
 
           @options[:db] = DEFAULTS.fetch(:db)
 
           @sentinels = @options.delete(:sentinels).dup
+          @sentinels_resolver = @options[:sentinels_resolver]
           @role = (@options[:role] || "master").to_s
           @master = @options[:host]
         end
@@ -629,6 +632,11 @@ class Redis
             ensure
               client.disconnect
             end
+          end
+
+          if sentinels_resolver
+            @sentinels = sentinels_resolver.call
+            return sentinel_detect
           end
 
           raise CannotConnectError, "No sentinels available."


### PR DESCRIPTION
Issue:
If you use kubernetes redis chart: https://hub.docker.com/r/bitnami/redis/ with sentinels support and Preemptible google cloud nodes, then you will have issue when your nodes recreated, ip address changed, and then your redis connection stop working, also sidekiqs, etc.

Solution:
Provide an resolver (lambda function) which can resolve new ip address by host name for sentinels nodes, and reset `@sentinels` variable for choose connection. 
