### PR TITLE
Fix a failure of a test case for a cluster client

### DIFF
--- a/cluster/test/commands_on_keys_test.rb
+++ b/cluster/test/commands_on_keys_test.rb
@@ -18,10 +18,7 @@ class TestClusterCommandsOnKeys < Minitest::Test
   def test_del
     set_some_keys
 
-    assert_raises(Redis::CommandError, "CROSSSLOT Keys in request don't hash to the same slot") do
-      redis.del('key1', 'key2')
-    end
-
+    assert_equal 2, redis.del('key1', 'key2')
     assert_equal 2, redis.del('{key}1', '{key}2')
   end
 


### PR DESCRIPTION
The version `0.9.0` of redis-cluster-client was released. It made `MSET`, `MGET` and `DEL` commands able to pass multiple keys without a hashtag by using pipelining. Although the performance is degradated, I think it may be useful in some use cases. So, because the behavior was changed, This pull request fixes a failure of a test case for a cluster client.