### PR TITLE
Add tests for `lpop`/`rpop` with the missing key

### DIFF
--- a/lib/redis/commands/lists.rb
+++ b/lib/redis/commands/lists.rb
@@ -99,7 +99,7 @@ class Redis
       #
       # @param [String] key
       # @param [Integer] count number of elements to remove
-      # @return [String, Array<String>] the values of the first elements
+      # @return [nil, String, Array<String>] the values of the first elements
       def lpop(key, count = nil)
         command = [:lpop, key]
         command << Integer(count) if count
@@ -110,7 +110,7 @@ class Redis
       #
       # @param [String] key
       # @param [Integer] count number of elements to remove
-      # @return [String, Array<String>] the values of the last elements
+      # @return [nil, String, Array<String>] the values of the last elements
       def rpop(key, count = nil)
         command = [:rpop, key]
         command << Integer(count) if count

--- a/test/lint/lists.rb
+++ b/test/lint/lists.rb
@@ -140,6 +140,7 @@ module Lint
       assert_equal 2, r.llen("foo")
       assert_equal "s1", r.lpop("foo")
       assert_equal 1, r.llen("foo")
+      assert_nil r.lpop("nonexistent")
     end
 
     def test_lpop_count
@@ -160,6 +161,7 @@ module Lint
       assert_equal 2, r.llen("foo")
       assert_equal "s2", r.rpop("foo")
       assert_equal 1, r.llen("foo")
+      assert_nil r.rpop("nonexistent")
     end
 
     def test_rpop_count


### PR DESCRIPTION
I noticed, that the docs for `lpop`/`rpop` are incomplete regarding missing keys. Also added test cases for this.