### PR TITLE
Mitigate long running job for truffleruby in CI by workaround

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -95,6 +95,7 @@ jobs:
         run: make start
       - name: Test
         run: bundle exec rake test:${{ matrix.suite }}
+        timeout-minutes: 3
       - name: Shutting down Redis
         run: make stop
 


### PR DESCRIPTION
This is just a workaround. I'm not understanding the root cause, sorry. I'd say that it's a pain in the neck because we are made to wait to fail the job with meaningless timeout every time.