### PR TITLE
Update default timeout docs

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -45,7 +45,7 @@ class Redis
   # @option options [String] :host ("127.0.0.1") server hostname
   # @option options [Integer] :port (6379) server port
   # @option options [String] :path path to server socket (overrides host and port)
-  # @option options [Float] :timeout (5.0) timeout in seconds
+  # @option options [Float] :timeout (1.0) timeout in seconds
   # @option options [Float] :connect_timeout (same as timeout) timeout for initial connect in seconds
   # @option options [String] :username Username to authenticate against server
   # @option options [String] :password Password to authenticate against server


### PR DESCRIPTION
Update the documentation to reflect the timeout is now 1 second.  This pr, https://github.com/redis-rb/redis-client/commit/90d219fe59dc124ed9157c353e4e9d0c75b0eb67#diff-dd62159b97639b7e6aca9f5c209b2ff5a74924bf38699581dcdc5074e2e62bbfL7 set it to 1 second.  It is also documented in the change-logs as being set to 1 second for version 5