### PR TITLE
Handle unknown subclasses of RedisClient::Error in clustering

### DIFF
--- a/cluster/test/client_pipelining_test.rb
+++ b/cluster/test/client_pipelining_test.rb
@@ -58,4 +58,22 @@ class TestClusterClientPipelining < Minitest::Test
     end
     assert_equal 1.upto(6).map(&:to_s), result
   end
+
+  def test_pipeline_unmapped_errors_are_bubbled_up
+    ex = Class.new(StandardError)
+    assert_raises(ex) do
+      redis.pipelined do |_pipe|
+        raise ex, "boom"
+      end
+    end
+  end
+
+  def test_pipeline_error_subclasses_are_mapped
+    ex = Class.new(RedisClient::ConnectionError)
+    assert_raises(Redis::ConnectionError) do
+      redis.pipelined do |_pipe|
+        raise ex, "tick tock"
+      end
+    end
+  end
 end

--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -27,18 +27,18 @@ class Redis
         super(protocol: 2, **kwargs, client_implementation: ::RedisClient)
       end
 
-      def translate_error!(error)
-        redis_error = translate_error_class(error.class)
+      def translate_error!(error, mapping: ERROR_MAPPING)
+        redis_error = translate_error_class(error.class, mapping: mapping)
         raise redis_error, error.message, error.backtrace
       end
 
       private
 
-      def translate_error_class(error_class)
-        ERROR_MAPPING.fetch(error_class)
+      def translate_error_class(error_class, mapping: ERROR_MAPPING)
+        mapping.fetch(error_class)
       rescue IndexError
-        if (client_error = error_class.ancestors.find { |a| ERROR_MAPPING[a] })
-          ERROR_MAPPING[error_class] = ERROR_MAPPING[client_error]
+        if (client_error = error_class.ancestors.find { |a| mapping[a] })
+          mapping[error_class] = mapping[client_error]
         else
           raise
         end


### PR DESCRIPTION
The Redis::Client code already knows how to crawl up through exception ancestors and match that against the hash; call into that code from Redis::Cluster::Client as well. `

Otherwise, you can get KeyError raised from e.g. pipeline blocks instead of the real error that happened.