### PR TITLE
Fix XAUTOCLAIM when entry is deleted

### DIFF
--- a/lib/redis/commands.rb
+++ b/lib/redis/commands.rb
@@ -119,7 +119,9 @@ class Redis
     HashifyStreamAutoclaim = lambda { |reply|
       {
         'next' => reply[0],
-        'entries' => reply[1].map { |entry| [entry[0], entry[1].each_slice(2).to_h] }
+        'entries' => reply[1].compact.map do |entry, values|
+          [entry, values.each_slice(2)&.to_h]
+        end
       }
     }
 

--- a/test/lint/streams.rb
+++ b/test/lint/streams.rb
@@ -712,6 +712,22 @@ module Lint
       assert_equal [], actual['entries']
     end
 
+    def test_xautoclaim_with_deleted_entry
+      omit_version(MIN_REDIS_VERSION_XAUTOCLAIM)
+
+      redis.xadd('s1', { f: 'v1' }, id: '0-1')
+      redis.xgroup(:create, 's1', 'g1', '$')
+      redis.xadd('s1', { f: 'v2' }, id: '0-2')
+      redis.xreadgroup('g1', 'c1', 's1', '>')
+      redis.xdel('s1', '0-2')
+      sleep 0.01
+
+      actual = redis.xautoclaim('s1', 'g1', 'c2', 0, '0-0')
+
+      assert_equal '0-0', actual['next']
+      assert_equal [], actual['entries']
+    end
+
     def test_xpending
       redis.xadd('s1', { f: 'v1' }, id: '0-1')
       redis.xgroup(:create, 's1', 'g1', '$')


### PR DESCRIPTION
This addresses https://github.com/redis/redis-rb/issues/1165. 

When a consumer has read an entry, it is added to the PEL. If the event is deleted, the entry in the PEL is not removed. If that is claimed with `XAUTOCLAIM` Redis responds with a null event (at least until version 7.0 where nulls are removed from the response). The HashifyStreamAutoclaim lambda doesn't handle the null value and throws a NoMethodError.

This change just compacts the entries so that nulls are removed.