### PR TITLE
Add support to HEXPIRE options

### DIFF
--- a/lib/redis/commands/hashes.rb
+++ b/lib/redis/commands/hashes.rb
@@ -271,11 +271,23 @@ class Redis
       # @param [String] key
       # @param [Integer] ttl
       # @param [Array<String>] fields
+      # @param [Hash] options
+      #   - `:nx => true`: Set expiry only when the key has no expiry.
+      #   - `:xx => true`: Set expiry only when the key has an existing expiry.
+      #   - `:gt => true`: Set expiry only when the new expiry is greater than current one.
+      #   - `:lt => true`: Set expiry only when the new expiry is less than current one.
       # @return [Array<Integer>] Feedback on if the fields have been updated.
       #
       # See https://redis.io/docs/latest/commands/hexpire/#return-information for array reply.
-      def hexpire(key, ttl, *fields)
-        send_command([:hexpire, key, ttl, 'FIELDS', fields.length, *fields])
+      def hexpire(key, ttl, *fields, nx: nil, xx: nil, gt: nil, lt: nil)
+        args = [:hexpire, key, ttl]
+        args << "NX" if nx
+        args << "XX" if xx
+        args << "GT" if gt
+        args << "LT" if lt
+        args.concat(['FIELDS', fields.length, *fields])
+
+        send_command(args)
       end
 
       # Returns the time to live in seconds for one or more fields.

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -918,8 +918,8 @@ class Redis
       node_for(key).hgetall(key)
     end
 
-    def hexpire(key, ttl, *fields)
-      node_for(key).hexpire(key, ttl, *fields)
+    def hexpire(key, ttl, *fields, nx: nil, xx: nil, gt: nil, lt: nil)
+      node_for(key).hexpire(key, ttl, *fields, nx: nx, xx: xx, gt: gt, lt: lt)
     end
 
     def httl(key, *fields)

--- a/test/lint/hashes.rb
+++ b/test/lint/hashes.rb
@@ -237,6 +237,24 @@ module Lint
       end
     end
 
+    def test_hexpire_options
+      target_version "7.4.0" do
+        r.hset("foo", "f1", "v2")
+        assert_equal [0], r.hexpire("foo", 5, "f1", xx: true)
+        assert_equal [-1], r.httl("foo", "f1")
+
+        assert_equal [1], r.hexpire("foo", 5, "f1", nx: true)
+        assert_in_range(1..5, r.httl("foo", "f1")[0])
+        assert_equal [0], r.hexpire("foo", 5, "f1", nx: true)
+
+        assert_equal [1], r.hexpire("foo", 5, "f1", xx: true)
+
+        assert_equal [0], r.hexpire("foo", 10, "f1", lt: true)
+        assert_equal [1], r.hexpire("foo", 10, "f1", gt: true)
+        assert_in_range(1..10, r.httl("foo", "f1")[0])
+      end
+    end
+
     def test_httl
       target_version "7.4.0" do
         assert [-2], r.httl("foo", "f1")


### PR DESCRIPTION
Towards: https://github.com/redis/redis-rb/issues/1187 

The current HEXPIRE implementation do not support options parameters. Creating the same support as I did [here](https://github.com/redis/redis-rb/pull/1331) for HPEXPIRE  

More details about option here:
https://redis.io/docs/latest/commands/hexpire/#options