### PR TITLE
Return an empty array instead of throwing ArgumentError if the transaction is empty in the cluster client

### DIFF
--- a/cluster/test/commands_on_transactions_test.rb
+++ b/cluster/test/commands_on_transactions_test.rb
@@ -24,9 +24,7 @@ class TestClusterCommandsOnTransactions < Minitest::Test
       redis.multi
     end
 
-    assert_raises(ArgumentError) do
-      redis.multi {}
-    end
+    assert_empty(redis.multi {})
 
     assert_equal([1], redis.multi { |r| r.incr('counter') })
   end
@@ -55,6 +53,8 @@ class TestClusterCommandsOnTransactions < Minitest::Test
         tx.call('SET', '{key}2', '2')
       end
     end
+
+    assert_empty(redis.watch('{key}1', '{key}2') {})
 
     redis.watch('{key}1', '{key}2') do |tx|
       tx.call('SET', '{key}1', '1')


### PR DESCRIPTION
I fixed a tiny bug which behaved different from standalone client in redis-cluster-client. The behavior is now the same as redis-client.

* https://github.com/redis-rb/redis-cluster-client/pull/349

According to the above change, I've fixed some test cases for the cluster client in this repository.