### PR TITLE
Add instrumentation and observability hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,74 @@ redis = Redis.new(
 
 [OpenSSL::SSL::SSLContext documentation]: http://ruby-doc.org/stdlib-2.5.0/libdoc/openssl/rdoc/OpenSSL/SSL/SSLContext.html
 
+## Instrumentation & Observability
+
+redis-rb includes an optional hook-based instrumentation system with zero overhead when
+not in use. Register `before`, `after`, or `around` hooks to observe command execution:
+
+```ruby
+# Log every command with its latency
+Redis::Instrumentation.after_command do |event|
+  puts "#{event.command_name.upcase} #{event.duration * 1000}ms"
+end
+
+# Wrap commands for tracing
+Redis::Instrumentation.around_command do |event, call|
+  span = Tracer.start_span("redis.#{event.command_name}")
+  call.call
+ensure
+  span.finish
+end
+```
+
+A built-in logger hook is included:
+
+```ruby
+Redis::Instrumentation::Hooks::Logger.new(
+  logger: Rails.logger,
+  level: :debug,
+  log_args: true,                                   # include filtered arguments
+  filter: ->(cmd) { !%w[ping select].include?(cmd) } # skip noisy commands
+).install!
+```
+
+### Disconnect Observability
+
+Register a hook to be notified when a client disconnects:
+
+```ruby
+Redis::Instrumentation.after_disconnect do |redis_id|
+  puts "Disconnected from #{redis_id}"
+end
+```
+
+The hook fires after `close` / `disconnect!` is called.
+
+Call `Redis::Instrumentation.clear!` to remove all hooks.
+
+### PII Filtering
+
+The `Event` object exposes both raw `args` and `filtered_args`. Sensitive data is
+automatically redacted in `filtered_args`:
+
+- `AUTH` arguments are always replaced with `[FILTERED]`
+- `CONFIG SET requirepass/masterauth/masteruser` values are filtered
+- Custom patterns match against all argument strings
+
+```ruby
+# Explicit patterns
+Redis::Instrumentation.parameter_filter =
+  Redis::Instrumentation::ParameterFilter.new(patterns: [:password, :email, /credit.?card/i])
+
+Redis::Instrumentation.after_command do |event|
+  # Safe for logs — PII is redacted
+  logger.info "#{event.command_name} #{event.filtered_args.join(' ')}"
+end
+```
+
+**Rails integration**: When no explicit patterns are provided, the filter automatically
+reads `Rails.application.config.filter_parameters`. No configuration required in a Rails app.
+
 ## Expert-Mode Options
 
  - `inherit_socket: true`: disable safety check that prevents a forked child

--- a/README.md
+++ b/README.md
@@ -405,6 +405,27 @@ Redis::Instrumentation::Hooks::Logger.new(
 ).install!
 ```
 
+Example log output (`log_args: false`):
+
+```
+D, [2026-02-23T10:15:32.004] DEBUG -- : Redis SET 0.38ms (id: redis://127.0.0.1:6379/0)
+D, [2026-02-23T10:15:32.009] DEBUG -- : Redis GET 0.22ms (id: redis://127.0.0.1:6379/0)
+D, [2026-02-23T10:15:32.015] DEBUG -- : Redis LPUSH 0.41ms (id: redis://127.0.0.1:6379/0)
+```
+
+With `log_args: true`:
+
+```
+D, [2026-02-23T10:15:32.004] DEBUG -- : Redis SET mykey myvalue 0.38ms (id: redis://127.0.0.1:6379/0)
+D, [2026-02-23T10:15:32.009] DEBUG -- : Redis GET mykey 0.22ms (id: redis://127.0.0.1:6379/0)
+```
+
+On error:
+
+```
+D, [2026-02-23T10:15:32.020] DEBUG -- : Redis SET mykey myvalue 1.05ms ERROR Redis::TimeoutError (id: redis://127.0.0.1:6379/0)
+```
+
 ### Disconnect Observability
 
 Register a hook to be notified when a client disconnects:

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -5,6 +5,7 @@ require "redis-client"
 require "monitor"
 require "redis/errors"
 require "redis/commands"
+require "redis/logging"
 
 class Redis
   BASE_PATH = __dir__
@@ -90,6 +91,7 @@ class Redis
   def close
     @client.close
     @subscription_client&.close
+    Instrumentation.notify_disconnect(id) if Instrumentation.enabled?
   end
   alias disconnect! close
 
@@ -150,16 +152,24 @@ class Redis
   end
 
   def send_command(command, &block)
-    @monitor.synchronize do
-      @client.call_v(command, &block)
+    if Instrumentation.enabled?
+      Instrumentation.instrument(command, id) do
+        @monitor.synchronize { @client.call_v(command, &block) }
+      end
+    else
+      @monitor.synchronize { @client.call_v(command, &block) }
     end
   rescue ::RedisClient::Error => error
     Client.translate_error!(error)
   end
 
   def send_blocking_command(command, timeout, &block)
-    @monitor.synchronize do
-      @client.blocking_call_v(timeout, command, &block)
+    if Instrumentation.enabled?
+      Instrumentation.instrument(command, id) do
+        @monitor.synchronize { @client.blocking_call_v(timeout, command, &block) }
+      end
+    else
+      @monitor.synchronize { @client.blocking_call_v(timeout, command, &block) }
     end
   end
 

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -5,7 +5,6 @@ require "redis-client"
 require "monitor"
 require "redis/errors"
 require "redis/commands"
-require "redis/logging"
 
 class Redis
   BASE_PATH = __dir__
@@ -89,9 +88,10 @@ class Redis
 
   # Disconnect the client as quickly and silently as possible.
   def close
+    redis_id = id
     @client.close
     @subscription_client&.close
-    Instrumentation.notify_disconnect(id) if Instrumentation.enabled?
+    Instrumentation.notify_disconnect(redis_id) if Instrumentation.enabled?
   end
   alias disconnect! close
 
@@ -152,11 +152,7 @@ class Redis
   end
 
   def send_command(command, &block)
-    if Instrumentation.enabled?
-      Instrumentation.instrument(command, id) do
-        @monitor.synchronize { @client.call_v(command, &block) }
-      end
-    else
+    maybe_instrument(command) do
       @monitor.synchronize { @client.call_v(command, &block) }
     end
   rescue ::RedisClient::Error => error
@@ -164,12 +160,16 @@ class Redis
   end
 
   def send_blocking_command(command, timeout, &block)
-    if Instrumentation.enabled?
-      Instrumentation.instrument(command, id) do
-        @monitor.synchronize { @client.blocking_call_v(timeout, command, &block) }
-      end
-    else
+    maybe_instrument(command) do
       @monitor.synchronize { @client.blocking_call_v(timeout, command, &block) }
+    end
+  end
+
+  def maybe_instrument(command)
+    if Instrumentation.enabled?
+      Instrumentation.instrument(command, id) { yield }
+    else
+      yield
     end
   end
 
@@ -204,3 +204,4 @@ require "redis/version"
 require "redis/client"
 require "redis/pipeline"
 require "redis/subscribe"
+require "redis/instrumentation"

--- a/lib/redis/instrumentation.rb
+++ b/lib/redis/instrumentation.rb
@@ -66,7 +66,7 @@ class Redis
         else
           []
         end
-      rescue
+      rescue StandardError
         []
       end
 
@@ -126,8 +126,12 @@ class Redis
       # Returns args with sensitive data replaced by [FILTERED].
       # Uses the global parameter_filter configured on Instrumentation.
       def filtered_args
-        Instrumentation.parameter_filter.filter_args(@command_name, @args)
+        @filtered_args ||= Instrumentation.parameter_filter.filter_args(@command_name, @args)
       end
+
+      private
+
+      attr_writer :start_time
     end
 
     @mutex = Mutex.new
@@ -157,6 +161,7 @@ class Redis
           @before_hooks << block
           @enabled = true
         end
+        block
       end
 
       def after_command(&block)
@@ -164,6 +169,7 @@ class Redis
           @after_hooks << block
           @enabled = true
         end
+        block
       end
 
       def around_command(&block)
@@ -171,6 +177,7 @@ class Redis
           @around_hooks << block
           @enabled = true
         end
+        block
       end
 
       def after_disconnect(&block)
@@ -178,11 +185,26 @@ class Redis
           @disconnect_hooks << block
           @enabled = true
         end
+        block
+      end
+
+      def remove_hook(hook)
+        @mutex.synchronize do
+          @before_hooks.delete(hook)
+          @after_hooks.delete(hook)
+          @around_hooks.delete(hook)
+          @disconnect_hooks.delete(hook)
+          @enabled = [@before_hooks, @after_hooks, @around_hooks, @disconnect_hooks].any? { |h| !h.empty? }
+        end
       end
 
       def notify_disconnect(redis_id)
         hooks = @mutex.synchronize { @disconnect_hooks.dup }
-        hooks.each { |hook| hook.call(redis_id) }
+        hooks.each do |hook|
+          hook.call(redis_id)
+        rescue StandardError
+          nil
+        end
       end
 
       def clear!
@@ -202,10 +224,14 @@ class Redis
 
         event = Event.new(command, redis_id)
 
-        before.each { |hook| hook.call(event) }
+        before.each do |hook|
+          hook.call(event)
+        rescue StandardError
+          nil
+        end
 
         execute = -> {
-          event.instance_variable_set(:@start_time, Process.clock_gettime(Process::CLOCK_MONOTONIC))
+          event.send(:start_time=, Process.clock_gettime(Process::CLOCK_MONOTONIC))
           begin
             event.result = yield
           rescue => e
@@ -224,20 +250,28 @@ class Redis
         begin
           chain.call
         ensure
-          after.each { |hook| hook.call(event) }
+          after.each do |hook|
+            hook.call(event)
+          rescue StandardError
+            nil
+          end
         end
       end
     end
 
     module Hooks
       class Logger
+        VALID_LEVELS = %i[debug info warn error fatal].freeze
+
         attr_reader :logger, :level, :filter
 
         # @param logger [::Logger] any Logger-compatible object
-        # @param level [:debug, :info, :warn, :error] log level for successful commands
+        # @param level [:debug, :info, :warn, :error, :fatal] log level for successful commands
         # @param filter [Proc, nil] optional proc receiving command_name string, return true to log
         # @param log_args [Boolean] whether to include filtered arguments in log output
         def initialize(logger:, level: :debug, filter: nil, log_args: false)
+          raise ArgumentError, "Invalid level: #{level}" unless VALID_LEVELS.include?(level)
+
           @logger = logger
           @level = level
           @filter = filter
@@ -280,7 +314,7 @@ class Redis
             )
           end
 
-          @logger.send(@level, message)
+          @logger.public_send(@level, message)
         end
       end
     end

--- a/lib/redis/logging.rb
+++ b/lib/redis/logging.rb
@@ -1,0 +1,288 @@
+# frozen_string_literal: true
+
+class Redis
+  module Instrumentation
+    class ParameterFilter
+      FILTERED = "[FILTERED]"
+
+      # Commands where all arguments are always sensitive
+      SENSITIVE_COMMANDS = %w[auth].freeze
+
+      # Config keys whose values must be filtered on CONFIG SET
+      SENSITIVE_CONFIG_KEYS = %w[requirepass masterauth masteruser].freeze
+
+      # @param patterns [Array<String, Symbol, Regexp>] additional filter patterns.
+      #   When nil, auto-loads Rails filter_parameters if available.
+      def initialize(patterns: nil)
+        @custom_patterns = patterns
+        @compiled = nil
+      end
+
+      # Returns a filtered copy of args with sensitive data replaced.
+      # @param command_name [String] downcased command name
+      # @param args [Array] raw command arguments
+      # @return [Array] filtered arguments
+      def filter_args(command_name, args)
+        return args if args.empty?
+
+        if SENSITIVE_COMMANDS.include?(command_name)
+          return args.map { FILTERED }
+        end
+
+        if command_name == "config"
+          filtered = filter_config_args(args)
+          return filtered if filtered
+        end
+
+        filter_with_patterns(args)
+      end
+
+      # Resets compiled patterns so Rails filter_parameters are re-read.
+      def reset!
+        @compiled = nil
+      end
+
+      private
+
+      def compiled_patterns
+        @compiled ||= compile_patterns(all_patterns)
+      end
+
+      def all_patterns
+        if @custom_patterns
+          Array(@custom_patterns)
+        else
+          rails_filter_parameters
+        end
+      end
+
+      def rails_filter_parameters
+        if defined?(::Rails) &&
+            ::Rails.respond_to?(:application) &&
+            ::Rails.application &&
+            ::Rails.application.respond_to?(:config) &&
+            ::Rails.application.config.respond_to?(:filter_parameters)
+          Array(::Rails.application.config.filter_parameters)
+        else
+          []
+        end
+      rescue
+        []
+      end
+
+      def compile_patterns(patterns)
+        patterns.filter_map do |pattern|
+          case pattern
+          when Regexp then pattern
+          when Symbol, String
+            /#{Regexp.escape(pattern.to_s)}/i
+          end
+        end
+      end
+
+      def filter_config_args(args)
+        sub = args[0].to_s.downcase
+        return nil unless sub == "set" && args.length >= 3
+
+        key = args[1].to_s.downcase
+        if SENSITIVE_CONFIG_KEYS.include?(key)
+          [args[0], args[1]] + args[2..].map { FILTERED }
+        end
+      end
+
+      def filter_with_patterns(args)
+        return args if compiled_patterns.empty?
+
+        args.map do |arg|
+          str = arg.to_s
+          if compiled_patterns.any? { |p| p.match?(str) }
+            FILTERED
+          else
+            arg
+          end
+        end
+      end
+    end
+
+    class Event
+      attr_reader :command_name, :command, :args, :redis_id, :start_time
+      attr_accessor :result, :error, :duration
+
+      def initialize(command, redis_id)
+        @command = command.frozen? ? command : command.dup.freeze
+        @command_name = command[0].to_s.downcase.freeze
+        @args = command[1..].freeze
+        @redis_id = redis_id
+        @start_time = nil
+        @result = nil
+        @error = nil
+        @duration = nil
+      end
+
+      def error?
+        !@error.nil?
+      end
+
+      # Returns args with sensitive data replaced by [FILTERED].
+      # Uses the global parameter_filter configured on Instrumentation.
+      def filtered_args
+        Instrumentation.parameter_filter.filter_args(@command_name, @args)
+      end
+    end
+
+    @mutex = Mutex.new
+    @before_hooks = []
+    @after_hooks = []
+    @around_hooks = []
+    @disconnect_hooks = []
+    @enabled = false
+    @parameter_filter = ParameterFilter.new
+
+    class << self
+      # The active parameter filter. Configurable via Instrumentation.parameter_filter=
+      attr_reader :parameter_filter
+
+      def enabled?
+        @enabled
+      end
+
+      # Replace the parameter filter.
+      # @param filter [ParameterFilter] a configured filter instance
+      def parameter_filter=(filter)
+        @parameter_filter = filter
+      end
+
+      def before_command(&block)
+        @mutex.synchronize do
+          @before_hooks << block
+          @enabled = true
+        end
+      end
+
+      def after_command(&block)
+        @mutex.synchronize do
+          @after_hooks << block
+          @enabled = true
+        end
+      end
+
+      def around_command(&block)
+        @mutex.synchronize do
+          @around_hooks << block
+          @enabled = true
+        end
+      end
+
+      def after_disconnect(&block)
+        @mutex.synchronize do
+          @disconnect_hooks << block
+          @enabled = true
+        end
+      end
+
+      def notify_disconnect(redis_id)
+        hooks = @mutex.synchronize { @disconnect_hooks.dup }
+        hooks.each { |hook| hook.call(redis_id) }
+      end
+
+      def clear!
+        @mutex.synchronize do
+          @before_hooks.clear
+          @after_hooks.clear
+          @around_hooks.clear
+          @disconnect_hooks.clear
+          @enabled = false
+        end
+      end
+
+      def instrument(command, redis_id)
+        before, after, around = @mutex.synchronize do
+          [@before_hooks.dup, @after_hooks.dup, @around_hooks.dup]
+        end
+
+        event = Event.new(command, redis_id)
+
+        before.each { |hook| hook.call(event) }
+
+        execute = -> {
+          event.instance_variable_set(:@start_time, Process.clock_gettime(Process::CLOCK_MONOTONIC))
+          begin
+            event.result = yield
+          rescue => e
+            event.error = e
+            raise
+          ensure
+            event.duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - event.start_time
+          end
+          event.result
+        }
+
+        chain = around.reverse_each.reduce(execute) do |inner, hook|
+          -> { hook.call(event, inner) }
+        end
+
+        begin
+          chain.call
+        ensure
+          after.each { |hook| hook.call(event) }
+        end
+      end
+    end
+
+    module Hooks
+      class Logger
+        attr_reader :logger, :level, :filter
+
+        # @param logger [::Logger] any Logger-compatible object
+        # @param level [:debug, :info, :warn, :error] log level for successful commands
+        # @param filter [Proc, nil] optional proc receiving command_name string, return true to log
+        # @param log_args [Boolean] whether to include filtered arguments in log output
+        def initialize(logger:, level: :debug, filter: nil, log_args: false)
+          @logger = logger
+          @level = level
+          @filter = filter
+          @log_args = log_args
+        end
+
+        def to_after_hook
+          proc { |event| log_event(event) }
+        end
+
+        def install!
+          hook = to_after_hook
+          Redis::Instrumentation.after_command(&hook)
+          hook
+        end
+
+        private
+
+        def log_event(event)
+          return if @filter && !@filter.call(event.command_name)
+
+          args_str = @log_args ? " #{event.filtered_args.join(' ')}" : ""
+
+          message = if event.error?
+            format(
+              "Redis %s%s %.2fms ERROR %s (id: %s)",
+              event.command_name.upcase,
+              args_str,
+              event.duration * 1000,
+              event.error.class,
+              event.redis_id
+            )
+          else
+            format(
+              "Redis %s%s %.2fms (id: %s)",
+              event.command_name.upcase,
+              args_str,
+              event.duration * 1000,
+              event.redis_id
+            )
+          end
+
+          @logger.send(@level, message)
+        end
+      end
+    end
+  end
+end

--- a/test/redis/instrumentation_test.rb
+++ b/test/redis/instrumentation_test.rb
@@ -198,6 +198,12 @@ class TestInstrumentation < Minitest::Test
     assert_match(/GET/, output)
   end
 
+  def test_logger_hook_rejects_invalid_level
+    assert_raises(ArgumentError) do
+      Redis::Instrumentation::Hooks::Logger.new(logger: ::Logger.new(StringIO.new), level: :bogus)
+    end
+  end
+
   def test_thread_safe_registration
     threads = 10.times.map do
       Thread.new do
@@ -233,6 +239,110 @@ class TestInstrumentation < Minitest::Test
 
     pipeline_events = events.select { |e| %w[set get].include?(e.command_name) }
     assert_equal 0, pipeline_events.size
+  end
+
+  # --- Hook error resilience tests ---
+
+  def test_before_hook_error_does_not_break_command
+    Redis::Instrumentation.before_command { |_| raise "boom" }
+
+    result = r.set("foo", "bar")
+    assert_equal "OK", result
+  end
+
+  def test_after_hook_error_does_not_break_command
+    Redis::Instrumentation.after_command { |_| raise "boom" }
+
+    result = r.set("foo", "bar")
+    assert_equal "OK", result
+  end
+
+  def test_disconnect_hook_error_does_not_break_close
+    Redis::Instrumentation.after_disconnect { |_| raise "boom" }
+
+    r.ping
+    r.close # should not raise
+  end
+
+  def test_broken_hook_does_not_prevent_other_hooks
+    results = []
+    Redis::Instrumentation.before_command { |_| raise "first hook fails" }
+    Redis::Instrumentation.before_command { |_| results << :second_ran }
+
+    r.ping
+
+    assert_equal [:second_ran], results
+  end
+
+  # --- remove_hook tests ---
+
+  def test_remove_hook_removes_before_hook
+    hook = Redis::Instrumentation.before_command { |_| }
+    assert Redis::Instrumentation.enabled?
+
+    Redis::Instrumentation.remove_hook(hook)
+    refute Redis::Instrumentation.enabled?
+  end
+
+  def test_remove_hook_removes_after_hook
+    hook = Redis::Instrumentation.after_command { |_| }
+    Redis::Instrumentation.remove_hook(hook)
+    refute Redis::Instrumentation.enabled?
+  end
+
+  def test_remove_hook_removes_around_hook
+    hook = Redis::Instrumentation.around_command { |_, call| call.call }
+    Redis::Instrumentation.remove_hook(hook)
+    refute Redis::Instrumentation.enabled?
+  end
+
+  def test_remove_hook_removes_disconnect_hook
+    hook = Redis::Instrumentation.after_disconnect { |_| }
+    Redis::Instrumentation.remove_hook(hook)
+    refute Redis::Instrumentation.enabled?
+  end
+
+  def test_remove_hook_keeps_other_hooks_enabled
+    hook1 = Redis::Instrumentation.before_command { |_| }
+    hook2 = Redis::Instrumentation.before_command { |_| }
+
+    Redis::Instrumentation.remove_hook(hook1)
+    assert Redis::Instrumentation.enabled?
+
+    Redis::Instrumentation.remove_hook(hook2)
+    refute Redis::Instrumentation.enabled?
+  end
+
+  def test_remove_hook_prevents_hook_from_firing
+    called = false
+    hook = Redis::Instrumentation.after_command { |_| called = true }
+    Redis::Instrumentation.remove_hook(hook)
+
+    # Need another hook to keep instrumentation enabled
+    Redis::Instrumentation.after_command { |_| }
+    r.ping
+
+    refute called
+  end
+
+  # --- around_command edge case ---
+
+  def test_around_hook_not_calling_inner_prevents_execution
+    Redis::Instrumentation.around_command do |_event, _call|
+      # intentionally not calling _call.call
+    end
+
+    # The command won't actually execute through to Redis
+    # but the hook chain completes without error
+    events = []
+    Redis::Instrumentation.after_command { |event| events << event }
+
+    r.set("foo", "bar")
+
+    # after hook still fires
+    assert_equal 1, events.size
+    # result is nil since inner was never called
+    assert_nil events.first.result
   end
 
   # --- ParameterFilter tests ---
@@ -323,6 +433,15 @@ class TestInstrumentation < Minitest::Test
     assert_equal ["[FILTERED]"], event.filtered_args
   end
 
+  def test_event_filtered_args_is_memoized
+    cmd = [:set, "key", "value"]
+    event = Redis::Instrumentation::Event.new(cmd, "test-id")
+
+    first_call = event.filtered_args
+    second_call = event.filtered_args
+    assert_same first_call, second_call
+  end
+
   def test_logger_hook_with_log_args_filters_sensitive
     saved_filter = Redis::Instrumentation.parameter_filter
     Redis::Instrumentation.parameter_filter = Redis::Instrumentation::ParameterFilter.new(patterns: [:token])
@@ -404,5 +523,25 @@ class TestInstrumentation < Minitest::Test
     r.close
 
     assert_equal [1, 1], counts
+  end
+
+  # --- registration return value tests ---
+
+  def test_before_command_returns_hook
+    block = proc { |_| }
+    result = Redis::Instrumentation.before_command(&block)
+    assert_same block, result
+  end
+
+  def test_after_command_returns_hook
+    block = proc { |_| }
+    result = Redis::Instrumentation.after_command(&block)
+    assert_same block, result
+  end
+
+  def test_around_command_returns_hook
+    block = proc { |_, call| call.call }
+    result = Redis::Instrumentation.around_command(&block)
+    assert_same block, result
   end
 end

--- a/test/redis/instrumentation_test.rb
+++ b/test/redis/instrumentation_test.rb
@@ -1,0 +1,408 @@
+# frozen_string_literal: true
+
+require "helper"
+require "logger"
+require "stringio"
+
+class TestInstrumentation < Minitest::Test
+  include Helper::Client
+
+  def teardown
+    Redis::Instrumentation.clear!
+    super
+  end
+
+  def test_enabled_is_false_by_default
+    assert_equal false, Redis::Instrumentation.enabled?
+  end
+
+  def test_registering_before_hook_enables
+    Redis::Instrumentation.before_command { |_| }
+    assert_equal true, Redis::Instrumentation.enabled?
+  end
+
+  def test_registering_after_hook_enables
+    Redis::Instrumentation.after_command { |_| }
+    assert_equal true, Redis::Instrumentation.enabled?
+  end
+
+  def test_registering_around_hook_enables
+    Redis::Instrumentation.around_command { |_, call| call.call }
+    assert_equal true, Redis::Instrumentation.enabled?
+  end
+
+  def test_clear_disables
+    Redis::Instrumentation.before_command { |_| }
+    Redis::Instrumentation.clear!
+    assert_equal false, Redis::Instrumentation.enabled?
+  end
+
+  def test_before_hook_receives_event
+    events = []
+    Redis::Instrumentation.before_command { |event| events << event }
+
+    r.set("foo", "bar")
+
+    assert_equal 1, events.size
+    event = events.first
+    assert_equal "set", event.command_name
+    assert_equal ["foo", "bar"], event.args
+  end
+
+  def test_after_hook_receives_result_and_duration
+    events = []
+    Redis::Instrumentation.after_command { |event| events << event }
+
+    r.set("foo", "bar")
+
+    assert_equal 1, events.size
+    event = events.first
+    assert_equal "set", event.command_name
+    assert_equal "OK", event.result
+    assert_kind_of Float, event.duration
+    assert_operator event.duration, :>, 0
+    refute event.error?
+  end
+
+  def test_after_hook_fires_on_error
+    events = []
+    Redis::Instrumentation.after_command { |event| events << event }
+
+    assert_raises(Redis::CommandError) do
+      r.call("INVALID_COMMAND_XXXXX")
+    end
+
+    assert_equal 1, events.size
+    event = events.first
+    assert event.error?
+    assert_kind_of Exception, event.error
+    assert_kind_of Float, event.duration
+  end
+
+  def test_around_hook_wraps_execution
+    order = []
+    Redis::Instrumentation.around_command do |_event, call|
+      order << :before
+      call.call
+      order << :after
+    end
+
+    r.set("foo", "bar")
+
+    assert_equal [:before, :after], order
+  end
+
+  def test_around_hooks_compose_in_registration_order
+    order = []
+
+    Redis::Instrumentation.around_command do |_event, call|
+      order << :a_before
+      call.call
+      order << :a_after
+    end
+
+    Redis::Instrumentation.around_command do |_event, call|
+      order << :b_before
+      call.call
+      order << :b_after
+    end
+
+    r.set("foo", "bar")
+
+    assert_equal [:a_before, :b_before, :b_after, :a_after], order
+  end
+
+  def test_full_hook_ordering
+    order = []
+
+    Redis::Instrumentation.before_command { |_| order << :before }
+    Redis::Instrumentation.around_command do |_, call|
+      order << :around_pre
+      call.call
+      order << :around_post
+    end
+    Redis::Instrumentation.after_command { |_| order << :after }
+
+    r.set("foo", "bar")
+
+    assert_equal [:before, :around_pre, :around_post, :after], order
+  end
+
+  def test_event_redis_id
+    events = []
+    Redis::Instrumentation.after_command { |event| events << event }
+
+    r.ping
+
+    assert_equal r.id, events.first.redis_id
+  end
+
+  def test_command_is_frozen
+    events = []
+    Redis::Instrumentation.before_command { |event| events << event }
+
+    r.set("foo", "bar")
+
+    assert events.first.command.frozen?
+  end
+
+  def test_blocking_command_instrumented
+    events = []
+    Redis::Instrumentation.after_command { |event| events << event }
+
+    r.lpush("list", "value")
+    r.blpop("list", timeout: 1)
+
+    blpop_event = events.find { |e| e.command_name == "blpop" }
+    refute_nil blpop_event
+    assert_kind_of Float, blpop_event.duration
+  end
+
+  def test_no_overhead_when_disabled
+    Redis::Instrumentation.clear!
+    assert_equal false, Redis::Instrumentation.enabled?
+
+    r.set("foo", "bar")
+    assert_equal "bar", r.get("foo")
+  end
+
+  def test_logger_hook
+    io = StringIO.new
+    logger = ::Logger.new(io)
+
+    hook = Redis::Instrumentation::Hooks::Logger.new(logger: logger)
+    hook.install!
+
+    r.set("foo", "bar")
+
+    output = io.string
+    assert_match(/Redis SET/, output)
+    assert_match(/ms/, output)
+  end
+
+  def test_logger_hook_with_filter
+    io = StringIO.new
+    logger = ::Logger.new(io)
+
+    hook = Redis::Instrumentation::Hooks::Logger.new(
+      logger: logger,
+      filter: ->(cmd) { cmd == "get" }
+    )
+    hook.install!
+
+    r.set("foo", "bar")
+    r.get("foo")
+
+    output = io.string
+    refute_match(/SET/, output)
+    assert_match(/GET/, output)
+  end
+
+  def test_thread_safe_registration
+    threads = 10.times.map do
+      Thread.new do
+        50.times do
+          Redis::Instrumentation.before_command { |_| }
+        end
+      end
+    end
+
+    threads.each(&:join)
+
+    assert Redis::Instrumentation.enabled?
+  end
+
+  def test_multiple_before_hooks_all_fire
+    counts = [0, 0]
+    Redis::Instrumentation.before_command { |_| counts[0] += 1 }
+    Redis::Instrumentation.before_command { |_| counts[1] += 1 }
+
+    r.ping
+
+    assert_equal [1, 1], counts
+  end
+
+  def test_pipeline_commands_not_instrumented
+    events = []
+    Redis::Instrumentation.after_command { |event| events << event }
+
+    r.pipelined do |p|
+      p.set("foo", "bar")
+      p.get("foo")
+    end
+
+    pipeline_events = events.select { |e| %w[set get].include?(e.command_name) }
+    assert_equal 0, pipeline_events.size
+  end
+
+  # --- ParameterFilter tests ---
+
+  def test_filter_auth_command_args
+    filter = Redis::Instrumentation::ParameterFilter.new
+    filtered = filter.filter_args("auth", ["mysecretpassword"])
+    assert_equal ["[FILTERED]"], filtered
+  end
+
+  def test_filter_auth_with_username
+    filter = Redis::Instrumentation::ParameterFilter.new
+    filtered = filter.filter_args("auth", ["default", "mysecretpassword"])
+    assert_equal ["[FILTERED]", "[FILTERED]"], filtered
+  end
+
+  def test_filter_config_set_requirepass
+    filter = Redis::Instrumentation::ParameterFilter.new
+    filtered = filter.filter_args("config", ["SET", "requirepass", "newsecret"])
+    assert_equal ["SET", "requirepass", "[FILTERED]"], filtered
+  end
+
+  def test_filter_config_set_masterauth
+    filter = Redis::Instrumentation::ParameterFilter.new
+    filtered = filter.filter_args("config", ["SET", "masterauth", "newsecret"])
+    assert_equal ["SET", "masterauth", "[FILTERED]"], filtered
+  end
+
+  def test_filter_config_get_not_filtered
+    filter = Redis::Instrumentation::ParameterFilter.new
+    filtered = filter.filter_args("config", ["GET", "maxmemory"])
+    assert_equal ["GET", "maxmemory"], filtered
+  end
+
+  def test_filter_non_sensitive_command_passthrough
+    filter = Redis::Instrumentation::ParameterFilter.new
+    filtered = filter.filter_args("set", ["mykey", "myvalue"])
+    assert_equal ["mykey", "myvalue"], filtered
+  end
+
+  def test_filter_custom_patterns_string
+    filter = Redis::Instrumentation::ParameterFilter.new(patterns: [:password, :email])
+    filtered = filter.filter_args("set", ["user:password:123", "secret"])
+    assert_equal ["[FILTERED]", "secret"], filtered
+  end
+
+  def test_filter_custom_patterns_regexp
+    filter = Redis::Instrumentation::ParameterFilter.new(patterns: [/credit.?card/i])
+    filtered = filter.filter_args("set", ["user:credit_card", "4111111111111111"])
+    assert_equal ["[FILTERED]", "4111111111111111"], filtered
+  end
+
+  def test_filter_custom_patterns_case_insensitive
+    filter = Redis::Instrumentation::ParameterFilter.new(patterns: [:ssn])
+    filtered = filter.filter_args("hset", ["user:1", "SSN", "123-45-6789"])
+    assert_equal ["user:1", "[FILTERED]", "123-45-6789"], filtered
+  end
+
+  def test_filter_empty_args
+    filter = Redis::Instrumentation::ParameterFilter.new
+    filtered = filter.filter_args("ping", [])
+    assert_equal [], filtered
+  end
+
+  def test_event_filtered_args_uses_global_filter
+    saved_filter = Redis::Instrumentation.parameter_filter
+    Redis::Instrumentation.parameter_filter = Redis::Instrumentation::ParameterFilter.new(patterns: [:secret])
+
+    events = []
+    Redis::Instrumentation.after_command { |event| events << event }
+
+    r.set("my_secret_key", "value")
+
+    event = events.first
+    assert_equal ["my_secret_key", "value"], event.args
+    assert_equal ["[FILTERED]", "value"], event.filtered_args
+  ensure
+    Redis::Instrumentation.parameter_filter = saved_filter
+  end
+
+  def test_event_filtered_args_auth_always_filtered
+    events = []
+    Redis::Instrumentation.before_command { |event| events << event }
+
+    # Simulate an AUTH event by testing the filter directly on an Event
+    cmd = [:auth, "mypassword"]
+    event = Redis::Instrumentation::Event.new(cmd, "test-id")
+    assert_equal ["[FILTERED]"], event.filtered_args
+  end
+
+  def test_logger_hook_with_log_args_filters_sensitive
+    saved_filter = Redis::Instrumentation.parameter_filter
+    Redis::Instrumentation.parameter_filter = Redis::Instrumentation::ParameterFilter.new(patterns: [:token])
+
+    io = StringIO.new
+    logger = ::Logger.new(io)
+
+    hook = Redis::Instrumentation::Hooks::Logger.new(logger: logger, log_args: true)
+    hook.install!
+
+    r.set("api_token_cache", "secret_token_value")
+
+    output = io.string
+    # Both args contain "token", so both are filtered
+    assert_match(/\[FILTERED\] \[FILTERED\]/, output)
+    refute_match(/secret_token_value/, output)
+  ensure
+    Redis::Instrumentation.parameter_filter = saved_filter
+  end
+
+  def test_logger_hook_log_args_shows_non_sensitive
+    io = StringIO.new
+    logger = ::Logger.new(io)
+
+    hook = Redis::Instrumentation::Hooks::Logger.new(logger: logger, log_args: true)
+    hook.install!
+
+    r.set("counter", "42")
+
+    output = io.string
+    assert_match(/SET counter 42/, output)
+  end
+
+  def test_parameter_filter_reset
+    filter = Redis::Instrumentation::ParameterFilter.new(patterns: [:password])
+    # First call compiles patterns
+    filter.filter_args("set", ["password", "secret"])
+    # Reset clears compiled cache
+    filter.reset!
+    # Still works after reset
+    filtered = filter.filter_args("set", ["password", "secret"])
+    assert_equal ["[FILTERED]", "secret"], filtered
+  end
+
+  # --- after_disconnect tests ---
+
+  def test_after_disconnect_hook_fires_on_close
+    ids = []
+    Redis::Instrumentation.after_disconnect { |redis_id| ids << redis_id }
+
+    redis_id = r.id
+    r.close
+
+    assert_equal [redis_id], ids
+  end
+
+  def test_after_disconnect_enables_instrumentation
+    Redis::Instrumentation.clear!
+    refute Redis::Instrumentation.enabled?
+
+    Redis::Instrumentation.after_disconnect { |_| }
+    assert Redis::Instrumentation.enabled?
+  end
+
+  def test_clear_removes_disconnect_hooks
+    called = false
+    Redis::Instrumentation.after_disconnect { |_| called = true }
+    Redis::Instrumentation.clear!
+
+    r.close
+    refute called
+  end
+
+  def test_multiple_disconnect_hooks_all_fire
+    counts = [0, 0]
+    Redis::Instrumentation.after_disconnect { |_| counts[0] += 1 }
+    Redis::Instrumentation.after_disconnect { |_| counts[1] += 1 }
+
+    r.close
+
+    assert_equal [1, 1], counts
+  end
+end


### PR DESCRIPTION
## Summary

- Add a hook-based instrumentation system (`Redis::Instrumentation`) with **zero overhead when disabled** — hooks are behind an `enabled?` guard so unhooking code pays nothing
- Support `before_command`, `after_command`, and `around_command` hooks that receive an `Event` with command name, args, result, error, duration, and connection id
- Add `after_disconnect` hook for disconnect observability (fires on `close`/`disconnect!`)
- Add `ParameterFilter` with automatic PII redaction:
  - `AUTH` args are always filtered
  - `CONFIG SET requirepass/masterauth/masteruser` values are filtered
  - Custom patterns (string, symbol, regexp) for application-specific filtering
  - Auto-reads `Rails.application.config.filter_parameters` when no explicit patterns are set
- Include a built-in `Hooks::Logger` with configurable level, command filter, and optional filtered-arg logging
- Instrument both `send_command` and `send_blocking_command` paths

## Files changed

| File | Description |
|------|-------------|
| `lib/redis/logging.rb` | New — `Instrumentation` module with `ParameterFilter`, `Event`, hook registry, and `Hooks::Logger` |
| `lib/redis.rb` | Require `redis/logging`; wrap `send_command`/`send_blocking_command` with instrumentation; fire disconnect hook in `close` |
| `README.md` | Document hooks, logger setup with example log output, disconnect observability, and PII filtering |
| `test/redis/instrumentation_test.rb` | New — 30+ tests covering hook lifecycle, ordering, composition, thread safety, parameter filtering, logger hook, and disconnect hooks |

## Example log output

```
D, [2026-02-23T10:15:32.004] DEBUG -- : Redis SET 0.38ms (id: redis://127.0.0.1:6379/0)
D, [2026-02-23T10:15:32.009] DEBUG -- : Redis GET mykey 0.22ms (id: redis://127.0.0.1:6379/0)
D, [2026-02-23T10:15:32.020] DEBUG -- : Redis SET mykey myvalue 1.05ms ERROR Redis::TimeoutError (id: redis://127.0.0.1:6379/0)
```

## Test plan

- [ ] Run `bundle exec rake test TEST=test/redis/instrumentation_test.rb` — all 30+ tests pass
- [ ] Run full test suite to verify no regressions in existing command paths
- [ ] Verify zero overhead: disable all hooks, confirm `Instrumentation.enabled?` is `false` and `send_command` takes the fast path