### PR TITLE
fix changelog instructions for enabling 5.0 behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Introduce `sadd?` and `srem?` as boolean returning versions of `sadd` and `srem`.
 * Deprecate `sadd` and `srem` returning a boolean when called with a single argument.
-  To enable the redis 5.0 behavior you can set `Redis.sadd_returns_boolean = true`.
+  To enable the redis 5.0 behavior you can set `Redis.sadd_returns_boolean = false`.
 * Deprecate passing `timeout` as a positional argument in blocking commands (`brpop`, `blop`, etc).
 
 # 4.7.1


### PR DESCRIPTION
Hello, this minor instruction in the changelog is incorrect.

Default behavior for 4.x: `Redis.sadd_returns_boolean = true`
5.x behavior: `Redis.sadd_returns_boolean = false`

This PR is against the 4.x branch, but you'll probably want to apply to main as well.