### PR TITLE
[Redis 6.2] Add idle option to XPENDING

### DIFF
--- a/lib/redis/commands/streams.rb
+++ b/lib/redis/commands/streams.rb
@@ -334,6 +334,8 @@ class Redis
       #   redis.xpending('mystream', 'mygroup')
       # @example With range options
       #   redis.xpending('mystream', 'mygroup', '-', '+', 10)
+      # @example With range and idle time options
+      #   redis.xpending('mystream', 'mygroup', '-', '+', 10, idle: 9000)
       # @example With range and consumer options
       #   redis.xpending('mystream', 'mygroup', '-', '+', 10, 'consumer1')
       #
@@ -344,10 +346,13 @@ class Redis
       # @param count    [Integer] count the number of entries as limit
       # @param consumer [String]  the consumer name
       #
+      # @option opts [Integer] :idle       pending message minimum idle time in milliseconds
+      #
       # @return [Hash]        the summary of pending entries
       # @return [Array<Hash>] the pending entries details if options were specified
-      def xpending(key, group, *args)
+      def xpending(key, group, *args, **opts)
         command_args = [:xpending, key, group]
+        command_args.concat(['IDLE', opts[:idle].to_i])  if opts[:idle]
         case args.size
         when 0, 3, 4
           command_args.concat(args)

--- a/test/lint/streams.rb
+++ b/test/lint/streams.rb
@@ -758,9 +758,11 @@ module Lint
       redis.xadd('s1', { f: 'v2' }, id: '0-2')
       redis.xadd('s1', { f: 'v3' }, id: '0-3')
       redis.xreadgroup('g1', 'c1', 's1', '>')
+      
+      actual = redis.xpending('s1', 'g1', '-', '+', 10)
+      assert_equal 2, actual.size
       actual = redis.xpending('s1', 'g1', '-', '+', 10, idle: 10)
       assert_equal 0, actual.size
-
       sleep 0.1
       actual = redis.xpending('s1', 'g1', '-', '+', 10, idle: 10)
       assert_equal 2, actual.size
@@ -768,6 +770,11 @@ module Lint
       redis.xadd('s1', { f: 'v4' }, id: '0-4')
       redis.xreadgroup('g1', 'c2', 's1', '>')
 
+      actual = redis.xpending('s1', 'g1', '-', '+', 10, idle: 1000)
+      assert_equal 0, actual.size
+
+      actual = redis.xpending('s1', 'g1', '-', '+', 10)
+      assert_equal 3, actual.size
       actual = redis.xpending('s1', 'g1', '-', '+', 10, idle: 10)
       assert_equal 2, actual.size
       sleep 0.01


### PR DESCRIPTION
Added support for [Idle time filter](https://redis.io/commands/xpending/#idle-time-filter) on the XPENDING command, which is available since 6.2.0.

Reference: https://github.com/redis/redis-rb/issues/978