### PR TITLE
Fix Ruby syntax in `reconnect_attempts` example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,8 +273,8 @@ of durations:
 ```ruby
 Redis.new(reconnect_attempts: [
   0, # retry immediately
-  0.25 # retry a second time after 250ms
-  1 # retry a third and final time after another 1s
+  0.25, # retry a second time after 250ms
+  1, # retry a third and final time after another 1s
 ])
 ```
 


### PR DESCRIPTION
[ci skip]