### PR TITLE
Support role being specified as a string

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -152,6 +152,9 @@ class Redis
         end
       end
 
+      # Role is expected to be a symbol
+      options[:role] = options[:role].to_sym if options.key?(:role)
+
       Client.sentinel(**options).new_client
     else
       Client.config(**options).new_client


### PR DESCRIPTION
sometimes the redis options are provided as a hash with string values.

This is true in my case where the configurations are read as a json object from an environment variable. 

 Given that only the role is expected to be a symbol, It is a much better user experience if the conversion was handled internally by the library instead of requiring the user to handle it themselves.