### PR TITLE
Remove unneeded requires

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -4,8 +4,6 @@ $LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
 
 require "minitest/autorun"
 require "mocha/minitest"
-require "logger"
-require "stringio"
 
 $VERBOSE = true
 


### PR DESCRIPTION
These were left after the logger was removed in version 5.0.

I am curious, what was the reason to remove it?