### PR TITLE
Add sharded Pub/Sub support for cluster

### DIFF
--- a/lib/redis/commands/pubsub.rb
+++ b/lib/redis/commands/pubsub.rb
@@ -49,6 +49,27 @@ class Redis
       def pubsub(subcommand, *args)
         send_command([:pubsub, subcommand] + args)
       end
+
+      # Post a message to a channel in a shard.
+      def spublish(channel, message)
+        send_command([:spublish, channel, message])
+      end
+
+      # Listen for messages published to the given channels in a shard.
+      def ssubscribe(*channels, &block)
+        _subscription(:ssubscribe, 0, channels, block)
+      end
+
+      # Listen for messages published to the given channels in a shard.
+      # Throw a timeout error if there is no messages for a timeout period.
+      def ssubscribe_with_timeout(timeout, *channels, &block)
+        _subscription(:ssubscribe_with_timeout, timeout, channels, block)
+      end
+
+      # Stop listening for messages posted to the given channels in a shard.
+      def sunsubscribe(*channels)
+        _subscription(:sunsubscribe, 0, channels, nil)
+      end
     end
   end
 end


### PR DESCRIPTION
* https://redis.io/docs/interact/pubsub/#sharded-pubsub
  * Sharded Pub/Sub is only supported in cluster mode since version 7.
  * The channels are sharded by its name as same as keys.
  * Sharded Pub/Sub reduces consumptions of network bandwidth, on the other hand, global Pub/Sub consumes network bandwidth via cluster bus because all channel's messages are propagated to all nodes.
* https://redis.io/commands/?group=pubsub
  * Several commands replies cross-slot error if the client passes arguments of channels located multiple slots.
    * e.g. `ssubscribe`, `sunsubscribe`
* https://github.com/redis-rb/redis-cluster-client
  * The underlying library already supports sharded Pub/Sub but it's fixed some bugs recently.
* #1187