### PR TITLE
Add novalues option support for HSCAN command

### DIFF
--- a/lib/redis/commands/hashes.rb
+++ b/lib/redis/commands/hashes.rb
@@ -220,13 +220,20 @@ class Redis
       # @param [Hash] options
       #   - `:match => String`: only return keys matching the pattern
       #   - `:count => Integer`: return count keys at most per iteration
+      #   - `:novalues => Boolean`: whether or not to include values in the output (default: false)
       #
-      # @return [String, Array<[String, String]>] the next cursor and all found keys
+      # @return [String, Array<[String, String]>, Array<String>] the next cursor and all found keys
+      #   - when `:novalues` is false: [cursor, [[field1, value1], [field2, value2], ...]]
+      #   - when `:novalues` is true: [cursor, [field1, field2, ...]]
       #
       # See the [Redis Server HSCAN documentation](https://redis.io/docs/latest/commands/hscan/) for further details
       def hscan(key, cursor, **options)
         _scan(:hscan, cursor, [key], **options) do |reply|
-          [reply[0], reply[1].each_slice(2).to_a]
+          if options[:novalues]
+            reply
+          else
+            [reply[0], reply[1].each_slice(2).to_a]
+          end
         end
       end
 
@@ -239,6 +246,7 @@ class Redis
       # @param [Hash] options
       #   - `:match => String`: only return keys matching the pattern
       #   - `:count => Integer`: return count keys at most per iteration
+      #   - `:novalues => Boolean`: whether or not to include values in the output (default: false)
       #
       # @return [Enumerator] an enumerator for all found keys
       #

--- a/lib/redis/commands/keys.rb
+++ b/lib/redis/commands/keys.rb
@@ -447,13 +447,14 @@ class Redis
 
       private
 
-      def _scan(command, cursor, args, match: nil, count: nil, type: nil, &block)
+      def _scan(command, cursor, args, match: nil, count: nil, type: nil, novalues: false, &block)
         # SSCAN/ZSCAN/HSCAN already prepend the key to +args+.
 
         args << cursor
         args << "MATCH" << match if match
         args << "COUNT" << Integer(count) if count
         args << "TYPE" << type if type
+        args << "NOVALUES" if novalues
 
         send_command([command] + args, &block)
       end


### PR DESCRIPTION
Adds support for the `NOVALUES` option in the `HSCAN` command, available in Redis 7.4+.
https://redis.io/docs/latest/commands/hscan/
https://redis.io/docs/latest/commands/scan//#the-novalues-option

When the `:novalues` option is set to `true`, `HSCAN` returns only field names without their values, which can improve
performance when only keys are needed.


```ruby
# Without novalues (default behavior)
cursor, pairs = redis.hscan("myhash", 0)
# => ["0", [["field1", "value1"], ["field2", "value2"]]]

# With novalues option
cursor, fields = redis.hscan("myhash", 0, novalues: true)
# => ["0", ["field1", "field2"]]

# Works with hscan_each as well
redis.hscan_each("myhash", novalues: true) do |field|
  puts field
end
```
