### PR TITLE
Fix several test cases for the cluster feature

### DIFF
--- a/cluster/test/commands_on_transactions_test.rb
+++ b/cluster/test/commands_on_transactions_test.rb
@@ -38,8 +38,11 @@ class TestClusterCommandsOnTransactions < Minitest::Test
   end
 
   def test_watch
-    assert_raises(Redis::CommandError, "CROSSSLOT Keys in request don't hash to the same slot") do
-      redis.watch('key1', 'key2')
+    assert_raises(Redis::Cluster::TransactionConsistencyError) do
+      redis.watch('key1', 'key2') do |tx|
+        tx.set('key1', '1')
+        tx.set('key2', '2')
+      end
     end
 
     assert_equal 'OK', redis.watch('{key}1', '{key}2')

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -174,7 +174,7 @@ module Helper
     def with_acl
       admin = _new_client
       admin.acl('SETUSER', 'johndoe', 'on',
-                '+ping', '+select', '+command', '+cluster|slots', '+cluster|nodes',
+                '+ping', '+select', '+command', '+cluster|slots', '+cluster|nodes', '+readonly',
                 '>mysecret')
       yield('johndoe', 'mysecret')
     ensure


### PR DESCRIPTION
* #1263

This may be a bug in the redis-cluster-client side, but I think we can do workaround at now.
https://github.com/redis/redis-rb/actions/runs/8666570773/job/23768812497?pr=1263
```
  1) Error:
TestClusterClientInternals#test_acl_auth_success:
Redis::Cluster::InitialSetupError: Redis client could not fetch cluster information: NOPERM User johndoe has no permissions to run the 'readonly' command (redis://127.0.0.1:16380),WRONGPASS invalid username-password pair or user is disabled. (redis://127.0.0.1:16385),WRONGPASS invalid username-password pair or user is disabled. (redis://127.0.0.1:16384)
    vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.7.9/lib/redis_client/cluster/node.rb:344:in `refetch_node_info_list'
    vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.7.9/lib/redis_client/cluster/node.rb:209:in `block (2 levels) in reload!'
    vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.7.9/lib/redis_client/cluster/node.rb:420:in `with_startup_clients'
    vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.7.9/lib/redis_client/cluster/node.rb:208:in `block in reload!'
    vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.7.9/lib/redis_client/cluster/node.rb:436:in `block in with_reload_lock'
    vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.7.9/lib/redis_client/cluster/node.rb:433:in `synchronize'
    vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.7.9/lib/redis_client/cluster/node.rb:433:in `with_reload_lock'
    vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.7.9/lib/redis_client/cluster/node.rb:207:in `reload!'
    vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.7.9/lib/redis_client/cluster/router.rb:312:in `update_cluster_info!'
    vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.7.9/lib/redis_client/cluster/router.rb:26:in `initialize'
    vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.7.9/lib/redis_client/cluster.rb:20:in `new'
    vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.7.9/lib/redis_client/cluster.rb:20:in `initialize'
    cluster/lib/redis/cluster/client.rb:51:in `block in initialize'
    cluster/lib/redis/cluster/client.rb:105:in `handle_errors'
    cluster/lib/redis/cluster/client.rb:51:in `initialize'
    vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.7.9/lib/redis_client/cluster_config.rb:74:in `new'
    vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.7.9/lib/redis_client/cluster_config.rb:74:in `new_client'
    cluster/lib/redis/cluster.rb:103:in `initialize_client'
    lib/redis.rb:73:in `initialize'
    cluster/lib/redis/cluster.rb:69:in `initialize'
    cluster/test/helper.rb:158:in `new'
    cluster/test/helper.rb:158:in `_new_client'
    cluster/test/client_internals_test.rb:59:in `block (2 levels) in test_acl_auth_success'
    test/helper.rb:179:in `with_acl'
    cluster/test/client_internals_test.rb:58:in `block in test_acl_auth_success'
    test/helper.rb:157:in `target_version'
    cluster/test/client_internals_test.rb:57:in `test_acl_auth_success'
```

The watch command behavior was changed in the redis-cluster-client side at the latest version.
https://github.com/redis/redis-rb/actions/runs/8668831551/job/23774590388?pr=1264
```
  1) Failure:
TestClusterCommandsOnTransactions#test_watch [cluster/test/commands_on_transactions_test.rb:41]:
CROSSSLOT Keys in request don't hash to the same slot.
[Redis::CommandError] exception expected, not
Class: <Redis::Cluster::TransactionConsistencyError>
Message: <"A block required. And you need to use the block argument as a client for the transaction.">
---Backtrace---
/home/runner/work/redis-rb/redis-rb/vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.8.0/lib/redis_client/cluster/router.rb:316:in `send_watch_command'
/home/runner/work/redis-rb/redis-rb/vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.8.0/lib/redis_client/cluster/router.rb:49:in `send_command'
/home/runner/work/redis-rb/redis-rb/vendor/bundle/ruby/2.7.0/gems/redis-cluster-client-0.8.0/lib/redis_client/cluster.rb:35:in `call_v'
/home/runner/work/redis-rb/redis-rb/cluster/lib/redis/cluster/client.rb:85:in `block in call_v'
/home/runner/work/redis-rb/redis-rb/cluster/lib/redis/cluster/client.rb:104:in `handle_errors'
/home/runner/work/redis-rb/redis-rb/cluster/lib/redis/cluster/client.rb:85:in `call_v'
/home/runner/work/redis-rb/redis-rb/lib/redis/commands/transactions.rb:63:in `block in watch'
/home/runner/work/redis-rb/redis-rb/lib/redis.rb:147:in `block in synchronize'
/home/runner/work/redis-rb/redis-rb/lib/redis.rb:147:in `synchronize'
/home/runner/work/redis-rb/redis-rb/lib/redis.rb:147:in `synchronize'
/home/runner/work/redis-rb/redis-rb/lib/redis/commands/transactions.rb:62:in `watch'
/home/runner/work/redis-rb/redis-rb/cluster/test/commands_on_transactions_test.rb:42:in `block in test_watch'
```