### PR TITLE
Fix `Redis#close` to properly reset the fork protection check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix `Redis#close` to properly reset the fork protection check.
+
 # 5.0.1
 
 - Added a fake `Redis::Connections.drivers` method to be compatible with older sidekiq versions.

--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -30,7 +30,7 @@ class Redis
     def initialize(*)
       super
       @inherit_socket = false
-      @pid = Process.pid
+      @pid = nil
     end
     ruby2_keywords :initialize if respond_to?(:ruby2_keywords, true)
 
@@ -114,10 +114,15 @@ class Redis
       @inherit_socket = true
     end
 
+    def close
+      super
+      @pid = nil
+    end
+
     private
 
     def ensure_connected(retryable: true)
-      unless @inherit_socket || Process.pid == @pid
+      unless @inherit_socket || (@pid ||= Process.pid) == Process.pid
         raise InheritedError,
               "Tried to use a connection from a child process without reconnecting. " \
               "You need to reconnect to Redis after forking " \

--- a/test/redis/client_test.rb
+++ b/test/redis/client_test.rb
@@ -34,4 +34,17 @@ class TestClient < Minitest::Test
     r.call("SET", "\x00\xFF", "fée")
     assert_equal "fée", r.call("GET", "\x00\xFF".b)
   end
+
+  def test_close_clear_pid
+    assert_equal "PONG", r.ping
+    fake_pid = Process.pid + 1
+    Process.stubs(:pid).returns(fake_pid)
+
+    assert_raises Redis::InheritedError do
+      r.ping
+    end
+
+    r.close
+    assert_equal "PONG", r.ping
+  end
 end


### PR DESCRIPTION
If you properly close the connection in the forked process, you can safely use it.
