### PR TITLE
Implement hscan, hscan_each, and hstrlen for Redis::Distributed

### DIFF
--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -918,6 +918,21 @@ class Redis
       node_for(key).hgetall(key)
     end
 
+    # Scan a hash
+    def hscan(key, cursor, **options)
+      node_for(key).hscan(key, cursor, **options)
+    end
+
+    # Scan a hash and return an enumerator
+    def hscan_each(key, **options, &block)
+      node_for(key).hscan_each(key, **options, &block)
+    end
+
+    # Get the length of the value stored in a hash field
+    def hstrlen(key, field)
+      node_for(key).hstrlen(key, field)
+    end
+
     # Post a message to a channel.
     def publish(channel, message)
       node_for(channel).publish(channel, message)

--- a/test/distributed/commands_on_hashes_test.rb
+++ b/test/distributed/commands_on_hashes_test.rb
@@ -6,14 +6,6 @@ class TestDistributedCommandsOnHashes < Minitest::Test
   include Helper::Distributed
   include Lint::Hashes
 
-  def test_hscan
-    # Not implemented yet
-  end
-
-  def test_hstrlen
-    # Not implemented yet
-  end
-
   def test_mapped_hmget_in_a_pipeline_returns_hash
     assert_raises(Redis::Distributed::CannotDistribute) do
       super


### PR DESCRIPTION
These are similar to the existing hash/set methods such as `Redis::Distributed#sscan` and allow the removal of some `# Not implemented yet` test overrides