### PR TITLE
Make `unlink` consistent with `del` when an empty keyset passed

### DIFF
--- a/lib/redis/commands/keys.rb
+++ b/lib/redis/commands/keys.rb
@@ -261,6 +261,9 @@ class Redis
       # @param [String, Array<String>] keys
       # @return [Integer] number of keys that were unlinked
       def unlink(*keys)
+        keys.flatten!(1)
+        return 0 if keys.empty?
+
         send_command([:unlink] + keys)
       end
 

--- a/test/redis/commands_on_value_types_test.rb
+++ b/test/redis/commands_on_value_types_test.rb
@@ -49,6 +49,10 @@ class TestCommandsOnValueTypes < Minitest::Test
 
     assert_equal ["bar", "baz", "foo"], r.keys("*").sort
 
+    assert_equal 0, r.unlink("")
+
+    assert_equal ["bar", "baz", "foo"], r.keys("*").sort
+
     assert_equal 1, r.unlink("foo")
 
     assert_equal ["bar", "baz"], r.keys("*").sort
@@ -62,14 +66,23 @@ class TestCommandsOnValueTypes < Minitest::Test
     r.set "foo", "s1"
     r.set "bar", "s2"
     r.set "baz", "s3"
+    r.set "bad", "s4"
 
-    assert_equal ["bar", "baz", "foo"], r.keys("*").sort
+    assert_equal ["bad", "bar", "baz", "foo"], r.keys("*").sort
+
+    assert_equal 0, r.unlink([])
+
+    assert_equal ["bad", "bar", "baz", "foo"], r.keys("*").sort
 
     assert_equal 1, r.unlink(["foo"])
 
-    assert_equal ["bar", "baz"], r.keys("*").sort
+    assert_equal ["bad", "bar", "baz"], r.keys("*").sort
 
     assert_equal 2, r.unlink(["bar", "baz"])
+
+    assert_equal ["bad"], r.keys("*").sort
+
+    assert_equal 1, r.unlink([["bad"]])
 
     assert_equal [], r.keys("*").sort
   end


### PR DESCRIPTION
`del` returns zero immideately if no keys were passed, I think it makes sense to do the same for `unlink`?

It simplifies and makes safer migration to unlinking