### PR TITLE
Fix `RedisClient::NoScriptError` issue

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'redis-client'
-
 class Redis
   class Client < ::RedisClient
     ERROR_MAPPING = {

--- a/lib/redis/errors.rb
+++ b/lib/redis/errors.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'redis-client'
+
 class Redis
   # Base error for all redis-rb errors.
   class BaseError < StandardError


### PR DESCRIPTION
I think `redis-client` should be required earlier, because otherwise this happens:

```shell
redis-rb/lib/redis/client.rb:21:in '<class:Client>': uninitialized constant Redis::NoScriptError (NameError)

      ERROR_MAPPING[RedisClient::NoScriptError] = Redis::NoScriptError
                                                       ^^^^^^^^^^^^^^^
	from redis-rb/lib/redis/client.rb:6:in '<class:Redis>'
	from redis-rb/lib/redis/client.rb:5:in '<top (required)>'
```

`errors.rb` dependes on `redis-client` and loaded ealier than `client.rb`.