### PR TITLE
Support for generating release notes

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,0 +1,49 @@
+name-template: '$NEXT_MAJOR_VERSION'
+tag-template: 'v$NEXT_MAJOR_VERSION'
+autolabeler:
+  - label: 'maintenance'
+    files:
+      - '*.md'
+      - '.github/*'
+  - label: 'bug'
+    branch:
+      - '/bug-.+'
+  - label: 'maintenance'
+    branch:
+      - '/maintenance-.+'
+  - label: 'feature'
+    branch:
+      - '/feature-.+'
+categories:
+  - title: 'Breaking Changes'
+    labels:
+      - 'breakingchange'
+
+  - title: '🧪 Experimental Features'
+    labels:
+      - 'experimental'
+  - title: '🚀 New Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+      - 'BUG'
+  - title: '🧰 Maintenance'
+    label: 'maintenance'
+change-template: '- $TITLE (#$NUMBER)'
+exclude-labels:
+  - 'skip-changelog'
+template: |
+  ## Changes
+
+  $CHANGES
+
+  ## Contributors
+  We'd like to thank all the contributors who worked on this release!
+
+  $CONTRIBUTORS
+

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,19 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+           config-name: release-drafter-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As discussed elsewhere, this is the release drafter, in use by the other clients, we currently maintain. It aims to help making the process of writing release notes better.  The drafter takes the titles of pull requests, and injects them into the release notes, in specific locations, as per the template included in the PR.

To use effectively we need to start labeled PRs prior to merge with one of the tags below, having created the labels.

The labels used are:

* *experimental* - Changes that are shared, and experimental - potentially to be promoted or walked back, use this label.

* *breakingchange* - When something is labeled thus, it appears, called out as a breaking change. 

* *feature* - Anything with this label is listed as a feature

* *bug* - PRs labeled with bugs are marked as bugs fixed

* *maintenance* - This label is used for all maintenance commits, CI, documentation, etc.

* *skip-changelog* - If for some reason, there's a commit that you'd like to exclude from the changelog, add this label. Note: I've never used it, but it seems more complete to support.

Today, this version of the drafter works acts upon merges to master, and maintains a single, auto-generated list. Upon release, using the GitHub release workflow, the maintainer edits the draft release, to tag and publish.

As an added benefit, in many clients ([see example](https://github.com/redis/redis-py/blob/master/.github/workflows/pypi-publish.yaml)) we automate the release to the appropriate package manager, when a release is published.