### PR TITLE
Add a mention of MGET, MSET and DEL commands to the cluster document, that behavior was changed by internal library

### DIFF
--- a/cluster/README.md
+++ b/cluster/README.md
@@ -99,3 +99,10 @@ end
 In a cluster mode client, you need to pass a block if you call the watch method and you need to specify an argument to the block.
 Also, you should use the block argument as a receiver to call commands in the block.
 Although the above restrictions are needed, this implementations is compatible with a standalone client.
+
+## MGET, MSET and DEL
+This gem allows you to use MGET, MSET and DEL specifying multiple keys without a hash tag.
+Cross-slot errors are prevented by an internal dedicated implementation.
+The underlying library makes the behavior possible.
+(ref. [redis-cluster-client](https://github.com/redis-rb/redis-cluster-client))
+That said, we recommend to use a hash tag for these commands to the better performance.


### PR DESCRIPTION
This pull request fixes a README file for the cluster client. A behavior of MGET, MSET and DEL commands was changed since [v0.9.0](https://github.com/redis-rb/redis-cluster-client/releases/tag/v0.9.0) in redis-cluster-client. So I added the mention to the document to realize for users.

ref. https://github.com/redis-rb/redis-cluster-client?tab=readme-ov-file#multiple-keys-and-crossslot-error