### PR TITLE
Add Ruby 3.4 and fix ubuntu version issue

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - "*"
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches:
       - "*"
+    paths-ignore:
+      - '**/*.md'
 jobs:
   lint:
     name: Rubocop
@@ -29,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.3", "3.2", "3.1", "3.0", "2.7", "2.6", "jruby-9.3.6.0"]
+        ruby: ["3.4", "3.3", "3.2", "3.1", "3.0", "2.7", "2.6", "jruby"]
     runs-on: ubuntu-latest
     env:
       LOW_TIMEOUT: "0.01"
@@ -178,8 +182,6 @@ jobs:
   sentinel:
     name: Sentinel
     timeout-minutes: 15
-    strategy:
-      fail-fast: false
     runs-on: ubuntu-latest
     env:
       LOW_TIMEOUT: "0.14"


### PR DESCRIPTION
- Add Ruby 3.4
- JRuby version 9.3.6.0 was unavailable on Ubuntu 24.04 cause the workflow now use 24.04 instead of 22.04 (https://github.com/actions/runner-images/issues/10636)
- Ignore *.md files by the workflow