### PR TITLE
✨ Add ZMPOP

### DIFF
--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -694,6 +694,13 @@ class Redis
       node_for(key).zmscore(key, *members)
     end
 
+    # Iterate over keys, removing members from the first non empty sorted set found.
+    def zmpop(*keys, modifier: "MIN", count: nil)
+      ensure_same_node(:zmpop, keys) do |node|
+        node.zmpop(*keys, modifier: modifier, count: count)
+      end
+    end
+
     # Return a range of members in a sorted set, by index, score or lexicographical ordering.
     def zrange(key, start, stop, **options)
       node_for(key).zrange(key, start, stop, **options)

--- a/test/lint/sorted_sets.rb
+++ b/test/lint/sorted_sets.rb
@@ -479,6 +479,20 @@ module Lint
       assert_equal [['d', 3.0]], r.zrange('foo', 0, -1, with_scores: true)
     end
 
+    def test_zmpop
+      target_version('7.0') do
+        assert_nil r.zmpop('foo')
+
+        r.zadd('foo', %w[0 a 1 b 2 c 3 d])
+        assert_equal ['foo', [['a', 0.0]]], r.zmpop('foo')
+        assert_equal ['foo', [['b', 1.0], ['c', 2.0], ['d', 3.0]]], r.zmpop('foo', count: 4)
+
+        r.zadd('foo', %w[0 a 1 b 2 c 3 d])
+        r.zadd('foo2', %w[0 a 1 b 2 c 3 d])
+        assert_equal ['foo', [['d', 3.0]]], r.zmpop('foo', 'foo2', modifier: "MAX")
+      end
+    end
+
     def test_zremrangebylex
       r.zadd('foo', %w[0 a 0 b 0 c 0 d 0 e 0 f 0 g])
       assert_equal 5, r.zremrangebylex('foo', '(b', '[g')


### PR DESCRIPTION
I noticed some 7.0 commands were missing and thought it might be fun to add them. I'm not super familiar with the code base standards, so I'm sure I stepped in it with a couple of decisions, happy to change whatever.

Also, and this is embarrassing, but I couldn't figure out how to run tests locally. 

**Example:**
```ruby
irb(main):001:0> redis = Redis.new(url: "redis://localhost:6379/2")
=> #<Redis client v5.0.6 for redis://localhost:6379/2>
irb(main):002:0> redis.zadd("myzset", [[1, "one"], [2, "two"], [3, "three"]])
=> 3
irb(main):003:0> redis.zmpop("myzset", min_or_max: "MAX", count: 2)
=> ["myzset", [["three", 3.0], ["two", 2.0]]]
```