### PR TITLE
Support Redis.default_configuration = { ... }

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ server or a different port, try:
 
 ```ruby
 redis = Redis.new(host: "10.0.1.1", port: 6380, db: 15)
+
+# or you can globally configure the connection information
+# and reuse it across your application
+
+Redis.default_configuration = {
+  host: "10.0.1.1", port: 6380, driver: :hiredis
+}
+
+redis_db_1 = Redis.new(db: 1)
+redis_db_2 = Redis.new(db: 2)
 ```
 
 You can also specify connection options as a [`redis://` URL][redis-url]:

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -133,7 +133,7 @@ class Redis
 
   def configure_options(options)
     default_configuration = self.class.default_configuration
-    return options if default_configuration.nil?
+    return options unless default_configuration
 
     h_deep_merge = lambda do |hash1, hash2|
       result = hash1.dup

--- a/test/redis/configuration_test.rb
+++ b/test/redis/configuration_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestRedisInitialization < Minitest::Test
+  def teardown
+    Redis.default_configuration = {}
+  end
+
+  def test_initialize_without_default_configuration
+    redis = Redis.new(host: "localhost", port: 6379)
+    assert_equal "localhost", redis.instance_variable_get(:@options)[:host]
+    assert_equal 6379, redis.instance_variable_get(:@options)[:port]
+  end
+
+  def test_initialize_with_default_configuration
+    Redis.default_configuration = { host: "default_host", db: 1 }
+    redis = Redis.new(port: 6380)
+    options = redis.instance_variable_get(:@options)
+
+    assert_equal "default_host", options[:host]
+    assert_equal 6380, options[:port]
+    assert_equal 1, options[:db]
+  end
+
+  def test_initialize_overriding_default_configuration
+    Redis.default_configuration = { host: "default_host", port: 6379, db: 1 }
+    redis = Redis.new(host: "custom_host", db: 2)
+    options = redis.instance_variable_get(:@options)
+
+    assert_equal "custom_host", options[:host]
+    assert_equal 6379, options[:port]
+    assert_equal 2, options[:db]
+  end
+
+  def test_initialize_with_nested_default_configuration
+    Redis.default_configuration = {
+      ssl: { verify_mode: 0 },
+      timeout: { connect: 5, read: 5 }
+    }
+    redis = Redis.new(
+      ssl: { ca_file: "/path/to/ca.crt" },
+      timeout: { connect: 10 }
+    )
+    options = redis.instance_variable_get(:@options)
+
+    assert_equal({ ca_file: "/path/to/ca.crt", verify_mode: 0 }, options[:ssl])
+    assert_equal 10, options[:timeout][:connect]
+    assert_equal 5, options[:timeout][:read]
+  end
+
+  def test_initialize_with_url
+    Redis.default_configuration = { host: "default_host", port: 6379 }
+    redis = Redis.new(url: "redis://custom_host:7000/2")
+    options = redis.instance_variable_get(:@options)
+
+    assert_equal "redis://custom_host:7000/2", options[:url]
+    assert_equal "default_host", options[:host]
+    assert_equal 6379, options[:port]
+  end
+end


### PR DESCRIPTION
problem: I have a rails app + sidekiq + anycable + rails cache. And i want all of them to use redis with hiredis + a different db

solution:

```ruby
redis_uri = URI.parse(ENV["REDIS_URL"])

Redis.default_configuration = { 
  host: redis_uri.host, port: port = redis_uri.port, driver: :hiredis
}

# for example sidekiq

Sidekiq.configure_server do |c|
  c.redis = { db: 0 }
end
```