### PR TITLE
Fix jruby CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.0", "2.7", "2.6", "2.5", "2.4"]
+        ruby: ["3.1", "3.0", "2.7", "2.6", "2.5", "2.4", "jruby-9.3.6.0"]
     runs-on: ubuntu-latest
     env:
       VERBOSE: "true"

--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,3 @@ gemspec
 gem 'minitest'
 gem 'rake'
 gem 'rubocop', '~> 1.0', '< 1.12'
-
-# Using jruby-openssl 0.10.0, we get NPEs in jruby tests: https://github.com/redis/redis-rb/issues/756
-platform :jruby do
-  gem 'jruby-openssl', '<0.10.0'
-end

--- a/test/support/redis_mock.rb
+++ b/test/support/redis_mock.rb
@@ -30,7 +30,6 @@ module RedisMock
 
     def shutdown
       @thread.kill
-      @thread.join
     end
 
     def run


### PR DESCRIPTION
I was hopping that removing the old openssl gem would fix it, but somehow it's still get stuck on CI.

Which is weird because it works relatively well locally.

If someone feels like digging into this.
