### PR TITLE
✨ Add ZINTERCARD

### DIFF
--- a/lib/redis/commands/sorted_sets.rb
+++ b/lib/redis/commands/sorted_sets.rb
@@ -722,6 +722,18 @@ class Redis
       end
       ruby2_keywords(:zinterstore) if respond_to?(:ruby2_keywords, true)
 
+      # This command is similar to ZINTER, but instead of returning the result set,
+      #   it returns just the cardinality of the result.
+      #
+      # @param [Array<String>] keys list of sorted sets
+      # @param [Integer] limit will short circuit operation if limit is met
+      def zintercard(*keys, limit: nil)
+        args = [:zintercard, keys.size, keys]
+        args << "LIMIT" << limit if limit
+
+        send_command(args)
+      end
+
       # Return the union of multiple sorted sets
       #
       # @example Retrieve the union of `2*zsetA` and `1*zsetB`

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -788,6 +788,14 @@ class Redis
       end
     end
 
+    # This command is similar to ZINTER, but instead of returning the result set,
+    #   it returns just the cardinality of the result.
+    def zintercard(*keys, limit: nil)
+      ensure_same_node(:zintercard, keys) do |node|
+        node.zintercard(*keys, limit)
+      end
+    end
+
     # Return the union of multiple sorted sets.
     def zunion(*keys, **options)
       keys.flatten!(1)

--- a/test/lint/sorted_sets.rb
+++ b/test/lint/sorted_sets.rb
@@ -786,6 +786,17 @@ module Lint
       assert_equal 1, r.zinterstore('{1}baz', %w[{1}foo {1}bar], weights: [2.0, 3.0])
     end
 
+    def test_zintercard
+      target_version('7.0') do
+        r.zadd('{1}foo', %w[0 a 1 b 2 c 3 d])
+        assert_equal 0, r.zintercard('{1}foo', '{2}foo2')
+
+        r.zadd('{2}foo2', %w[0 a 1 b 2 c])
+        assert_equal 3, r.zintercard('{1}foo', '{2}foo2')
+        assert_equal 2, r.zintercard('{1}foo', '{2}foo2', limit: 2)
+      end
+    end
+
     def test_zscan
       r.zadd('foo', %w[0 a 1 b 2 c])
       expected = ['0', [['a', 0.0], ['b', 1.0], ['c', 2.0]]]


### PR DESCRIPTION
* Adding [ZINTERCARD](https://redis.io/commands/zintercard/)
* https://github.com/redis/redis-rb/issues/1187

```ruby
irb(main):001:0> redis = Redis.new(url: "redis://localhost:6379/2")
=> #<Redis client v5.0.6 for redis://localhost:6379/2>
irb(main):002:0> redis.zadd("zseta", 2, "two")
=> true
irb(main):003:0> redis.zadd("zsetb", 3, "three")
=> true
irb(main):004:0> redis.zinter("zseta", "zsetb")
=> []
irb(main):005:0> redis.zintercard("zseta", "zsetb")
=> 0
irb(main):006:0> redis.zadd("zsetb", 2, "two")
=> true
irb(main):007:0> redis.zintercard("zseta", "zsetb")
=> 1
irb(main):005:0> redis.zintercard("zseta", "zsetb", "zsetc")
=> 0
```