### PR TITLE
Add wait on blocking commands for an extra `config.read_timeout`

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -78,9 +78,9 @@ class Redis
     def blocking_call_v(timeout, command, &block)
       if timeout && timeout > 0
         # Can't use the command timeout argument as the connection timeout
-        # otherwise it would be very racy. So we add an extra 100ms to account for
-        # the network delay.
-        timeout += 0.1
+        # otherwise it would be very racy. So we add the regular read_timeout on top
+        # to account for the network delay.
+        timeout += config.read_timeout
       end
 
       super(timeout, command, &block)


### PR DESCRIPTION
Previously we were waiting an extra 100ms which is totally arbitrary and might not be enough.

cc @ChrisBr