### PR TITLE
Lower client timeout on CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   lint:
     name: Rubocop
-    timeout-minutes: 30
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -29,16 +29,15 @@ jobs:
 
   rubies:
     name: Ruby
-    timeout-minutes: 30
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.0", "2.7", "2.6", "2.5", "jruby-9.3.6.0", "truffleruby-22.2.0"]
+        ruby: ["3.1", "3.0", "2.7", "2.6", "2.5", "jruby-9.3.6.0"]
     runs-on: ubuntu-latest
     env:
       LOW_TIMEOUT: "0.01"
       REDIS_BRANCH: "7.0"
-      TRUFFLERUBYOPT: "--engine.Mode=latency"
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -65,9 +64,47 @@ jobs:
       - name: Shutting down Redis
         run: make stop
 
+  truffle:
+    name: TruffleRuby
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: ["redis", "distributed"]
+    runs-on: ubuntu-latest
+    env:
+      LOW_TIMEOUT: "0.01"
+      REDIS_BRANCH: "7.0"
+      TRUFFLERUBYOPT: "--engine.Mode=latency"
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Print environment variables
+        run: |
+          echo "TIMEOUT=${TIMEOUT}"
+          echo "LOW_TIMEOUT=${LOW_TIMEOUT}"
+          echo "DRIVER=${DRIVER}"
+          echo "REDIS_BRANCH=${REDIS_BRANCH}"
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: truffleruby-22.2.0
+          bundler-cache: true
+      - name: Cache local temporary directory
+        uses: actions/cache@v3
+        with:
+          path: tmp
+          key: "local-tmp-redis-7.0-on-ubuntu-latest"
+      - name: Booting up Redis
+        run: make start
+      - name: Test
+        run: bundle exec rake test:${{ matrix.suite }}
+      - name: Shutting down Redis
+        run: make stop
+
   drivers:
     name: Driver
-    timeout-minutes: 30
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -105,7 +142,7 @@ jobs:
 
   redises:
     name: Redis
-    timeout-minutes: 30
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -142,7 +179,7 @@ jobs:
 
   sentinel:
     name: Sentinel
-    timeout-minutes: 30
+    timeout-minutes: 15
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -177,7 +214,7 @@ jobs:
 
   cluster:
     name: Cluster
-    timeout-minutes: 30
+    timeout-minutes: 15
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VERBOSE: "true"
-      TIMEOUT: "30"
       LOW_TIMEOUT: "0.01"
       DRIVER: ruby
       REDIS_BRANCH: "7.0"
@@ -78,7 +77,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VERBOSE: "true"
-      TIMEOUT: "30"
       LOW_TIMEOUT: "0.01"
       DRIVER: ${{ matrix.driver }}
       REDIS_BRANCH: "7.0"
@@ -118,7 +116,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VERBOSE: "true"
-      TIMEOUT: "30"
       LOW_TIMEOUT: "0.14"
       DRIVER: ruby
       REDIS_BRANCH: ${{ matrix.redis }}
@@ -156,7 +153,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VERBOSE: "true"
-      TIMEOUT: "30"
       LOW_TIMEOUT: "0.14"
       DRIVER: ruby
       REDIS_BRANCH: "7.0"
@@ -194,7 +190,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VERBOSE: "true"
-      TIMEOUT: "30"
+      TIMEOUT: "15"
       LOW_TIMEOUT: "0.14"
       DRIVER: ruby
       REDIS_BRANCH: "7.0"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,9 +36,7 @@ jobs:
         ruby: ["3.1", "3.0", "2.7", "2.6", "2.5", "jruby-9.3.6.0", "truffleruby-22.2.0"]
     runs-on: ubuntu-latest
     env:
-      VERBOSE: "true"
       LOW_TIMEOUT: "0.01"
-      DRIVER: ruby
       REDIS_BRANCH: "7.0"
       TRUFFLERUBYOPT: "--engine.Mode=latency"
     steps:
@@ -76,7 +74,6 @@ jobs:
         driver: ["hiredis"]
     runs-on: ubuntu-latest
     env:
-      VERBOSE: "true"
       LOW_TIMEOUT: "0.01"
       DRIVER: ${{ matrix.driver }}
       REDIS_BRANCH: "7.0"
@@ -115,9 +112,7 @@ jobs:
         redis: ["6.2", "6.0", "5.0"]
     runs-on: ubuntu-latest
     env:
-      VERBOSE: "true"
       LOW_TIMEOUT: "0.14"
-      DRIVER: ruby
       REDIS_BRANCH: ${{ matrix.redis }}
     steps:
       - name: Check out code
@@ -152,9 +147,7 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     env:
-      VERBOSE: "true"
       LOW_TIMEOUT: "0.14"
-      DRIVER: ruby
       REDIS_BRANCH: "7.0"
     steps:
       - name: Check out code
@@ -189,10 +182,8 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     env:
-      VERBOSE: "true"
       TIMEOUT: "15"
       LOW_TIMEOUT: "0.14"
-      DRIVER: ruby
       REDIS_BRANCH: "7.0"
       BUNDLE_GEMFILE: redis_cluster/Gemfile
     steps:

--- a/test/redis/internals_test.rb
+++ b/test/redis/internals_test.rb
@@ -9,6 +9,10 @@ class TestInternals < Minitest::Test
     # see: https://github.com/redis/redis-rb/issues/962
     # large payloads will trigger write_nonblock to write a portion
     # of the payload in connection/ruby.rb _write_to_socket
+
+    # We use a larger timeout for TruffleRuby
+    # https://github.com/redis/redis-rb/pull/1128#issuecomment-1218490684
+    r = init(_new_client(timeout: TIMEOUT * 5))
     large = "\u3042" * 4_000_000
     r.setex("foo", 10, large)
     result = r.get("foo")


### PR DESCRIPTION
Because of the flakiness of the cluster and sentinel suite we've bumped the timeout to some absurd level. 

Now that the suites have been split and somewhat stabilized I think we can reduced it.

NB: I try the 1.0 default for all suite, but worst case I think we can keep it relatively high on `cluster` & `sentinel`.