### PR TITLE
Cast ttl argument to integer in `expire`, `setex` and a few others.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Cast `ttl` argument to integer in `expire`, `setex` and a few others.
+
 # 5.0.3
 
 - Add `OutOfMemoryError` as a subclass of `CommandError`

--- a/lib/redis/commands/keys.rb
+++ b/lib/redis/commands/keys.rb
@@ -76,7 +76,7 @@ class Redis
       #   - `:lt => true`: Set expiry only when the new expiry is less than current one.
       # @return [Boolean] whether the timeout was set or not
       def expire(key, seconds, nx: nil, xx: nil, gt: nil, lt: nil)
-        args = [:expire, key, seconds]
+        args = [:expire, key, Integer(seconds)]
         args << "NX" if nx
         args << "XX" if xx
         args << "GT" if gt
@@ -96,7 +96,7 @@ class Redis
       #   - `:lt => true`: Set expiry only when the new expiry is less than current one.
       # @return [Boolean] whether the timeout was set or not
       def expireat(key, unix_time, nx: nil, xx: nil, gt: nil, lt: nil)
-        args = [:expireat, key, unix_time]
+        args = [:expireat, key, Integer(unix_time)]
         args << "NX" if nx
         args << "XX" if xx
         args << "GT" if gt
@@ -132,7 +132,7 @@ class Redis
       #   - `:lt => true`: Set expiry only when the new expiry is less than current one.
       # @return [Boolean] whether the timeout was set or not
       def pexpire(key, milliseconds, nx: nil, xx: nil, gt: nil, lt: nil)
-        args = [:pexpire, key, milliseconds]
+        args = [:pexpire, key, Integer(milliseconds)]
         args << "NX" if nx
         args << "XX" if xx
         args << "GT" if gt
@@ -152,7 +152,7 @@ class Redis
       #   - `:lt => true`: Set expiry only when the new expiry is less than current one.
       # @return [Boolean] whether the timeout was set or not
       def pexpireat(key, ms_unix_time, nx: nil, xx: nil, gt: nil, lt: nil)
-        args = [:pexpireat, key, ms_unix_time]
+        args = [:pexpireat, key, Integer(ms_unix_time)]
         args << "NX" if nx
         args << "XX" if xx
         args << "GT" if gt

--- a/lib/redis/commands/strings.rb
+++ b/lib/redis/commands/strings.rb
@@ -105,7 +105,7 @@ class Redis
       # @param [String] value
       # @return [String] `"OK"`
       def setex(key, ttl, value)
-        send_command([:setex, key, ttl, value.to_s])
+        send_command([:setex, key, Integer(ttl), value.to_s])
       end
 
       # Set the time to live in milliseconds of a key.
@@ -115,7 +115,7 @@ class Redis
       # @param [String] value
       # @return [String] `"OK"`
       def psetex(key, ttl, value)
-        send_command([:psetex, key, ttl, value.to_s])
+        send_command([:psetex, key, Integer(ttl), value.to_s])
       end
 
       # Set the value of a key, only if the key does not exist.


### PR DESCRIPTION
While migrating a big Rails app I noticed that it was extremely frequent to pass `ActiveSupport::Duration` instances as `ttl` argument.

We already cast a few arguments explicitly like this, so I think it's worth it here.