### PR TITLE
Fix cluster test helpers to support CLUSTER SHARDS command

### DIFF
--- a/cluster/test/helper.rb
+++ b/cluster/test/helper.rb
@@ -41,6 +41,48 @@ module Helper
       "$#{line.size}\r\n#{line}\r\n"
     }
 
+    ClusterShardsRawReply = lambda { |host, port|
+      <<-REPLY.delete(' ')
+        *1\r
+        *4\r
+        $5\r
+        slots\r
+        *2\r
+        :0\r
+        :16383\r
+        $5\r
+        nodes\r
+        *1\r
+        *14\r
+        $2\r
+        id\r
+        $40\r
+        51a0020c166dab7f3f259b6cc46ce4ed4437fa1d\r
+        $4\r
+        port\r
+        :#{port}\r
+        $2\r
+        ip\r
+        $#{host.size}\r
+        #{host}\r
+        $8\r
+        endpoint\r
+        $#{host.size}\r
+        #{host}\r
+        $4\r
+        role\r
+        $6\r
+        master\r
+        $18\r
+        replication-offset\r
+        :967228\r
+        $6\r
+        health\r
+        $6\r
+        online\r
+      REPLY
+    }
+
     def init(redis)
       redis.flushall
       redis
@@ -85,6 +127,7 @@ module Helper
           case subcommand.downcase
           when 'slots' then ClusterSlotsRawReply.call(host, port)
           when 'nodes' then ClusterNodesRawReply.call(host, port)
+          when 'shards' then ClusterShardsRawReply.call(host, port)
           else '+OK'
           end
         end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -174,7 +174,7 @@ module Helper
     def with_acl
       admin = _new_client
       admin.acl('SETUSER', 'johndoe', 'on',
-                '+ping', '+select', '+command', '+cluster|slots', '+cluster|nodes', '+readonly',
+                '+ping', '+select', '+command', '+cluster|slots', '+cluster|nodes', '+cluster|shards', '+readonly',
                 '>mysecret')
       yield('johndoe', 'mysecret')
     ensure


### PR DESCRIPTION
The redis-cluster-client now uses the CLUSTER SHARDS command instead of CLUSTER NODES, so we need to tweak some test helpers to adapt the internal client.

* https://github.com/redis-rb/redis-cluster-client/pull/479
* https://github.com/redis-rb/redis-cluster-client/pull/485

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to test helpers/mocks and ACL setup, with no production logic or data-handling impact.
> 
> **Overview**
> Updates the cluster test Redis mock to support `CLUSTER SHARDS` by adding a canned raw RESP reply and routing `cluster shards` requests to it.
> 
> Extends the test ACL setup to grant `+cluster|shards`, preventing auth failures in cluster-mode tests that now prefer `CLUSTER SHARDS` over `CLUSTER NODES`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 574789bbe44556ce4ee819383a786f21412742bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->