### PR TITLE
Fix several test cases for the stuck in TruffleRuby

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,6 +57,7 @@ jobs:
         run: make start
       - name: Test
         run: bundle exec rake test:redis test:distributed
+        timeout-minutes: 3
       - name: Shutting down Redis
         run: make stop
 

--- a/test/redis/ssl_test.rb
+++ b/test/redis/ssl_test.rb
@@ -16,6 +16,7 @@ class SslTest < Minitest::Test
     RedisMock.start({ ping: proc { "+PONG" } }, ssl_server_opts("trusted")) do |port|
       redis = Redis.new(host: "127.0.0.1", port: port, ssl: true, ssl_params: { ca_file: ssl_ca_file })
       assert_equal redis.ping, "PONG"
+      redis.close
     end
   end
 
@@ -41,6 +42,7 @@ class SslTest < Minitest::Test
     RedisMock.start({}, ssl_server_opts("trusted")) do |port|
       redis = Redis.new(host: "127.0.0.1", port: port, ssl: true, ssl_params: { ca_file: ssl_ca_file })
       assert_equal redis.set("boom", "a" * 10_000_000), "OK"
+      redis.close
     end
   end
 


### PR DESCRIPTION
* #1292

This pull request is a continuation from the above.

* Add a timeout setting to a step in the workflow. JRuby environment may also exceed the timeout of the whole job.
* Add a closing step to several blocks for RedisMock. They are the root cause of the weird behavior in TruffleRuby. Although I'm not still understanding the internal mechanism.