### PR TITLE
Support `BIT/BYTE` for `bitcount` and `bitpos` for redis 7+

### DIFF
--- a/lib/redis/commands/bitmaps.rb
+++ b/lib/redis/commands/bitmaps.rb
@@ -27,9 +27,13 @@ class Redis
       # @param [String] key
       # @param [Integer] start start index
       # @param [Integer] stop stop index
+      # @param [String, Symbol] scale the scale of the offset range
+      #     e.g. 'BYTE' - interpreted as a range of bytes, 'BIT' - interpreted as a range of bits
       # @return [Integer] the number of bits set to 1
-      def bitcount(key, start = 0, stop = -1)
-        send_command([:bitcount, key, start, stop])
+      def bitcount(key, start = 0, stop = -1, scale: nil)
+        command = [:bitcount, key, start, stop]
+        command << scale if scale
+        send_command(command)
       end
 
       # Perform a bitwise operation between strings and store the resulting string in a key.
@@ -51,14 +55,17 @@ class Redis
       # @param [Integer] bit whether to look for the first 1 or 0 bit
       # @param [Integer] start start index
       # @param [Integer] stop stop index
+      # @param [String, Symbol] scale the scale of the offset range
+      #     e.g. 'BYTE' - interpreted as a range of bytes, 'BIT' - interpreted as a range of bits
       # @return [Integer] the position of the first 1/0 bit.
       #                  -1 if looking for 1 and it is not found or start and stop are given.
-      def bitpos(key, bit, start = nil, stop = nil)
+      def bitpos(key, bit, start = nil, stop = nil, scale: nil)
         raise(ArgumentError, 'stop parameter specified without start parameter') if stop && !start
 
         command = [:bitpos, key, bit]
         command << start if start
         command << stop if stop
+        command << scale if scale
         send_command(command)
       end
     end

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -370,8 +370,8 @@ class Redis
     end
 
     # Count the number of set bits in a range of the string value stored at key.
-    def bitcount(key, start = 0, stop = -1)
-      node_for(key).bitcount(key, start, stop)
+    def bitcount(key, start = 0, stop = -1, scale: nil)
+      node_for(key).bitcount(key, start, stop, scale: scale)
     end
 
     # Perform a bitwise operation between strings and store the resulting string in a key.
@@ -383,8 +383,8 @@ class Redis
     end
 
     # Return the position of the first bit set to 1 or 0 in a string.
-    def bitpos(key, bit, start = nil, stop = nil)
-      node_for(key).bitpos(key, bit, start, stop)
+    def bitpos(key, bit, start = nil, stop = nil, scale: nil)
+      node_for(key).bitpos(key, bit, start, stop, scale: scale)
     end
 
     # Set the string value of a key and return its old value.

--- a/test/lint/strings.rb
+++ b/test/lint/strings.rb
@@ -249,6 +249,15 @@ module Lint
       assert_equal 17, r.bitcount("foo", 0, -1)
     end
 
+    def test_bitcount_bits_range
+      target_version "7.0" do
+        r.set("foo", "abcde")
+
+        assert_equal 10, r.bitcount("foo", 8, 31, scale: :bit)
+        assert_equal 17, r.bitcount("foo", 0, -1, scale: :byte)
+      end
+    end
+
     def test_getrange
       r.set("foo", "abcde")
 

--- a/test/redis/bitpos_test.rb
+++ b/test/redis/bitpos_test.rb
@@ -41,6 +41,14 @@ class TestBitpos < Minitest::Test
     assert_equal(8,  r.bitpos("foo", 1, 1, 1))
   end
 
+  def test_bitpos_one_intervals_bit_range
+    target_version "7.0" do
+      r.set "foo", "\x00\xff\x00"
+      assert_equal(8, r.bitpos("foo", 1, 8, -1, scale: 'bit'))
+      assert_equal(-1, r.bitpos("foo", 1, 8, -1, scale: 'byte'))
+    end
+  end
+
   def test_bitpos_raise_exception_if_stop_not_start
     assert_raises(ArgumentError) do
       r.bitpos("foo", 0, nil, 2)


### PR DESCRIPTION
Reference https://github.com/redis/redis-rb/issues/1187

Redis 7.0 release notes - https://raw.githubusercontent.com/redis/redis/7.0/00-RELEASENOTES

I am not very happy with the `bytes_range` parameter name. Maybe you can suggest something better? Maybe `use_bytes` or `offset_unit` etc...