### PR TITLE
Clean up rubocop todos

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,12 +11,6 @@ Lint/HashCompareByIdentity:
   Exclude:
     - 'lib/redis.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Lint/RedundantStringCoercion:
-  Exclude:
-    - 'examples/consistency.rb'
-
 # Offense count: 2
 # Configuration parameters: EnforcedStyle, CheckMethodNames, CheckSymbols, AllowedIdentifiers.
 # SupportedStyles: snake_case, normalcase, non_integer

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,14 +11,6 @@ Lint/HashCompareByIdentity:
   Exclude:
     - 'lib/redis.rb'
 
-# Offense count: 2
-# Configuration parameters: EnforcedStyle, CheckMethodNames, CheckSymbols, AllowedIdentifiers.
-# SupportedStyles: snake_case, normalcase, non_integer
-# AllowedIdentifiers: capture3, iso8601, rfc1123_date, rfc822, rfc2822, rfc3339
-Naming/VariableNumber:
-  Exclude:
-    - 'test/remote_server_control_commands_test.rb'
-
 # Offense count: 6
 # Configuration parameters: AllowedMethods.
 # AllowedMethods: respond_to_missing?

--- a/examples/consistency.rb
+++ b/examples/consistency.rb
@@ -52,7 +52,7 @@ class ConsistencyTester
   def genkey
     # Write more often to a small subset of keys
     ks = rand > 0.5 ? @keyspace : @working_set
-    "#{@prefix}key_#{rand(ks).to_s}"
+    "#{@prefix}key_#{rand(ks)}"
   end
 
   def check_consistency(key, value)


### PR DESCRIPTION
This just cleans up some Rubocop exclusions and fixes one offense. 

The `Naming/VariableNumber` cop was resolved with this change:
https://github.com/redis/redis-rb/commit/221fa474d888f938dfe7c1031c0093101832b912#diff-c88392b188437e96c61abfa18c6a946b25adb60979605f673fe1b855b0306be4L38

The `Lint/RedundantStringCoercion` cop is resolved by not calling `#to_s` during string interpolation because it's called by default.