### PR TITLE
Eagerly and strictly cast Integer and Float parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Eagerly and strictly cast Integer and Float parameters.
+
 # 5.0.0.beta4
 
 - Allow to call `subscribe`, `unsubscribe`, `psubscribe` and `punsubscribe` from a subscribed client. See #1131.

--- a/lib/redis/commands/geo.rb
+++ b/lib/redis/commands/geo.rb
@@ -74,9 +74,9 @@ class Redis
       private
 
       def _geoarguments(*args, options: nil, sort: nil, count: nil)
-        args.push sort if sort
-        args.push 'count', count if count
-        args.push options if options
+        args << sort if sort
+        args << 'COUNT' << Integer(count) if count
+        args << options if options
         args
       end
     end

--- a/lib/redis/commands/hashes.rb
+++ b/lib/redis/commands/hashes.rb
@@ -174,7 +174,7 @@ class Redis
       # @param [Integer] increment
       # @return [Integer] value of the field after incrementing it
       def hincrby(key, field, increment)
-        send_command([:hincrby, key, field, increment])
+        send_command([:hincrby, key, field, Integer(increment)])
       end
 
       # Increment the numeric value of a hash field by the given float number.
@@ -184,7 +184,7 @@ class Redis
       # @param [Float] increment
       # @return [Float] value of the field after incrementing it
       def hincrbyfloat(key, field, increment)
-        send_command([:hincrbyfloat, key, field, increment], &Floatify)
+        send_command([:hincrbyfloat, key, field, Float(increment)], &Floatify)
       end
 
       # Get all the fields in a hash.

--- a/lib/redis/commands/keys.rb
+++ b/lib/redis/commands/keys.rb
@@ -427,7 +427,7 @@ class Redis
 
         args << cursor
         args << "MATCH" << match if match
-        args << "COUNT" << count if count
+        args << "COUNT" << Integer(count) if count
         args << "TYPE" << type if type
 
         send_command([command] + args, &block)

--- a/lib/redis/commands/lists.rb
+++ b/lib/redis/commands/lists.rb
@@ -102,7 +102,7 @@ class Redis
       # @return [String, Array<String>] the values of the first elements
       def lpop(key, count = nil)
         command = [:lpop, key]
-        command << count if count
+        command << Integer(count) if count
         send_command(command)
       end
 
@@ -113,7 +113,7 @@ class Redis
       # @return [String, Array<String>] the values of the last elements
       def rpop(key, count = nil)
         command = [:rpop, key]
-        command << count if count
+        command << Integer(count) if count
         send_command(command)
       end
 
@@ -189,7 +189,7 @@ class Redis
       # @param [Integer] index
       # @return [String]
       def lindex(key, index)
-        send_command([:lindex, key, index])
+        send_command([:lindex, key, Integer(index)])
       end
 
       # Insert an element before or after another element in a list.
@@ -211,7 +211,7 @@ class Redis
       # @param [Integer] stop stop index
       # @return [Array<String>]
       def lrange(key, start, stop)
-        send_command([:lrange, key, start, stop])
+        send_command([:lrange, key, Integer(start), Integer(stop)])
       end
 
       # Remove elements from a list.
@@ -224,7 +224,7 @@ class Redis
       # @param [String] value
       # @return [Integer] the number of removed elements
       def lrem(key, count, value)
-        send_command([:lrem, key, count, value])
+        send_command([:lrem, key, Integer(count), value])
       end
 
       # Set the value of an element in a list by its index.
@@ -234,7 +234,7 @@ class Redis
       # @param [String] value
       # @return [String] `OK`
       def lset(key, index, value)
-        send_command([:lset, key, index, value])
+        send_command([:lset, key, Integer(index), value])
       end
 
       # Trim a list to the specified range.
@@ -244,7 +244,7 @@ class Redis
       # @param [Integer] stop stop index
       # @return [String] `OK`
       def ltrim(key, start, stop)
-        send_command([:ltrim, key, start, stop])
+        send_command([:ltrim, key, Integer(start), Integer(stop)])
       end
 
       private

--- a/lib/redis/commands/server.rb
+++ b/lib/redis/commands/server.rb
@@ -158,7 +158,7 @@ class Redis
       # @return [Array<String>, Integer, String] depends on subcommand
       def slowlog(subcommand, length = nil)
         args = [:slowlog, subcommand]
-        args << length if length
+        args << Integer(length) if length
         send_command(args)
       end
 

--- a/lib/redis/commands/sets.rb
+++ b/lib/redis/commands/sets.rb
@@ -60,7 +60,7 @@ class Redis
         if count.nil?
           send_command([:spop, key])
         else
-          send_command([:spop, key, count])
+          send_command([:spop, key, Integer(count)])
         end
       end
 

--- a/lib/redis/commands/sorted_sets.rb
+++ b/lib/redis/commands/sorted_sets.rb
@@ -136,7 +136,9 @@ class Redis
       # @return [Array<String, Float>] element and score pair if count is not specified
       # @return [Array<Array<String, Float>>] list of popped elements and scores
       def zpopmax(key, count = nil)
-        send_command([:zpopmax, key, count].compact) do |members|
+        command = [:zpopmax, key]
+        command << Integer(count) if count
+        send_command(command) do |members|
           members = FloatifyPairs.call(members)
           count.to_i > 1 ? members : members.first
         end
@@ -157,7 +159,9 @@ class Redis
       # @return [Array<String, Float>] element and score pair if count is not specified
       # @return [Array<Array<String, Float>>] list of popped elements and scores
       def zpopmin(key, count = nil)
-        send_command([:zpopmin, key, count].compact) do |members|
+        command = [:zpopmin, key]
+        command << Integer(count) if count
+        send_command(command) do |members|
           members = FloatifyPairs.call(members)
           count.to_i > 1 ? members : members.first
         end
