### PR TITLE
Add a description about replica_affinity option for cluster gem

### DIFF
--- a/cluster/README.md
+++ b/cluster/README.md
@@ -39,6 +39,12 @@ If you want [the connection to be able to read from any replica](https://redis.i
 Redis::Cluster.new(nodes: nodes, replica: true)
 ```
 
+Also, you can specify the `:replica_affinity` option if you want to prevent accessing cross availability zones.
+
+```ruby
+Redis::Cluster.new(nodes: nodes, replica: true, replica_affinity: :latency)
+```
+
 The calling code is responsible for [avoiding cross slot commands](https://redis.io/topics/cluster-spec#keys-distribution-model).
 
 ```ruby
@@ -59,13 +65,13 @@ redis.mget('{key}1', '{key}2')
 Since Redis can return FQDN of nodes in reply to client since `7.*` with CLUSTER commands, we can use cluster feature with SSL/TLS connection like this:
 
 ```ruby
-Redis.new(cluster: %w[rediss://foo.example.com:6379])
+Redis::Cluster.new(nodes: %w[rediss://foo.example.com:6379])
 ```
 
 On the other hand, in Redis versions prior to `6.*`, you can specify options like the following if cluster mode is enabled and client has to connect to nodes via single endpoint with SSL/TLS.
 
 ```ruby
-Redis.new(cluster: %w[rediss://foo-endpoint.example.com:6379], fixed_hostname: 'foo-endpoint.example.com')
+Redis::Cluster.new(nodes: %w[rediss://foo-endpoint.example.com:6379], fixed_hostname: 'foo-endpoint.example.com')
 ```
 
 In case of the above architecture, if you don't pass the `fixed_hostname` option to the client and servers return IP addresses of nodes, the client may fail to verify certificates.

--- a/cluster/lib/redis/cluster.rb
+++ b/cluster/lib/redis/cluster.rb
@@ -53,6 +53,7 @@ class Redis
     # @option options [Boolean] :inherit_socket (false) Whether to use socket in forked process or not
     # @option options [Array<String, Hash{Symbol => String, Integer}>] :nodes List of cluster nodes to contact
     # @option options [Boolean] :replica Whether to use readonly replica nodes in Redis Cluster or not
+    # @option options [Symbol] :replica_affinity scale reading strategy, currently supported: `:random`, `:latency`
     # @option options [String] :fixed_hostname Specify a FQDN if cluster mode enabled and
     #   client has to connect nodes via single endpoint with SSL/TLS
     # @option options [Class] :connector Class of custom connector

--- a/cluster/redis-clustering.gemspec
+++ b/cluster/redis-clustering.gemspec
@@ -47,5 +47,5 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.7.0'
 
   s.add_runtime_dependency('redis', s.version)
-  s.add_runtime_dependency('redis-cluster-client', '~> 0.2')
+  s.add_runtime_dependency('redis-cluster-client', '>= 0.3.2')
 end


### PR DESCRIPTION
closes #1067

I added a new feature to [redis-cluster-client](https://github.com/redis-rb/redis-cluster-client) that we become able to specify the strategy for reading from replicas. I tried to simulate the environment of multiple availability zones with the `tc` command.

* https://github.com/redis-rb/redis-cluster-client/blob/dcfeb6f583043c22c7a8ee49f70156ffd6b95171/docker-compose.latency.yaml#L34-L51
* https://github.com/redis-rb/redis-cluster-client/blob/dcfeb6f583043c22c7a8ee49f70156ffd6b95171/.github/workflows/test.yaml#L261-L316

near node:
```
PING 172.18.0.5 (172.18.0.5) 56(84) bytes of data.
64 bytes from 172.18.0.5: icmp_seq=1 ttl=64 time=0.049 ms
64 bytes from 172.18.0.5: icmp_seq=2 ttl=64 time=0.052 ms
64 bytes from 172.18.0.5: icmp_seq=3 ttl=64 time=0.041 ms
64 bytes from 172.18.0.5: icmp_seq=4 ttl=64 time=0.039 ms
64 bytes from 172.18.0.5: icmp_seq=5 ttl=64 time=0.056 ms
```

far node:
```
PING 172.18.0.4 (172.18.0.4) 56(84) bytes of data.
64 bytes from 172.18.0.4: icmp_seq=1 ttl=64 time=2.13 ms
64 bytes from 172.18.0.4: icmp_seq=2 ttl=64 time=2.07 ms
64 bytes from 172.18.0.4: icmp_seq=3 ttl=64 time=2.07 ms
64 bytes from 172.18.0.4: icmp_seq=4 ttl=64 time=2.06 ms
64 bytes from 172.18.0.4: icmp_seq=5 ttl=64 time=2.15 ms
```

replica_affinity: `:random`
```
BenchCommand::ScaleReadRandom#bench_get = bench_get	 0.000531	 0.027782	 0.103212	 1.216746	12.433569
```

replica_affinity: `:latency`
```
BenchCommand::ScaleReadLatency#bench_get = bench_get	 0.000344	 0.001310	 0.008482	 0.086164	 0.762670
```