### PR TITLE
Fix several test cases for the cluster client

### DIFF
--- a/cluster/test/client_internals_test.rb
+++ b/cluster/test/client_internals_test.rb
@@ -56,7 +56,8 @@ class TestClusterClientInternals < Minitest::Test
   def test_acl_auth_success
     target_version "6.0.0" do
       with_acl do |username, password|
-        r = _new_client(nodes: DEFAULT_PORTS.map { |port| "redis://#{username}:#{password}@#{DEFAULT_HOST}:#{port}" })
+        nodes = DEFAULT_PORTS.map { |port| "redis://#{username}:#{password}@#{DEFAULT_HOST}:#{port}" }
+        r = _new_client(nodes: nodes)
         assert_equal('PONG', r.ping)
       end
     end
@@ -66,7 +67,9 @@ class TestClusterClientInternals < Minitest::Test
     target_version "6.0.0" do
       with_acl do |username, _|
         assert_raises(Redis::Cluster::InitialSetupError) do
-          _new_client(nodes: DEFAULT_PORTS.map { |port| "redis://#{username}:wrongpassword@#{DEFAULT_HOST}:#{port}" })
+          nodes = DEFAULT_PORTS.map { |port| "redis://#{username}:wrongpassword@#{DEFAULT_HOST}:#{port}" }
+          r = _new_client(nodes: nodes)
+          r.ping
         end
       end
     end


### PR DESCRIPTION
* #1276

Given the fix for the above issue, redis-cluster-client is now able to delay initialization. But the fix makes some test cases failed on redis-clustering. So this pull request fixes them.