### PR TITLE
Add `Redis::Distributed#mset_nonatomic` & `mapped_mset_nonatomic`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 5.0.8
+
+- Add `Redis::Distributed#mset_nonatomic` & `mapped_mset_nonatomic`
+
 # 5.0.7
 
 - Fix compatibility with `redis-client 0.15.0` when using Redis Sentinel. Fix #1209.

--- a/test/distributed/commands_on_strings_test.rb
+++ b/test/distributed/commands_on_strings_test.rb
@@ -37,10 +37,24 @@ class TestDistributedCommandsOnStrings < Minitest::Test
     end
   end
 
+  def test_mset_nonatomic
+    r.mset_nonatomic(:foo, "s1", :bar, "s2")
+
+    assert_equal 's1', r.get('foo')
+    assert_equal 's2', r.get('bar')
+  end
+
   def test_mset_mapped
     assert_raises Redis::Distributed::CannotDistribute do
       r.mapped_mset(foo: "s1", bar: "s2")
     end
+  end
+
+  def test_mset_mapped_nonatomic
+    r.mapped_mset_nonatomic(foo: "s1", bar: "s2")
+
+    assert_equal 's1', r.get('foo')
+    assert_equal 's2', r.get('bar')
   end
 
   def test_msetnx


### PR DESCRIPTION
`Redis::Distributed#mset` can't be guaranteed to be atomic, so it raises CannotDistribute by default. 

However, sometimes we don't care so much about atomicity (eg in Rails' `RedisCacheStore#write_multi`), so allow bypassing the CannotDistribute check.

This is part of the fix for https://github.com/rails/rails/issues/48938


I'm not totally decided on the best way of doing this. I'd originally tried just adding an option to the original method - 

```ruby
   def mapped_mset(hash, atomic: true)
      raise CannotDistribute, :mapped_mset if atomic

     group_hash_by_node(hash) do |node, subhash|
        node.mapped_mset(subhash)
      end
    end
```

but the kwargs make it tricky - I don't think it's possible to do that and still support `redis.mapped_mset({ foo: 1}, atomic: true)` and `redis.mapped_mset(foo: 1)`.

Another option would be to set it as an option on the client (eg `Redis::Distributed.new(node_configs, allow_nonatomic_operations: true))`), but I decided that was a bit weird since it only really makes sense for mset and mapped_mset.

So for now I went with adding extra `mset_nonatomic` & `mapped_mset_nonatomic` methods, but I could definitely be persuaded otherwise.

---

We maybe also ought to consider what the fix in Rails will look like if & when this is fixed in redis-rb. I guess if we take the approach of this PR it'd be something like:


```diff
diff --git a/activesupport/lib/active_support/cache/redis_cache_store.rb b/activesupport/lib/active_support/cache/redis_cache_store.rb
index 4a5a28a47d..88c900782b 100644
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -311,15 +311,22 @@ def mset_capable? # :nodoc:
         @mset_capable
       end
 
+      def nonatomic_mset?
+        set_redis_capabilities unless defined? @nonatomic_mset
+        @nonatomic_mset
+      end
+
       private
         def set_redis_capabilities
           case redis
           when Redis::Distributed
             @mget_capable = true
             @mset_capable = false
+            @nonatonic_mset = redis.respond_to?(:mapped_mset_nonatomic)
           else
             @mget_capable = true
             @mset_capable = true
+            @nonatonic_mset = false
           end
         end
 
@@ -416,7 +423,7 @@ def write_multi_entries(entries, expires_in: nil, **options)
               failsafe :write_multi_entries do
                 payload = serialize_entries(entries, **options)
                 redis.with do |c|
-                  c.mapped_mset(payload)
+                  nonatomic_mset? ? c.mapped_mset_nonatomic(payload) : c.mapped_mset(payload)
                 end
               end
             else

```


Any opinions?