### PR TITLE
[Redis 6.2] Add NOMKSTREAM option to XADD

### DIFF
--- a/lib/redis/commands/streams.rb
+++ b/lib/redis/commands/streams.rb
@@ -34,7 +34,7 @@ class Redis
       # @example Without options
       #   redis.xadd('mystream', f1: 'v1', f2: 'v2')
       # @example With options
-      #   redis.xadd('mystream', { f1: 'v1', f2: 'v2' }, id: '0-0', maxlen: 1000, approximate: true)
+      #   redis.xadd('mystream', { f1: 'v1', f2: 'v2' }, id: '0-0', maxlen: 1000, approximate: true, nomkstream: true)
       #
       # @param key   [String] the stream key
       # @param entry [Hash]   one or multiple field-value pairs
@@ -43,10 +43,12 @@ class Redis
       # @option opts [String]  :id          the entry id, default value is `*`, it means auto generation
       # @option opts [Integer] :maxlen      max length of entries
       # @option opts [Boolean] :approximate whether to add `~` modifier of maxlen or not
+      # @option opts [Boolean] :nomkstream  whether to add NOMKSTREAM, default is not to add
       #
       # @return [String] the entry id
-      def xadd(key, entry, approximate: nil, maxlen: nil, id: '*')
+      def xadd(key, entry, approximate: nil, maxlen: nil, nomkstream: nil, id: '*')
         args = [:xadd, key]
+        args << 'NOMKSTREAM' if nomkstream
         if maxlen
           args << "MAXLEN"
           args << "~" if approximate

--- a/test/lint/streams.rb
+++ b/test/lint/streams.rb
@@ -3,7 +3,6 @@
 module Lint
   module Streams
     MIN_REDIS_VERSION = '4.9.0'
-    MIN_REDIS_VERSION_XAUTOCLAIM = '6.2.0'
     ENTRY_ID_FORMAT = /\d+-\d+/.freeze
 
     def setup
@@ -87,6 +86,16 @@ module Lint
 
     def test_xadd_with_maxlen_and_approximate_option
       actual = redis.xadd('s1', { f1: 'v1', f2: 'v2' }, maxlen: 2, approximate: true)
+      assert_match ENTRY_ID_FORMAT, actual
+    end
+
+    def test_xadd_with_nomkstream_option
+      omit_version('6.2.0')
+
+      actual = redis.xadd('s1', { f1: 'v1', f2: 'v2' }, nomkstream: true)
+      assert_nil actual
+
+      actual = redis.xadd('s1', { f1: 'v1', f2: 'v2' }, nomkstream: false)
       assert_match ENTRY_ID_FORMAT, actual
     end
 
@@ -647,7 +656,7 @@ module Lint
     end
 
     def test_xautoclaim
-      omit_version(MIN_REDIS_VERSION_XAUTOCLAIM)
+      omit_version('6.2.0')
 
       redis.xadd('s1', { f: 'v1' }, id: '0-1')
       redis.xgroup(:create, 's1', 'g1', '$')
@@ -664,7 +673,7 @@ module Lint
     end
 
     def test_xautoclaim_with_justid_option
-      omit_version(MIN_REDIS_VERSION_XAUTOCLAIM)
+      omit_version('6.2.0')
 
       redis.xadd('s1', { f: 'v1' }, id: '0-1')
       redis.xgroup(:create, 's1', 'g1', '$')
@@ -680,7 +689,7 @@ module Lint
     end
 
     def test_xautoclaim_with_count_option
-      omit_version(MIN_REDIS_VERSION_XAUTOCLAIM)
+      omit_version('6.2.0')
 
       redis.xadd('s1', { f: 'v1' }, id: '0-1')
       redis.xgroup(:create, 's1', 'g1', '$')
@@ -697,7 +706,7 @@ module Lint
     end
 
     def test_xautoclaim_with_larger_interval
-      omit_version(MIN_REDIS_VERSION_XAUTOCLAIM)
+      omit_version('6.2.0')
 
       redis.xadd('s1', { f: 'v1' }, id: '0-1')
       redis.xgroup(:create, 's1', 'g1', '$')
@@ -713,7 +722,7 @@ module Lint
     end
 
     def test_xautoclaim_with_deleted_entry
-      omit_version(MIN_REDIS_VERSION_XAUTOCLAIM)
+      omit_version('6.2.0')
 
       redis.xadd('s1', { f: 'v1' }, id: '0-1')
       redis.xgroup(:create, 's1', 'g1', '$')


### PR DESCRIPTION
This adds the ability to add the NOMKSTREAM option to XADD. By default it does not add the option to the command, meaning that a stream will be created if it doesn't exist.

From the Redis documentation at: https://redis.io/commands/xadd/
> Appends the specified stream entry to the stream at the specified key. If the key does not exist, as a side effect of running this command the key is created with a stream value. The creation of stream's key can be disabled with the NOMKSTREAM option.

References https://github.com/redis/redis-rb/issues/978