### PR TITLE
Improve performance of mapped method's hash flattening

### DIFF
--- a/lib/redis/commands/hashes.rb
+++ b/lib/redis/commands/hashes.rb
@@ -63,7 +63,7 @@ class Redis
       #
       # @see #hmset
       def mapped_hmset(key, hash)
-        hmset(key, hash.to_a.flatten)
+        hmset(key, hash.flatten)
       end
 
       # Get the value of a hash field.

--- a/lib/redis/commands/streams.rb
+++ b/lib/redis/commands/streams.rb
@@ -53,7 +53,7 @@ class Redis
           args << maxlen
         end
         args << id
-        args.concat(entry.to_a.flatten)
+        args.concat(entry.flatten)
         send_command(args)
       end
 

--- a/lib/redis/commands/strings.rb
+++ b/lib/redis/commands/strings.rb
@@ -152,7 +152,7 @@ class Redis
       #
       # @see #mset
       def mapped_mset(hash)
-        mset(hash.to_a.flatten)
+        mset(hash.flatten)
       end
 
       # Set one or more values, only if none of the keys exist.
@@ -180,7 +180,7 @@ class Redis
       #
       # @see #msetnx
       def mapped_msetnx(hash)
-        msetnx(hash.to_a.flatten)
+        msetnx(hash.flatten)
       end
 
       # Get the value of a key.


### PR DESCRIPTION
In `mapped_hmset`, `mapped_mset` and `xadd` method,
Hash variable does not need to be cast as Array type for flattening.

Also In benchmark,
`hash.flatten` is faster than `hash.to_a.flatten`.

So I think it would be better.

```
hash = {'key1': '1', 'key2': '2', 'key3': '3', 'key4': '4'}

Benchmark.bm do |x|
  x.report { hash.to_a.flatten }
  x.report { hash.flatten }
end

=== OUTPUT ===

       user     system      total        real
   0.000011   0.000002   0.000013 (  0.000009)
   0.000004   0.000001   0.000005 (  0.000004)

```