### PR TITLE
Add NodeMightBeDown to redis client error mapping

### DIFF
--- a/cluster/lib/redis/cluster/client.rb
+++ b/cluster/lib/redis/cluster/client.rb
@@ -11,6 +11,7 @@ class Redis
         RedisClient::Cluster::AmbiguousNodeError => Redis::Cluster::AmbiguousNodeError,
         RedisClient::Cluster::ErrorCollection => Redis::Cluster::CommandErrorCollection,
         RedisClient::Cluster::Transaction::ConsistencyError => Redis::Cluster::TransactionConsistencyError
+        RedisClient::Cluster::NodeMightBeDown => Redis::Cluster::NodeMightBeDown
       ).freeze
 
       class << self


### PR DESCRIPTION
We've experienced `RedisClient::Cluster::NodeMightBeDown` errors when scaling in our Elasticache clusters. This seems expected, but this error doesn't exist in the error map, so we receive an exception similar to the following:
```
/var/bundle/ruby/3.1.0/gems/redis-clustering-5.0.8/lib/redis/cluster/client.rb:89:in 'fetch': key not found: RedisClient::Cluster::NodeMightBeDown
Did you mean?  RedisClient::Cluster::ErrorCollection (KeyError)
from /var/bundle/ruby/3.1.0/gems/redis-clustering-5.0.8/lib/redis/cluster/client.rb:89:in `rescue in handle_errors'
from /var/bundle/ruby/3.1.0/gems/redis-clustering-5.0.8/lib/redis/cluster/client.rb:79:in `handle_errors'
from /var/bundle/ruby/3.1.0/gems/redis-clustering-5.0.8/lib/redis/cluster/client.rb:61:in `call_v'
from /var/bundle/ruby/3.1.0/gems/redis-5.0.8/lib/redis.rb:152:in `block in send_command'
from /var/bundle/ruby/3.1.0/gems/redis-5.0.8/lib/redis.rb:151:in `synchronize'
from /var/bundle/ruby/3.1.0/gems/redis-5.0.8/lib/redis.rb:151:in `send_command'
from /var/bundle/ruby/3.1.0/gems/redis-5.0.8/lib/redis/commands/strings.rb:95:in `set'
```
This adds the `NodeMightBeDown` error to the error mapping so it can be fetched as expected.
