### PR TITLE
Support latest redis-client

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2", "3.1", "3.0", "2.7", "2.6", "2.5", "jruby-9.3.6.0"]
+        ruby: ["3.2", "3.1", "3.0", "2.7", "2.6", "jruby-9.3.6.0"]
     runs-on: ubuntu-latest
     env:
       LOW_TIMEOUT: "0.01"
@@ -122,7 +122,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.5"
+          ruby-version: "2.6"
           bundler-cache: true
       - name: Cache local temporary directory
         uses: actions/cache@v4
@@ -159,7 +159,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.5"
+          ruby-version: "2.6"
           bundler-cache: true
       - name: Cache local temporary directory
         uses: actions/cache@v4
@@ -194,7 +194,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.5"
+          ruby-version: "2.6"
           bundler-cache: true
       - name: Cache local temporary directory
         uses: actions/cache@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 
 Layout/LineLength:
   Max: 120
@@ -54,6 +54,9 @@ Metrics/PerceivedComplexity:
   Enabled: false
 
 Style/PercentLiteralDelimiters:
+  Enabled: false
+
+Style/SlicingWithRange:
   Enabled: false
 
 Style/TrailingCommaInArrayLiteral:

--- a/cluster/test/helper.rb
+++ b/cluster/test/helper.rb
@@ -72,8 +72,7 @@ module Helper
       port = nil
 
       cluster_subcommands = if commands.key?(:cluster)
-        commands.delete(:cluster)
-                .to_h { |k, v| [k.to_s.downcase, v] }
+        commands.delete(:cluster).transform_keys { |k| k.to_s.downcase }
       else
         {}
       end

--- a/redis.gemspec
+++ b/redis.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.files         = Dir["CHANGELOG.md", "LICENSE", "README.md", "lib/**/*"]
   s.executables   = `git ls-files -- exe/*`.split("\n").map { |f| File.basename(f) }
 
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.6.0'
 
   s.add_runtime_dependency('redis-client', '>= 0.17.0')
 end

--- a/test/lint/streams.rb
+++ b/test/lint/streams.rb
@@ -135,7 +135,7 @@ module Lint
 
         assert_equal 1, redis.xtrim('s1', 0, approximate: true, limit: 1)
         error = assert_raises(Redis::CommandError) { redis.xtrim('s1', 0, limit: 1) }
-        assert_equal "ERR syntax error, LIMIT cannot be used without the special ~ option", error.message
+        assert_includes error.message, "ERR syntax error, LIMIT cannot be used without the special ~ option"
       ensure
         redis.config(:set, 'stream-node-max-entries', original)
       end
@@ -174,7 +174,7 @@ module Lint
 
       redis.xadd('s1', { f: 'v1' })
       error = assert_raises(Redis::CommandError) { redis.xtrim('s1', '1-0', strategy: '') }
-      assert_equal "ERR syntax error", error.message
+      assert_includes error.message, "ERR syntax error"
     end
 
     def test_xtrim_with_not_existed_stream

--- a/test/redis/connection_test.rb
+++ b/test/redis/connection_test.rb
@@ -37,27 +37,27 @@ class TestConnection < Minitest::Test
 
   def test_default_id_with_host_and_port
     redis = Redis.new(OPTIONS.merge(host: "host", port: "1234", db: 0))
-    assert_equal "redis://host:1234/0", redis.connection.fetch(:id)
+    assert_equal "redis://host:1234", redis.connection.fetch(:id)
   end
 
   def test_default_id_with_host_and_port_and_ssl
     redis = Redis.new(OPTIONS.merge(host: 'host', port: '1234', db: 0, ssl: true))
-    assert_equal "rediss://host:1234/0", redis.connection.fetch(:id)
+    assert_equal "rediss://host:1234", redis.connection.fetch(:id)
   end
 
   def test_default_id_with_host_and_port_and_explicit_scheme
     redis = Redis.new(OPTIONS.merge(host: "host", port: "1234", db: 0))
-    assert_equal "redis://host:1234/0", redis.connection.fetch(:id)
+    assert_equal "redis://host:1234", redis.connection.fetch(:id)
   end
 
   def test_default_id_with_path
     redis = Redis.new(OPTIONS.merge(path: "/tmp/redis.sock", db: 0))
-    assert_equal "/tmp/redis.sock/0", redis.connection.fetch(:id)
+    assert_equal "unix:///tmp/redis.sock", redis.connection.fetch(:id)
   end
 
   def test_default_id_with_path_and_explicit_scheme
     redis = Redis.new(OPTIONS.merge(path: "/tmp/redis.sock", db: 0))
-    assert_equal "/tmp/redis.sock/0", redis.connection.fetch(:id)
+    assert_equal "unix:///tmp/redis.sock", redis.connection.fetch(:id)
   end
 
   def test_override_id


### PR DESCRIPTION
The server_url rendering changed a bit, and also Ruby 2.5 support was dropped.