### PR TITLE
Update README to remove mutex language

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,9 @@ available on [RubyDoc.info][rubydoc].
 ## Connection Pooling and Thread safety
 
 The client does not provide connection pooling. Each `Redis` instance
-has one and only one connection to the server, and use of this connection
-is protected by a mutex.
+has one and only one connection to the server.
 
-As such it is heavilly recommended to use the [`connection_pool` gem](https://github.com/mperham/connection_pool), e.g.:
+As such it is heavily recommended to use the [`connection_pool` gem](https://github.com/mperham/connection_pool), e.g.:
 
 ```ruby
 module MyApp


### PR DESCRIPTION
This change removes references to their being a `mutex` protecting the underlying Redis connection from concurrent access. This was removed in `5.x`[1].

[1]: https://github.com/redis/redis-rb/issues/1070