### PR TITLE
doc: add redis doc URL written acceptable regular expressions patterns

### DIFF
--- a/lib/redis/commands/hashes.rb
+++ b/lib/redis/commands/hashes.rb
@@ -222,6 +222,8 @@ class Redis
       #   - `:count => Integer`: return count keys at most per iteration
       #
       # @return [String, Array<[String, String]>] the next cursor and all found keys
+      # 
+      # See the [Redis Server HSCAN documentation](https://redis.io/docs/latest/commands/hscan/) for further details
       def hscan(key, cursor, **options)
         _scan(:hscan, cursor, [key], **options) do |reply|
           [reply[0], reply[1].each_slice(2).to_a]
@@ -239,6 +241,8 @@ class Redis
       #   - `:count => Integer`: return count keys at most per iteration
       #
       # @return [Enumerator] an enumerator for all found keys
+      # 
+      # See the [Redis Server HSCAN documentation](https://redis.io/docs/latest/commands/hscan/) for further details
       def hscan_each(key, **options, &block)
         return to_enum(:hscan_each, key, **options) unless block_given?
 

--- a/lib/redis/commands/keys.rb
+++ b/lib/redis/commands/keys.rb
@@ -22,6 +22,8 @@ class Redis
       #   - `:type => String`: return keys only of the given type
       #
       # @return [String, Array<String>] the next cursor and all found keys
+      # 
+      # See the [Redis Server SCAN documentation](https://redis.io/docs/latest/commands/scan/) for further details
       def scan(cursor, **options)
         _scan(:scan, cursor, [], **options)
       end
@@ -46,6 +48,8 @@ class Redis
       #   - `:type => String`: return keys only of the given type
       #
       # @return [Enumerator] an enumerator for all found keys
+      # 
+      # See the [Redis Server SCAN documentation](https://redis.io/docs/latest/commands/scan/) for further details
       def scan_each(**options, &block)
         return to_enum(:scan_each, **options) unless block_given?
 
@@ -282,6 +286,8 @@ class Redis
       #
       # @param [String] pattern
       # @return [Array<String>]
+      # 
+      # See the [Redis Server KEYS documentation](https://redis.io/docs/latest/commands/keys/) for further details
       def keys(pattern = "*")
         send_command([:keys, pattern]) do |reply|
           if reply.is_a?(String)

--- a/lib/redis/commands/pubsub.rb
+++ b/lib/redis/commands/pubsub.rb
@@ -29,17 +29,20 @@ class Redis
       end
 
       # Listen for messages published to channels matching the given patterns.
+      # See the [Redis Server PSUBSCRIBE documentation](https://redis.io/docs/latest/commands/psubscribe/) for further details
       def psubscribe(*channels, &block)
         _subscription(:psubscribe, 0, channels, block)
       end
 
       # Listen for messages published to channels matching the given patterns.
       # Throw a timeout error if there is no messages for a timeout period.
+      # See the [Redis Server PSUBSCRIBE documentation](https://redis.io/docs/latest/commands/psubscribe/) for further details
       def psubscribe_with_timeout(timeout, *channels, &block)
         _subscription(:psubscribe_with_timeout, timeout, channels, block)
       end
 
       # Stop listening for messages posted to channels matching the given patterns.
+      # See the [Redis Server PUNSUBSCRIBE documentation](https://redis.io/docs/latest/commands/punsubscribe/) for further details
       def punsubscribe(*channels)
         _subscription(:punsubscribe, 0, channels, nil)
       end

--- a/lib/redis/commands/sets.rb
+++ b/lib/redis/commands/sets.rb
@@ -184,6 +184,8 @@ class Redis
       #   - `:count => Integer`: return count keys at most per iteration
       #
       # @return [String, Array<String>] the next cursor and all found members
+      #
+      # See the [Redis Server SSCAN documentation](https://redis.io/docs/latest/commands/sscan/) for further details
       def sscan(key, cursor, **options)
         _scan(:sscan, cursor, [key], **options)
       end
@@ -199,6 +201,8 @@ class Redis
       #   - `:count => Integer`: return count keys at most per iteration
       #
       # @return [Enumerator] an enumerator for all keys in the set
+      #
+      # See the [Redis Server SSCAN documentation](https://redis.io/docs/latest/commands/sscan/) for further details
       def sscan_each(key, **options, &block)
         return to_enum(:sscan_each, key, **options) unless block_given?
 

--- a/lib/redis/commands/sorted_sets.rb
+++ b/lib/redis/commands/sorted_sets.rb
@@ -817,6 +817,8 @@ class Redis
       #
       # @return [String, Array<[String, Float]>] the next cursor and all found
       #   members and scores
+      #
+      # See the [Redis Server ZSCAN documentation](https://redis.io/docs/latest/commands/zscan/) for further details
       def zscan(key, cursor, **options)
         _scan(:zscan, cursor, [key], **options) do |reply|
           [reply[0], FloatifyPairs.call(reply[1])]
@@ -834,6 +836,8 @@ class Redis
       #   - `:count => Integer`: return count keys at most per iteration
       #
       # @return [Enumerator] an enumerator for all found scores and members
+      # 
+      # See the [Redis Server ZSCAN documentation](https://redis.io/docs/latest/commands/zscan/) for further details
       def zscan_each(key, **options, &block)
         return to_enum(:zscan_each, key, **options) unless block_given?
 

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -948,12 +948,14 @@ class Redis
     end
 
     # Listen for messages published to channels matching the given patterns.
+    # See the [Redis Server PSUBSCRIBE documentation](https://redis.io/docs/latest/commands/psubscribe/) for further details
     def psubscribe(*channels, &block)
       raise NotImplementedError
     end
 
     # Stop listening for messages posted to channels matching the given
     # patterns.
+    # See the [Redis Server PUNSUBSCRIBE documentation](https://redis.io/docs/latest/commands/punsubscribe/) for further details
     def punsubscribe(*channels)
       raise NotImplementedError
     end


### PR DESCRIPTION
Current documentation for some methods have common description "pattern", but accutually they have different acceptable regular expressions patterns.
To understand acceptable patterns reading rubydoc, those doccments have link to redis documentation on every methods.

Conversation issue is https://github.com/redis/redis-rb/issues/1266

