### PR TITLE
treat ReadOnlyError as ConnectionError

### DIFF
--- a/lib/redis/errors.rb
+++ b/lib/redis/errors.rb
@@ -26,9 +26,6 @@ class Redis
   class WrongTypeError < CommandError
   end
 
-  class ReadOnlyError < CommandError
-  end
-
   class OutOfMemoryError < CommandError
   end
 
@@ -50,6 +47,10 @@ class Redis
 
   # Raised when the connection was inherited by a child process.
   class InheritedError < BaseConnectionError
+  end
+
+  # Generally raised after during Redis failover scenarios
+  class ReadOnlyError < BaseConnectionError
   end
 
   # Raised when client options are invalid.

--- a/lib/redis/errors.rb
+++ b/lib/redis/errors.rb
@@ -49,7 +49,7 @@ class Redis
   class InheritedError < BaseConnectionError
   end
 
-  # Generally raised after during Redis failover scenarios
+  # Generally raised during Redis failover scenarios
   class ReadOnlyError < BaseConnectionError
   end
 

--- a/test/redis/internals_test.rb
+++ b/test/redis/internals_test.rb
@@ -317,8 +317,8 @@ class TestInternals < Minitest::Test
 
     redis = Redis.new(host: "127.0.0.1", port: port)
     redis.call("PING")
-    # This shuld raise the redis-rb error but lets get this working first
-    assert_raises RedisClient::ReadOnlyError do
+
+    assert_raises Redis::ReadOnlyError do
       redis.call("SET", "foo", "bar")
     end
 


### PR DESCRIPTION
`ReadOnlyError` is now considered a connection error in redis-client as of `0.11.2` (https://github.com/redis-rb/redis-client/pull/65). This error is usually raised during failover scenarios and reconnection will likely work.