### PR TITLE
Keep compatibilities as possible for the transaction feature between a standalone client and a cluster client

### DIFF
--- a/cluster/bin/console
+++ b/cluster/bin/console
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'irb'
+require 'bundler/setup'
+require 'redis/cluster'
+
+IRB.start(File.expand_path('..', __dir__))

--- a/cluster/lib/redis/cluster.rb
+++ b/cluster/lib/redis/cluster.rb
@@ -96,8 +96,20 @@ class Redis
       send_command([:cluster, subcommand] + args, &block)
     end
 
+    # @example A typical use case.
+    #   redis.watch("key") do |client|        # The client is an instance of the adapter
+    #     if redis.get("key") == "some value" # We can't use the client passed by the block argument
+    #       client.multi do |tx|              # The tx is the same instance of the adapter
+    #         tx.set("key", "other value")
+    #         tx.incr("counter")
+    #       end
+    #     else
+    #       client.unwatch
+    #     end
+    #   end
+    #   # => ["OK", 6]
     def watch(*keys, &block)
-      synchronize { |c| c.call_v([:watch] + keys, &block) }
+      synchronize { |c| c.watch(*keys, &block) }
     end
 
     private

--- a/cluster/lib/redis/cluster/transaction_adapter.rb
+++ b/cluster/lib/redis/cluster/transaction_adapter.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'redis_client/cluster/transaction'
+
+class Redis
+  class Cluster
+    class TransactionAdapter < RedisClient::Cluster::Transaction
+      def initialize(client, router, command_builder, node: nil, slot: nil, asking: false)
+        @client = client
+        super(router, command_builder, node: node, slot: slot, asking: asking)
+      end
+
+      def multi
+        yield self
+      end
+
+      def exec
+        # no need to do anything
+      end
+
+      def discard
+        # no need to do anything
+      end
+
+      def watch(*_)
+        # no need to do anything
+      end
+
+      def unwatch
+        # no need to do anything
+      end
+
+      private
+
+      def method_missing(name, *args, **kwargs, &block)
+        return call(name, *args, **kwargs, &block) if @client.respond_to?(name)
+
+        super
+      end
+
+      def respond_to_missing?(name, include_private = false)
+        return true if @client.respond_to?(name)
+
+        super
+      end
+    end
+  end
+end

--- a/cluster/test/commands_on_transactions_test.rb
+++ b/cluster/test/commands_on_transactions_test.rb
@@ -42,23 +42,23 @@ class TestClusterCommandsOnTransactions < Minitest::Test
 
     assert_raises(Redis::Cluster::TransactionConsistencyError) do
       redis.watch('key1', 'key2') do |tx|
-        tx.call('SET', 'key1', '1')
-        tx.call('SET', 'key2', '2')
+        tx.set('key1', '1')
+        tx.set('key2', '2')
       end
     end
 
     assert_raises(Redis::Cluster::TransactionConsistencyError) do
       redis.watch('{hey}1', '{hey}2') do |tx|
-        tx.call('SET', '{key}1', '1')
-        tx.call('SET', '{key}2', '2')
+        tx.set('{key}1', '1')
+        tx.set('{key}2', '2')
       end
     end
 
     assert_empty(redis.watch('{key}1', '{key}2') {})
 
     redis.watch('{key}1', '{key}2') do |tx|
-      tx.call('SET', '{key}1', '1')
-      tx.call('SET', '{key}2', '2')
+      tx.set('{key}1', '1')
+      tx.set('{key}2', '2')
     end
 
     assert_equal %w[1 2], redis.mget('{key}1', '{key}2')


### PR DESCRIPTION
There are some differences of the interface for the transaction feature between redis gem and redis-client gem. It seems that the redis-client gem is designed to be more simpler than the redis gem.

redis gem:
https://github.com/redis/redis-rb/blob/cdfe17264f1a67b35eb60d1532cee103c18692f1/lib/redis/commands/transactions.rb#L38-L49

redis-client gem:
https://github.com/redis-rb/redis-client?tab=readme-ov-file#transactions
```ruby
redis.multi(watch: %w[key]) do |tx|
  next unless redis.call('GET', 'key') == 'some value'

  tx.call('SET', 'key', 'other value')
  tx.call('INCR', 'counter')
end
```

On the redis-clustering gem side, I fixed some bugs for the transaction feature, but several compatibilities were broken.

* #1255

So I tried to implement to keep the compatibility as possible by using an adapter. The adapter fills the interface gap between the redis-clustering gem and the redis-cluster-client gem. Because the cluster client implementation for the transaction feature tends to be complex for the sharding, we are hard to keep the same behaviors between the redis gem and the redis-clustering gem. But I thought it is possible up to a point.

```ruby
redis.watch("key") do |client|        # The client is an instance of the adapter
  if redis.get("key") == "some value" # We can't use the client passed by the block argument
    client.multi do |tx|              # The tx is the same instance of the adapter
      tx.set("key", "other value") 
      tx.incr("counter") 
    end 
  else 
    client.unwatch 
  end 
end 
```