### PR TITLE
Pass watch: kwarg to #multi calls on clients

### DIFF
--- a/cluster/lib/redis/cluster/client.rb
+++ b/cluster/lib/redis/cluster/client.rb
@@ -70,8 +70,8 @@ class Redis
         handle_errors { super(&block) }
       end
 
-      def multi(&block)
-        handle_errors { super(&block) }
+      def multi(watch: nil, &block)
+        handle_errors { super(watch: watch, &block) }
       end
 
       private

--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -111,7 +111,7 @@ class Redis
       Client.translate_error!(error)
     end
 
-    def multi
+    def multi(watch: nil)
       super
     rescue ::RedisClient::Error => error
       Client.translate_error!(error)


### PR DESCRIPTION
Both RedisClient and RedisClient::Cluster have #multi methods that accept a watch: kwarg to watch keys as part of the transaction. See:

* https://github.com/redis-rb/redis-client/blob/ba8848b195404ab337daa94647f600b1a4506f0f/lib/redis_client.rb#L419
* https://github.com/redis-rb/redis-cluster-client/blob/c00ee01d087471b690f44ecbac8d0cea005783fd/lib/redis_client/cluster/transaction.rb#L36

However, the subclasses `Redis::Client` and `Redis::Cluster::Client` in this gem(s) don't forward these keyword arguments, so you can't take advantage of them.

This PR simply delegates the `watch` argument.