### PR TITLE
Restore connection.timeout correctly for Redis::Client#with_socket_timeout in 4.x 

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -330,8 +330,8 @@ class Redis
         @options[:read_timeout] = timeout # for reconnection
         yield
       ensure
-        connection.timeout = self.timeout if connected?
         @options[:read_timeout] = original
+        connection.timeout = self.timeout if connected?
       end
     end
 


### PR DESCRIPTION
I use redis gem 4.8.1 in my application, so I found this problem.

After block is called in `Redis::Client#with_socket_timeout`, `conneciton.timeout` can't be restored correctly in 4.x implementation, I guess. Because `self.timeout` returns `@options[:read_timeout]` restored after `connection.timeout`. This causes the bug that `with_socket_timeout` uses wrong timeout value unexpectedly.

I can't find the tests for `Redis::Client#with_socket_timeout`, so I couldn't wirte one, sorry.