### PR TITLE
add flag to disable raising exceptions with pipelined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Add `exception` flag in `pipelined` allowing failed commands to be returned in the result array when set to `false`.
+
 # 5.1.0
 
 - `multi` now accept a `watch` keyword argument like `redis-client`. See #1236.

--- a/README.md
+++ b/README.md
@@ -191,6 +191,28 @@ end
 # => ["OK"]
 ```
 
+### Exception management
+
+The `exception` flag in the `#pipelined` is a feature that modifies the pipeline execution behavior. When set
+to `false`, it doesn't raise an exception when a command error occurs. Instead, it allows the pipeline to execute all
+commands, and any failed command will be available in the returned array. (Defaults to `true`)
+
+```ruby
+results = redis.pipelined(exception: false) do |pipeline|
+  pipeline.set('key1', 'value1')
+  pipeline.lpush('key1', 'something') # This will fail
+  pipeline.set('key2', 'value2')
+end
+# results => ["OK", #<RedisClient::WrongTypeError: WRONGTYPE Operation against a key holding the wrong kind of value>, "OK"]
+
+results.each do |result|
+  if result.is_a?(Redis::CommandError)
+    # Do something with the failed result
+  end
+end
+```
+
+
 ### Executing commands atomically
 
 You can use `MULTI/EXEC` to run a number of commands in an atomic

--- a/cluster/lib/redis/cluster/client.rb
+++ b/cluster/lib/redis/cluster/client.rb
@@ -90,8 +90,8 @@ class Redis
         handle_errors { super(timeout, command, &block) }
       end
 
-      def pipelined(&block)
-        handle_errors { super(&block) }
+      def pipelined(exception: true, &block)
+        handle_errors { super(exception: exception, &block) }
       end
 
       def multi(watch: nil, &block)

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -99,10 +99,10 @@ class Redis
     @client
   end
 
-  def pipelined
+  def pipelined(exception: true)
     synchronize do |client|
-      client.pipelined do |raw_pipeline|
-        yield PipelinedConnection.new(raw_pipeline)
+      client.pipelined(exception: exception) do |raw_pipeline|
+        yield PipelinedConnection.new(raw_pipeline, exception: exception)
       end
     end
   end

--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -105,7 +105,7 @@ class Redis
       Client.translate_error!(error)
     end
 
-    def pipelined
+    def pipelined(exception: true)
       super
     rescue ::RedisClient::Error => error
       Client.translate_error!(error)

--- a/redis.gemspec
+++ b/redis.gemspec
@@ -45,5 +45,5 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.6.0'
 
-  s.add_runtime_dependency('redis-client', '>= 0.17.0')
+  s.add_runtime_dependency('redis-client', '>= 0.22.0')
 end


### PR DESCRIPTION
Linked to https://github.com/redis-rb/redis-client/pull/187
Depends on https://github.com/redis-rb/redis-cluster-client/pull/343

Modifying the pipelined method in lib/redis_client.rb to include an optional exception parameter, which determines whether an exception should be raised when an error occurs during pipelining.

This gives better flexibility for error management when we want to retry only failed commands.