### PR TITLE
Correct usage for ConnectionPool guide.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ As such it is heavilly recommended to use the [`connection_pool` gem](https://gi
 ```ruby
 module MyApp
   def self.redis
-    @redis ||= ConnectionPool.new do
+    @redis ||= ConnectionPool::Wrapper.new do
       Redis.new(url: ENV["REDIS_URL"])
     end
   end


### PR DESCRIPTION
https://github.com/mperham/connection_pool#migrating-to-a-connection-pool

There need to use `ConnectionPool::Wrapper` for initialize. 

```rb
$redis = ConnectionPool::Wrapper.new(size: 5, timeout: 3) { Redis.new }
$redis.sadd('foo', 1)
$redis.smembers('foo')
```