### PR TITLE
Fix the watch command bugs for the cluster client

### DIFF
--- a/cluster/lib/redis/cluster.rb
+++ b/cluster/lib/redis/cluster.rb
@@ -96,6 +96,10 @@ class Redis
       send_command([:cluster, subcommand] + args, &block)
     end
 
+    def watch(*keys, &block)
+      synchronize { |c| c.call_v([:watch] + keys, &block) }
+    end
+
     private
 
     def initialize_client(options)

--- a/cluster/redis-clustering.gemspec
+++ b/cluster/redis-clustering.gemspec
@@ -47,5 +47,5 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.7.0'
 
   s.add_runtime_dependency('redis', s.version)
-  s.add_runtime_dependency('redis-cluster-client', '>= 0.7.0')
+  s.add_runtime_dependency('redis-cluster-client', '>= 0.7.11')
 end

--- a/cluster/test/commands_on_transactions_test.rb
+++ b/cluster/test/commands_on_transactions_test.rb
@@ -38,10 +38,29 @@ class TestClusterCommandsOnTransactions < Minitest::Test
   end
 
   def test_watch
-    assert_raises(Redis::CommandError, "CROSSSLOT Keys in request don't hash to the same slot") do
-      redis.watch('key1', 'key2')
+    assert_raises(Redis::Cluster::TransactionConsistencyError) do
+      redis.watch('{key}1', '{key}2')
     end
 
-    assert_equal 'OK', redis.watch('{key}1', '{key}2')
+    assert_raises(Redis::Cluster::TransactionConsistencyError) do
+      redis.watch('key1', 'key2') do |tx|
+        tx.call('SET', 'key1', '1')
+        tx.call('SET', 'key2', '2')
+      end
+    end
+
+    assert_raises(Redis::Cluster::TransactionConsistencyError) do
+      redis.watch('{hey}1', '{hey}2') do |tx|
+        tx.call('SET', '{key}1', '1')
+        tx.call('SET', '{key}2', '2')
+      end
+    end
+
+    redis.watch('{key}1', '{key}2') do |tx|
+      tx.call('SET', '{key}1', '1')
+      tx.call('SET', '{key}2', '2')
+    end
+
+    assert_equal %w[1 2], redis.mget('{key}1', '{key}2')
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -174,7 +174,7 @@ module Helper
     def with_acl
       admin = _new_client
       admin.acl('SETUSER', 'johndoe', 'on',
-                '+ping', '+select', '+command', '+cluster|slots', '+cluster|nodes',
+                '+ping', '+select', '+command', '+cluster|slots', '+cluster|nodes', '+readonly',
                 '>mysecret')
       yield('johndoe', 'mysecret')
     ensure


### PR DESCRIPTION
* The redis-cluster-client gem had had several bugs regarding the transaction feature. They has been resolved with the version `0.7.11`.
  * https://github.com/redis-rb/redis-cluster-client/issues/299
* The above release makes a portion of our test cases failure. So this pull request fixes them.
  * In the cluster client, a block is needed for the watch command because of the guarantee for a critical section with an optimistic locking. This behavior is different from the standalone client. So the cluster client overrides the watch method.