### PR TITLE
Fix a memoization bug for cluster client

### DIFF
--- a/cluster/lib/redis/cluster/client.rb
+++ b/cluster/lib/redis/cluster/client.rb
@@ -54,11 +54,11 @@ class Redis
       ruby2_keywords :initialize if respond_to?(:ruby2_keywords, true)
 
       def id
-        @router.node_keys.join(' ')
+        server_url.join(' ')
       end
 
       def server_url
-        @router.node_keys
+        @router.nil? ? @config.startup_nodes.keys : router.node_keys
       end
 
       def connected?
@@ -115,9 +115,9 @@ class Redis
         end
 
         handle_errors do
-          RedisClient::Cluster::OptimisticLocking.new(@router).watch(keys) do |c, slot, asking|
+          RedisClient::Cluster::OptimisticLocking.new(router).watch(keys) do |c, slot, asking|
             transaction = Redis::Cluster::TransactionAdapter.new(
-              self, @router, @command_builder, node: c, slot: slot, asking: asking
+              self, router, @command_builder, node: c, slot: slot, asking: asking
             )
 
             result = yield transaction

--- a/cluster/redis-clustering.gemspec
+++ b/cluster/redis-clustering.gemspec
@@ -47,5 +47,5 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.7.0'
 
   s.add_runtime_dependency('redis', s.version)
-  s.add_runtime_dependency('redis-cluster-client', '>= 0.7.11')
+  s.add_runtime_dependency('redis-cluster-client', '>= 0.10.0')
 end


### PR DESCRIPTION
Closes #1282

I fixed redis-cluster-client to be able to delay the initialization to the first query.

* https://github.com/redis-rb/redis-cluster-client/pull/364
* https://github.com/redis-rb/redis-cluster-client/releases/tag/v0.10.0

But I've forgotten to fix it on redis-clustering side. So this pull request fixes it.