### PR TITLE
Refactor pubusb to allow subscribing and unsubscribing from another thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Allow to call `subscribe`, `unsubscribe`, `psubscribe` and `punsubscribe` from a subscribed client. See #1131.
 - Fix `redis-clustering` gem to specify the dependency on `redis`
 
 # 5.0.0.beta3

--- a/lib/redis/commands/pubsub.rb
+++ b/lib/redis/commands/pubsub.rb
@@ -14,50 +14,34 @@ class Redis
 
       # Listen for messages published to the given channels.
       def subscribe(*channels, &block)
-        synchronize do |_client|
-          _subscription(:subscribe, 0, channels, block)
-        end
+        _subscription(:subscribe, 0, channels, block)
       end
 
       # Listen for messages published to the given channels. Throw a timeout error
       # if there is no messages for a timeout period.
       def subscribe_with_timeout(timeout, *channels, &block)
-        synchronize do |_client|
-          _subscription(:subscribe_with_timeout, timeout, channels, block)
-        end
+        _subscription(:subscribe_with_timeout, timeout, channels, block)
       end
 
       # Stop listening for messages posted to the given channels.
       def unsubscribe(*channels)
-        raise "Can't unsubscribe if not subscribed." unless subscribed?
-
-        synchronize do |_client|
-          _subscription(:unsubscribe, 0, channels, nil)
-        end
+        _subscription(:unsubscribe, 0, channels, nil)
       end
 
       # Listen for messages published to channels matching the given patterns.
       def psubscribe(*channels, &block)
-        synchronize do |_client|
-          _subscription(:psubscribe, 0, channels, block)
-        end
+        _subscription(:psubscribe, 0, channels, block)
       end
 
       # Listen for messages published to channels matching the given patterns.
       # Throw a timeout error if there is no messages for a timeout period.
       def psubscribe_with_timeout(timeout, *channels, &block)
-        synchronize do |_client|
-          _subscription(:psubscribe_with_timeout, timeout, channels, block)
-        end
+        _subscription(:psubscribe_with_timeout, timeout, channels, block)
       end
 
       # Stop listening for messages posted to channels matching the given patterns.
       def punsubscribe(*channels)
-        raise "Can't unsubscribe if not subscribed." unless subscribed?
-
-        synchronize do |_client|
-          _subscription(:punsubscribe, 0, channels, nil)
-        end
+        _subscription(:punsubscribe, 0, channels, nil)
       end
 
       # Inspect the state of the Pub/Sub subsystem.

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -904,7 +904,7 @@ class Redis
 
     # Stop listening for messages posted to the given channels.
     def unsubscribe(*channels)
-      raise "Can't unsubscribe if not subscribed." unless subscribed?
+      raise SubscriptionError, "Can't unsubscribe if not subscribed." unless subscribed?
 
       @subscribed_node.unsubscribe(*channels)
     end

--- a/lib/redis/errors.rb
+++ b/lib/redis/errors.rb
@@ -52,4 +52,7 @@ class Redis
   # Raised when client options are invalid.
   class InvalidClientOptionError < BaseError
   end
+
+  class SubscriptionError < BaseError
+  end
 end

--- a/test/distributed/publish_subscribe_test.rb
+++ b/test/distributed/publish_subscribe_test.rb
@@ -83,7 +83,7 @@ class TestDistributedPublishSubscribe < Minitest::Test
   end
 
   def test_subscribe_without_a_block
-    assert_raises LocalJumpError do
+    assert_raises Redis::SubscriptionError do
       r.subscribe("foo")
     end
   end


### PR DESCRIPTION
`redis-rb`'s pubsub always has been very hard to work with, because once you
are subscribed, you can no longer manage the subscription outside of
the various callback.

But the `SUBSCRIBE` family of command returns no response, and the
subscribed client only reads the socket. So we can actually send
`SUBSCRIBE` style of commands from another thread.