### PR TITLE
Prevent to continue to wait for sentinels which not to recognize broken replications

### DIFF
--- a/makefile
+++ b/makefile
@@ -82,14 +82,21 @@ start_sentinel: ${BINARY}
 			--sentinel;\
 	done
 
+wait_for_sentinel: MAX_ATTEMPTS_FOR_WAIT ?= 60
 wait_for_sentinel:
 	@for port in ${SENTINEL_PORTS}; do\
+		i=0;\
 		while : ; do\
+			if [ $${i} -ge ${MAX_ATTEMPTS_FOR_WAIT} ]; then\
+				echo "Max attempts exceeded: $${i} times";\
+				exit 1;\
+			fi;\
 			if [ $$(${REDIS_CLIENT} -p $${port} SENTINEL SLAVES ${HA_GROUP_NAME} | wc -l) -gt 1 ]; then\
 				break;\
 			fi;\
 			echo 'Waiting for Redis sentinel to be ready...';\
 			sleep 1;\
+			i=$$(( $${i}+1 ));\
 		done;\
 	done
 

--- a/test/support/conf/redis-5.0.conf
+++ b/test/support/conf/redis-5.0.conf
@@ -1,3 +1,2 @@
-slaveof no one
 appendonly no
 save ""

--- a/test/support/conf/redis-6.0.conf
+++ b/test/support/conf/redis-6.0.conf
@@ -1,3 +1,2 @@
-slaveof no one
 appendonly no
 save ""

--- a/test/support/conf/redis-6.2.conf
+++ b/test/support/conf/redis-6.2.conf
@@ -1,3 +1,2 @@
-slaveof no one
 appendonly no
 save ""

--- a/test/support/conf/redis-7.0.conf
+++ b/test/support/conf/redis-7.0.conf
@@ -1,4 +1,3 @@
-slaveof no one
 appendonly no
 save ""
 enable-debug-command yes


### PR DESCRIPTION
I found the test patterns using Redis 5.0 reached 30 minutes which is a timeout setting by workflows. These jobs were canceled by GitHub Actions. These jobs continued to wait for sentinels to the last.
https://github.com/redis/redis-rb/actions/runs/2824449545
![gh-pic](https://user-images.githubusercontent.com/364486/183824834-c5eb052f-c0ee-4ddc-ba3d-ed93a55e76de.png)

I dug into it to figure out what the cause was, and then, the instance as a primary role was a replica.

```
$ tmp/cache/redis-5.0/src/redis-cli -p 6381 info replication
# Replication
role:slave
master_host:no
master_port:0
master_link_status:down
master_last_io_seconds_ago:-1
master_sync_in_progress:0
slave_repl_offset:1
master_link_down_since_seconds:1660105903
slave_priority:100
slave_read_only:1
connected_slaves:0
master_replid:5ebfcdbe07401a93fd53d8910dcdd8fcf2772105
master_replid2:0000000000000000000000000000000000000000
master_repl_offset:0
second_repl_offset:-1
repl_backlog_active:0
repl_backlog_size:1048576
repl_backlog_first_byte_offset:0
repl_backlog_histlen:0                                       
```

The instance as a replica role was a replica. It was correct.

```
$ tmp/cache/redis-5.0/src/redis-cli -p 6382 info replication
# Replication
role:slave
master_host:127.0.0.1
master_port:6381
master_link_status:down
master_last_io_seconds_ago:-1
master_sync_in_progress:0
slave_repl_offset:1
master_link_down_since_seconds:1660105927                                                                                                                                                                                                                                                                                                                                                                                                 slave_priority:100
slave_read_only:1
connected_slaves:0
master_replid:467649ff631e358582745c0fddabaee92dd077cb
master_replid2:0000000000000000000000000000000000000000
master_repl_offset:0
second_repl_offset:-1
repl_backlog_active:0
repl_backlog_size:1048576
repl_backlog_first_byte_offset:0
repl_backlog_histlen:0
```

It seems that the sentinels of Redis 5.0 did not adjust the role of the primary instance.
The sentinels replied empty list of replicas. It caused endless loops.

```
$ tmp/cache/redis-5.0/src/redis-cli -p 6400 sentinel slaves master1
(empty list or set)
```

So I removed the `slaveof` setting from the configuration files for testing and added a limitation of max count of attempts for waiting for sentinels to be ready.

```
$ make start_all REDIS_BRANCH=5.0 MAX_ATTEMPTS_FOR_WAIT=10
8785:C 10 Aug 2022 13:23:17.839 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
8785:C 10 Aug 2022 13:23:17.839 # Redis version=5.0.14, bits=64, commit=1c7cd38a, modified=0, pid=8785, just started
8785:C 10 Aug 2022 13:23:17.839 # Configuration loaded
8787:C 10 Aug 2022 13:23:17.846 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
8787:C 10 Aug 2022 13:23:17.846 # Redis version=5.0.14, bits=64, commit=1c7cd38a, modified=0, pid=8787, just started
8787:C 10 Aug 2022 13:23:17.846 # Configuration loaded
8797:X 10 Aug 2022 13:23:17.855 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
8797:X 10 Aug 2022 13:23:17.855 # Redis version=5.0.14, bits=64, commit=1c7cd38a, modified=0, pid=8797, just started
8797:X 10 Aug 2022 13:23:17.855 # Configuration loaded
8803:X 10 Aug 2022 13:23:17.865 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
8803:X 10 Aug 2022 13:23:17.865 # Redis version=5.0.14, bits=64, commit=1c7cd38a, modified=0, pid=8803, just started
8803:X 10 Aug 2022 13:23:17.865 # Configuration loaded
8806:X 10 Aug 2022 13:23:17.875 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
8806:X 10 Aug 2022 13:23:17.875 # Redis version=5.0.14, bits=64, commit=1c7cd38a, modified=0, pid=8806, just started
8806:X 10 Aug 2022 13:23:17.875 # Configuration loaded
Waiting for Redis sentinel to be ready...
Waiting for Redis sentinel to be ready...
Waiting for Redis sentinel to be ready...
Waiting for Redis sentinel to be ready...
Waiting for Redis sentinel to be ready...
Waiting for Redis sentinel to be ready...
Waiting for Redis sentinel to be ready...
Waiting for Redis sentinel to be ready...
Waiting for Redis sentinel to be ready...
Waiting for Redis sentinel to be ready...
Max attempts exceeded: 10 times
make: *** [makefile:87: wait_for_sentinel] Error 1
```