### PR TITLE
Eagerly close subscribed connection

### DIFF
--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -175,6 +175,7 @@ class Redis
           @subscription_client.send(method, *channels, &block)
         end
       ensure
+        @subscription_client&.close
         @subscription_client = nil
       end
     else


### PR DESCRIPTION
Fix: https://github.com/redis/redis-rb/issues/1259

Otherwise we need to wait for GC to close it.