### PR TITLE
Fix `Redis#without_reconnect` for sentinel clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix `Redis#without_reconnect` for sentinel clients. Fix #1212.
+
 # 5.0.7
 
 - Fix compatibility with `redis-client 0.15.0` when using Redis Sentinel. Fix #1209.

--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -117,10 +117,6 @@ class Redis
       Client.translate_error!(error)
     end
 
-    def disable_reconnection(&block)
-      ensure_connected(retryable: false, &block)
-    end
-
     def inherit_socket!
       @inherit_socket = true
     end

--- a/redis.gemspec
+++ b/redis.gemspec
@@ -45,5 +45,5 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.5.0'
 
-  s.add_runtime_dependency('redis-client', '>= 0.9.0')
+  s.add_runtime_dependency('redis-client', '>= 0.16.0')
 end

--- a/test/sentinel/sentinel_test.rb
+++ b/test/sentinel/sentinel_test.rb
@@ -23,6 +23,14 @@ class SentinelTest < Minitest::Test
     assert_equal MASTER_PORT.to_i, actual[2]
   end
 
+  def test_without_reconnect
+    wait_for_quorum
+
+    redis.without_reconnect do
+      redis.get("key")
+    end
+  end
+
   def test_the_client_can_connect_to_available_slaves
     commands = {
       sentinel: lambda do |*_|


### PR DESCRIPTION
Fix: https://github.com/redis/redis-rb/issues/1212