### PR TITLE
Fix compatibility with `redis-client 0.15.0` when using Redis Sentinel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix compatibility with `redis-client 0.15.0` when using Redis Sentinel. Fix #1209.
+
 # 5.0.6
 
 - Wait for an extra `config.read_timeout` in blocking commands rather than an arbitrary 100ms. See #1175.

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -166,6 +166,8 @@ class Redis
     @monitor.synchronize do
       @client.call_v(command, &block)
     end
+  rescue ::RedisClient::Error => error
+    Client.translate_error!(error)
   end
 
   def send_blocking_command(command, timeout, &block)

--- a/test/redis/client_test.rb
+++ b/test/redis/client_test.rb
@@ -28,10 +28,10 @@ class TestClient < Minitest::Test
 
   def test_error_translate_subclasses
     error = Class.new(RedisClient::CommandError)
-    assert_equal Redis::CommandError, r._client.send(:translate_error_class, error)
+    assert_equal Redis::CommandError, Redis::Client.send(:translate_error_class, error)
 
     assert_raises KeyError do
-      r._client.send(:translate_error_class, StandardError)
+      Redis::Client.send(:translate_error_class, StandardError)
     end
   end
 


### PR DESCRIPTION
Fix: https://github.com/redis/redis-rb/issues/1209

Use raw `RedisClient` for sentinel calls

Otherwise the error translation messes with the redis-client code.

Also update tests to account for the password being preserved.