@@ -261,7 +265,7 @@ class Redis
         end
 
         args = [:zrandmember, key]
-        args << count if count
+        args << Integer(count) if count
 
         if with_scores
           args << "WITHSCORES"
@@ -313,7 +317,7 @@ class Redis
 
         if limit
           args << "LIMIT"
-          args.concat(limit)
+          args.concat(limit.map { |l| Integer(l) })
         end
 
         if with_scores
@@ -354,7 +358,7 @@ class Redis
 
         if limit
           args << "LIMIT"
-          args.concat(limit)
+          args.concat(limit.map { |l| Integer(l) })
         end
 
         send_command(args)
@@ -372,7 +376,7 @@ class Redis
       #
       # @see #zrange
       def zrevrange(key, start, stop, withscores: false, with_scores: withscores)
-        args = [:zrevrange, key, start, stop]
+        args = [:zrevrange, key, Integer(start), Integer(stop)]
 
         if with_scores
           args << "WITHSCORES"
@@ -466,7 +470,7 @@ class Redis
 
         if limit
           args << "LIMIT"
-          args.concat(limit)
+          args.concat(limit.map { |l| Integer(l) })
         end
 
         send_command(args)
@@ -488,7 +492,7 @@ class Redis
 
         if limit
           args << "LIMIT"
-          args.concat(limit)
+          args.concat(limit.map { |l| Integer(l) })
         end
 
         send_command(args)
@@ -531,7 +535,7 @@ class Redis
 
         if limit
           args << "LIMIT"
-          args.concat(limit)
+          args.concat(limit.map { |l| Integer(l) })
         end
 
         send_command(args, &block)
@@ -561,7 +565,7 @@ class Redis
 
         if limit
           args << "LIMIT"
-          args.concat(limit)
+          args.concat(limit.map { |l| Integer(l) })
         end
 
         send_command(args, &block)

--- a/lib/redis/commands/strings.rb
+++ b/lib/redis/commands/strings.rb
@@ -25,7 +25,7 @@ class Redis
       # @param [Integer] decrement
       # @return [Integer] value after decrementing it
       def decrby(key, decrement)
-        send_command([:decrby, key, decrement])
+        send_command([:decrby, key, Integer(decrement)])
       end
 
       # Increment the integer value of a key by one.
@@ -50,7 +50,7 @@ class Redis
       # @param [Integer] increment
       # @return [Integer] value after incrementing it
       def incrby(key, increment)
-        send_command([:incrby, key, increment])
+        send_command([:incrby, key, Integer(increment)])
       end
 
       # Increment the numeric value of a key by the given float number.
@@ -63,7 +63,7 @@ class Redis
       # @param [Float] increment
       # @return [Float] value after incrementing it
       def incrbyfloat(key, increment)
-        send_command([:incrbyfloat, key, increment], &Floatify)
+        send_command([:incrbyfloat, key, Float(increment)], &Floatify)
       end
 
       # Set the string value of a key.
@@ -82,10 +82,10 @@ class Redis
       # @return [String, Boolean] `"OK"` or true, false if `:nx => true` or `:xx => true`
       def set(key, value, ex: nil, px: nil, exat: nil, pxat: nil, nx: nil, xx: nil, keepttl: nil, get: nil)
         args = [:set, key, value.to_s]
-        args << "EX" << ex if ex
-        args << "PX" << px if px
-        args << "EXAT" << exat if exat
-        args << "PXAT" << pxat if pxat
+        args << "EX" << Integer(ex) if ex
+        args << "PX" << Integer(px) if px
+        args << "EXAT" << Integer(exat) if exat
+        args << "PXAT" << Integer(pxat) if pxat
         args << "NX" if nx
         args << "XX" if xx
         args << "KEEPTTL" if keepttl
@@ -233,7 +233,7 @@ class Redis
       # @param [String] value
       # @return [Integer] length of the string after it was modified
       def setrange(key, offset, value)
-        send_command([:setrange, key, offset, value.to_s])
+        send_command([:setrange, key, Integer(offset), value.to_s])
       end
 
       # Get a substring of the string stored at a key.
@@ -244,7 +244,7 @@ class Redis
       #   the end of the string
       # @return [Integer] `0` or `1`
       def getrange(key, start, stop)
-        send_command([:getrange, key, start, stop])
+        send_command([:getrange, key, Integer(start), Integer(stop)])
       end
 
       # Append a value to a key.
@@ -292,10 +292,10 @@ class Redis
       # @return [String] The value of key, or nil when key does not exist.
       def getex(key, ex: nil, px: nil, exat: nil, pxat: nil, persist: false)
         args = [:getex, key]
-        args << "EX" << ex if ex
-        args << "PX" << px if px
-        args << "EXAT" << exat if exat
-        args << "PXAT" << pxat if pxat
+        args << "EX" << Integer(ex) if ex
+        args << "PX" << Integer(px) if px
+        args << "EXAT" << Integer(exat) if exat
+        args << "PXAT" << Integer(pxat) if pxat
         args << "PERSIST" if persist
 
         send_command(args)

--- a/test/redis/pipelining_commands_test.rb
+++ b/test/redis/pipelining_commands_test.rb
@@ -130,7 +130,8 @@ class TestPipeliningCommands < Minitest::Test
   def test_futures_raise_when_command_errors_and_needs_transformation
     assert_raises(Redis::CommandError) do
       r.pipelined do |p|
-        @result = p.zrange("a", "b", 5, with_scores: true)
+        p.zadd("set", "1", "one")
+        @result = p.zincryby("set", "fail", "one")
       end
     end
   end


### PR DESCRIPTION
This helps catching errors early, and allow `to_i` and similar interface to work out of the box.