### PR TITLE
Add security supported versions to testing matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -148,7 +148,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redis: ["7.0", "6.2", "6.0", "5.0"]
+        redis: ["8.2", "8.0", "7.4", "7.2", "7.0", "6.2", "6.0", "5.0"]
     runs-on: ubuntu-latest
     env:
       LOW_TIMEOUT: "0.14"

--- a/test/redis/commands_on_geo_test.rb
+++ b/test/redis/commands_on_geo_test.rb
@@ -59,12 +59,28 @@ class TestCommandsGeo < Minitest::Test
     assert_equal [["Palermo", "166.2742"]], city
   end
 
+  def coordinates_catania
+    if version >= "8.0"
+      ["15.087267458438873", "37.50266842333162"]
+    else
+      ["15.08726745843887329", "37.50266842333162032"]
+    end
+  end
+
+  def coordinates_palermo
+    if version >= "8.0"
+      ["13.361389338970184", "38.1155563954963"]
+    else
+      ["13.36138933897018433", "38.11555639549629859"]
+    end
+  end
+
   def test_geopos
     location = r.geopos("Sicily", "Catania")
-    assert_equal [["15.08726745843887329", "37.50266842333162032"]], location
+    assert_equal [coordinates_catania], location
 
     locations = r.geopos("Sicily", ["Palermo", "Catania"])
-    assert_equal [["13.36138933897018433", "38.11555639549629859"], ["15.08726745843887329", "37.50266842333162032"]], locations
+    assert_equal [coordinates_palermo, coordinates_catania], locations
   end
 
   def test_geopos_nonexistant_location
@@ -72,7 +88,7 @@ class TestCommandsGeo < Minitest::Test
     assert_equal [nil], location
 
     locations = r.geopos("Sicily", ["Rome", "Catania"])
-    assert_equal [nil, ["15.08726745843887329", "37.50266842333162032"]], locations
+    assert_equal [nil, coordinates_catania], locations
   end
 
   def test_geodist

--- a/test/support/conf/redis-7.4.conf
+++ b/test/support/conf/redis-7.4.conf
@@ -1,0 +1,3 @@
+appendonly no
+save ""
+enable-debug-command yes

--- a/test/support/conf/redis-8.0.conf
+++ b/test/support/conf/redis-8.0.conf
@@ -1,0 +1,3 @@
+appendonly no
+save ""
+enable-debug-command yes

--- a/test/support/conf/redis-8.2.conf
+++ b/test/support/conf/redis-8.2.conf
@@ -1,0 +1,3 @@
+appendonly no
+save ""
+enable-debug-command yes


### PR DESCRIPTION
The Github Actions testing matrix currently only runs against versions <=7.0.

As per https://endoflife.date/redis, the security supported versions are 7.2, 7.4 and 8.0.
8.2 also came out yesterday: https://github.com/redis/redis/releases

This leaves versions <=7.0 in the test matrix, even though they are no longer supported upstream.