### PR TITLE
Add exponential backoff retry with configurable delays

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ If no message is received after 5 seconds, the client will unsubscribe.
 
 ## Reconnections
 
-**By default**, this gem will only **retry a connection once** and then fail, but
+**By default**, this gem will **retry a connection 5 times** and then fail, but
 the client allows you to configure how many `reconnect_attempts` it should
 complete before declaring a connection as failed.
 
@@ -373,6 +373,24 @@ redis = Redis.new(
 ```
 
 [OpenSSL::SSL::SSLContext documentation]: http://ruby-doc.org/stdlib-2.5.0/libdoc/openssl/rdoc/OpenSSL/SSL/SSLContext.html
+
+## Exponential Backoff Retry
+
+For resilient connections in production, use `exponential_backoff_retry` to reconnect
+with exponential backoff:
+
+```ruby
+redis = Redis.new
+
+# Uses defaults: 5 attempts, 0.5s base delay, 30s max delay
+redis.exponential_backoff_retry
+
+# Custom parameters
+redis.exponential_backoff_retry(10, base_delay: 1.0, max_delay: 60.0)
+```
+
+The delay between attempts doubles each time (`0.5s → 1s → 2s → 4s → ...`) up to
+`max_delay`. Raises `Redis::CannotConnectError` if all attempts fail.
 
 ## Expert-Mode Options
 

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -65,7 +65,7 @@ class Redis
   def initialize(options = {})
     @monitor = Monitor.new
     @options = options.dup
-    @options[:reconnect_attempts] = 1 unless @options.key?(:reconnect_attempts)
+    @options[:reconnect_attempts] = 5 unless @options.key?(:reconnect_attempts)
     if ENV["REDIS_URL"] && SERVER_URL_OPTIONS.none? { |o| @options.key?(o) }
       @options[:url] = ENV["REDIS_URL"]
     end
@@ -74,6 +74,35 @@ class Redis
 
     @client = initialize_client(@options)
     @client.inherit_socket! if inherit_socket
+  end
+
+  # Retry connecting to Redis with exponential backoff.
+  #
+  # @param reconnect_attempts [Integer] number of attempts
+  # @param base_delay [Float] initial delay in seconds between attempts
+  # @param max_delay [Float] maximum delay cap in seconds
+  # @return [true] on successful connection
+  # @raise [Redis::CannotConnectError] if all attempts fail
+  def exponential_backoff_retry(reconnect_attempts = @options.fetch(:reconnect_attempts, 5),
+                                base_delay: 0.5, max_delay: 30.0)
+    last_error = nil
+
+    reconnect_attempts.times do |attempt|
+      begin
+        send_command([:ping])
+        return true
+      rescue BaseConnectionError => e
+        last_error = e
+        @client.close
+
+        next if attempt == reconnect_attempts - 1
+
+        delay = [base_delay * (2**attempt), max_delay].min
+        sleep(delay)
+      end
+    end
+
+    raise CannotConnectError, "Failed to connect after #{reconnect_attempts} attempts: #{last_error&.message}"
   end
 
   # Run code without the client reconnecting

--- a/test/redis/internals_test.rb
+++ b/test/redis/internals_test.rb
@@ -111,7 +111,7 @@ class TestInternals < Minitest::Test
   end
 
   def test_retry_only_once_when_read_raises_econnreset
-    close_on_ping([0, 1]) do |redis|
+    close_on_ping([0, 1], reconnect_attempts: 1) do |redis|
       assert_raises Redis::ConnectionError do
         redis.ping
       end
@@ -143,6 +143,81 @@ class TestInternals < Minitest::Test
       redis._client.config.expects(:sleep).with(0.04).returns(true)
 
       assert_equal "3", redis.ping
+    end
+  end
+
+  # --- exponential_backoff_retry tests ---
+
+  def test_exponential_backoff_retry_succeeds_on_first_attempt
+    redis_mock(ping: ->(*_) { "+PONG" }) do |redis|
+      assert_equal true, redis.exponential_backoff_retry(3)
+    end
+  end
+
+  def test_exponential_backoff_retry_succeeds_after_failures
+    close_on_ping([0, 1], reconnect_attempts: 0) do |redis|
+      Redis.any_instance.stubs(:sleep)
+      assert_equal true, redis.exponential_backoff_retry(5, base_delay: 0.001)
+    end
+  end
+
+  def test_exponential_backoff_retry_raises_after_all_attempts_exhausted
+    close_on_ping([0, 1, 2, 3, 4], reconnect_attempts: 0) do |redis|
+      Redis.any_instance.stubs(:sleep)
+      error = assert_raises(Redis::CannotConnectError) do
+        redis.exponential_backoff_retry(3, base_delay: 0.001)
+      end
+      assert_match(/Failed to connect after 3 attempts/, error.message)
+    end
+  end
+
+  def test_exponential_backoff_retry_uses_exponential_delays
+    close_on_ping([0, 1, 2], reconnect_attempts: 0) do |redis|
+      delays = []
+      Redis.any_instance.stubs(:sleep).with { |d| delays << d; true }
+      redis.exponential_backoff_retry(5, base_delay: 0.1, max_delay: 10.0)
+      # attempts 0,1,2 fail -> sleep after each (none is the last attempt) -> attempt 3 succeeds
+      assert_equal 3, delays.size
+      assert_in_delta 0.1, delays[0], 0.001  # 0.1 * 2^0
+      assert_in_delta 0.2, delays[1], 0.001  # 0.1 * 2^1
+      assert_in_delta 0.4, delays[2], 0.001  # 0.1 * 2^2
+    end
+  end
+
+  def test_exponential_backoff_retry_caps_delay_at_max
+    close_on_ping([0, 1, 2, 3], reconnect_attempts: 0) do |redis|
+      delays = []
+      Redis.any_instance.stubs(:sleep).with { |d| delays << d; true }
+      redis.exponential_backoff_retry(6, base_delay: 1.0, max_delay: 2.5)
+      # attempts 0,1,2,3 fail -> sleep after each (none is the last attempt) -> attempt 4 succeeds
+      assert_equal 4, delays.size
+      assert_in_delta 1.0, delays[0], 0.001  # min(1.0 * 2^0, 2.5) = 1.0
+      assert_in_delta 2.0, delays[1], 0.001  # min(1.0 * 2^1, 2.5) = 2.0
+      assert_in_delta 2.5, delays[2], 0.001  # min(1.0 * 2^2, 2.5) = 2.5
+      assert_in_delta 2.5, delays[3], 0.001  # min(1.0 * 2^3, 2.5) = 2.5 (capped)
+    end
+  end
+
+  def test_exponential_backoff_retry_defaults_to_options_reconnect_attempts
+    close_on_ping([0, 1, 2, 3, 4, 5], reconnect_attempts: 0) do |redis|
+      redis.instance_variable_get(:@options)[:reconnect_attempts] = 2
+      Redis.any_instance.stubs(:sleep)
+      error = assert_raises(Redis::CannotConnectError) do
+        redis.exponential_backoff_retry(base_delay: 0.001)
+      end
+      assert_match(/Failed to connect after 2 attempts/, error.message)
+    end
+  end
+
+  def test_exponential_backoff_retry_does_not_sleep_after_last_attempt
+    close_on_ping([0, 1, 2], reconnect_attempts: 0) do |redis|
+      delays = []
+      Redis.any_instance.stubs(:sleep).with { |d| delays << d; true }
+      assert_raises(Redis::CannotConnectError) do
+        redis.exponential_backoff_retry(3, base_delay: 0.1)
+      end
+      # 3 attempts all fail, sleep after attempt 0 and 1, NOT after attempt 2
+      assert_equal 2, delays.size
     end
   end
 


### PR DESCRIPTION
## Summary

- Change default `reconnect_attempts` from 1 to **5** for more resilient connections out of the box
- Add `exponential_backoff_retry` public method with configurable `base_delay` and `max_delay` parameters
- Delay doubles each attempt (`0.5s → 1s → 2s → 4s → ...`) capped at `max_delay`
- Defaults to the instance's `reconnect_attempts` option when no explicit count is passed
- Raises `Redis::CannotConnectError` with the last error message when all attempts are exhausted
- Does not sleep after the final failed attempt

## Usage

```ruby
redis = Redis.new

# Uses defaults: 5 attempts, 0.5s base delay, 30s max delay
redis.exponential_backoff_retry

# Custom parameters
redis.exponential_backoff_retry(10, base_delay: 1.0, max_delay: 60.0)
```

## Files changed

| File | Description |
|------|-------------|
| `lib/redis.rb` | Default `reconnect_attempts` 1→5; add `exponential_backoff_retry` method |
| `README.md` | Update reconnection docs to reflect new default; add Exponential Backoff Retry section |
| `test/redis/internals_test.rb` | Fix existing test to pass explicit `reconnect_attempts: 1`; add 7 new tests covering success, failure, delay progression, max cap, defaults, and no-sleep-after-last-attempt |

## Test plan

- [ ] Run `bundle exec rake test TEST=test/redis/internals_test.rb` — all tests pass including 7 new backoff tests
- [ ] Run full test suite to verify no regressions from the default change (1→5)
- [ ] Verify existing `test_retry_only_once_when_read_raises_econnreset` still passes with explicit `reconnect_attempts: 1`