### PR TITLE
Support transactions for cluster client

### DIFF
--- a/cluster/lib/redis/cluster.rb
+++ b/cluster/lib/redis/cluster.rb
@@ -38,6 +38,9 @@ class Redis
     class AmbiguousNodeError < BaseError
     end
 
+    class TransactionConsistencyError < BaseError
+    end
+
     def connection
       raise NotImplementedError, "Redis::Cluster doesn't implement #connection"
     end

--- a/cluster/lib/redis/cluster/client.rb
+++ b/cluster/lib/redis/cluster/client.rb
@@ -9,7 +9,8 @@ class Redis
         RedisClient::Cluster::InitialSetupError => Redis::Cluster::InitialSetupError,
         RedisClient::Cluster::OrchestrationCommandNotSupported => Redis::Cluster::OrchestrationCommandNotSupported,
         RedisClient::Cluster::AmbiguousNodeError => Redis::Cluster::AmbiguousNodeError,
-        RedisClient::Cluster::ErrorCollection => Redis::Cluster::CommandErrorCollection
+        RedisClient::Cluster::ErrorCollection => Redis::Cluster::CommandErrorCollection,
+        RedisClient::Cluster::Transaction::ConsistencyError => Redis::Cluster::TransactionConsistencyError
       ).freeze
 
       class << self

--- a/cluster/redis-clustering.gemspec
+++ b/cluster/redis-clustering.gemspec
@@ -47,5 +47,5 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.7.0'
 
   s.add_runtime_dependency('redis', s.version)
-  s.add_runtime_dependency('redis-cluster-client', '>= 0.6.1')
+  s.add_runtime_dependency('redis-cluster-client', '>= 0.7.0')
 end

--- a/cluster/test/client_transactions_test.rb
+++ b/cluster/test/client_transactions_test.rb
@@ -6,9 +6,46 @@ require "helper"
 class TestClusterClientTransactions < Minitest::Test
   include Helper::Cluster
 
-  def test_cluster_client_does_not_support_transaction
-    assert_raises(Redis::Cluster::AmbiguousNodeError) do
-      redis.multi { |r| r.set('key', 'foo') }
+  def test_cluster_client_does_support_transaction_by_single_key
+    actual = redis.multi do |r|
+      r.set('counter', '0')
+      r.incr('counter')
+      r.incr('counter')
+    end
+
+    assert_equal(['OK', 1, 2], actual)
+    assert_equal('2', redis.get('counter'))
+  end
+
+  def test_cluster_client_does_support_transaction_by_hashtag
+    actual = redis.multi do |r|
+      r.mset('{key}1', 1, '{key}2', 2)
+      r.mset('{key}3', 3, '{key}4', 4)
+    end
+
+    assert_equal(%w[OK OK], actual)
+    assert_equal(%w[1 2 3 4], redis.mget('{key}1', '{key}2', '{key}3', '{key}4'))
+  end
+
+  def test_cluster_client_does_not_support_transaction_by_multiple_keys
+    assert_raises(Redis::Cluster::TransactionConsistencyError) do
+      redis.multi do |r|
+        r.set('key1', 1)
+        r.set('key2', 2)
+        r.set('key3', 3)
+        r.set('key4', 4)
+      end
+    end
+
+    assert_raises(Redis::Cluster::TransactionConsistencyError) do
+      redis.multi do |r|
+        r.mset('key1', 1, 'key2', 2)
+        r.mset('key3', 3, 'key4', 4)
+      end
+    end
+
+    (1..4).each do |i|
+      assert_nil(redis.get("key#{i}"))
     end
   end
 end

--- a/cluster/test/commands_on_transactions_test.rb
+++ b/cluster/test/commands_on_transactions_test.rb
@@ -20,9 +20,15 @@ class TestClusterCommandsOnTransactions < Minitest::Test
   end
 
   def test_multi
-    assert_raises(Redis::Cluster::AmbiguousNodeError) do
+    assert_raises(LocalJumpError) do
       redis.multi
     end
+
+    assert_raises(ArgumentError) do
+      redis.multi {}
+    end
+
+    assert_equal([1], redis.multi { |r| r.incr('counter') })
   end
 
   def test_unwatch


### PR DESCRIPTION
The redis-cluster-client underlying the redis-clustering is now supported transactions by method `#multi`. So this PR fixes error mappings and adds related test cases.

* #1224
* https://github.com/redis-rb/redis-cluster-client/pull/277

closes #1224