### PR TITLE
Run Rubocop against Ruby 3.2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,12 +18,8 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.6"
-      - name: Set up Gems
-        run: |
-          gem update --system --no-document
-          gem install bundler --no-document
-          bundle install --jobs 4 --retry 3 --path=.bundle
+          ruby-version: "3.2"
+          bundler-cache: true
       - name: Lint
         run: bundle exec rubocop
 


### PR DESCRIPTION
There's no reason to run Rubocop against such an old version of Ruby; it's perfectly capable of parsing code according to Ruby 2.6 rules even when running on a more modern ruby (`TargetRubyVersion` in rubocop.yml). So, just run it on Ruby 3.2.