### PR TITLE
Cluster: Preserve message and suberrors when raising CommandErrorCollection

### DIFF
--- a/cluster/test/commands_on_server_test.rb
+++ b/cluster/test/commands_on_server_test.rb
@@ -21,9 +21,11 @@ class TestClusterCommandsOnServer < Minitest::Test
               'Use BGSAVE SCHEDULE in order to schedule a BGSAVE whenever possible.'
 
     redis_cluster_mock(bgsave: ->(*_) { "-Error #{err_msg}" }) do |redis|
-      assert_raises(Redis::Cluster::CommandErrorCollection, 'Command error replied on any node') do
+      err = assert_raises(Redis::Cluster::CommandErrorCollection, 'Command error replied on any node') do
         redis.bgsave
       end
+      assert_includes err.message, err_msg
+      assert_kind_of Redis::CommandError, err.errors.values.first
     end
   end
 


### PR DESCRIPTION
The constructor signature for CommandErrorCollection is (errors, message). That means if you call "raise CommandErrorCollection, 'foobar'", that actually winds up setting the _errors_ field to 'foobar', _NOT_ the message. This leads to incredibly undescriptive "Command errors were replied on any node" errors getting emitted if there are errors using pipelining.

Fix this by:
1) explicitly constructing the error, with the arguments in the right order
2) mapping the sub-errors into redis-rb errors too - presumably there's an :errors attr_reader because somebody will find that useful.