### PR TITLE
Use `MD5` for hashing server nodes in `Redis::Distributed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Unreleased 5.0.0
 
+- Use `MD5` for hashing server nodes in `Redis::Distributed`. This should improve keys distribution among servers. See #1089.
 - Cluster support has been moved to a `redis_cluster` companion gem.
 - `select` no longer record the current database. If the client has to reconnect after `select` was used, it will reconnect to the original database.
 - Removed `logger` option.

--- a/test/distributed/key_tags_test.rb
+++ b/test/distributed/key_tags_test.rb
@@ -28,7 +28,7 @@ class TestDistributedKeyTags < Minitest::Test
   end
 
   def test_distributes_keys_if_no_clustering_is_used
-    r.add_node("redis://127.0.0.1:#{PORT}/14")
+    r.add_node("redis://127.0.0.1:#{PORT}/13")
     r.flushdb
 
     r.set "users:1", 1


### PR DESCRIPTION
Closes #1089.

I verified, md5 is indeed faster than sha1 by 20%. 

> We should probably make that configurable though. e.g. accept a callable, or simply call on common interface like #digest or #hexdigest

The callable will provide the most flexibility. But do we need it? Implemented accepting an object with `#hexdigest` interface as a hasher in this PR.