### PR TITLE
Add change to default client timeout to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 # 5.0.0
 
+- Default client timeout decreased from 5 seconds to 1 second.
 - Eagerly and strictly cast Integer and Float parameters.
 - Allow to call `subscribe`, `unsubscribe`, `psubscribe` and `punsubscribe` from a subscribed client. See #1131.
 - Use `MD5` for hashing server nodes in `Redis::Distributed`. This should improve keys distribution among servers. See #1089.


### PR DESCRIPTION
After deploying a redis gem upgrade (among other things) today we started getting `Redis::TimeoutError: RedisClient::ReadTimeoutError` every now and then. Took us quite a while to figure out that the default timeout had changed from 5 seconds in 4.x to 1 second in 5.x.

This change deserves a changelog entry.