### PR TITLE
Added support for GEOSEARCH and GEOSEARCHSTORE command + Claude related specs

### DIFF
--- a/.claude/skills/add-new-command/SKILL.md
+++ b/.claude/skills/add-new-command/SKILL.md
@@ -1,0 +1,82 @@
+---
+description: Adds support for a new Redis command from a given specification. Check examples/command-specification-template.md.
+argument-hint: [path-to-specification]
+---
+
+# Execute: Add new Redis command support
+
+## Plan to Execute
+
+Read specification file: `$ARGUMENTS`
+
+## Execution Instructions
+
+### 1. Preparations
+
+- Go through the guide `specs/adding-commands.md`
+
+### 2. Read and Understand
+
+- Read the ENTIRE specification carefully
+- Go through Command Description and identify command type (string, list, set, etc.)
+- Go through the Command API:
+    - Identify required and optional arguments
+    - Identify how to match Redis command arguments type to Python types
+    - Identify return value and possible response types
+- Check relevant Redis-Cli examples, if provided
+- Review the Test Plan
+
+### 3. Execute Tasks in Order
+
+#### a. Navigate to the task
+- Identify the files and action required
+- Read existing related files if modifying
+
+#### b. Implement the command
+- Identify the command API surface object you need to work with.
+- Identify required and optional arguments and their matching types.
+- Add command implementation following `specs/adding-commands.md`
+- Ensure doc string documents are added
+
+#### c. Verify as you go
+- After each file change, check syntax
+- Ensure imports are correct
+- Verify types are properly defined
+- Verify that response schema is similar for RESP2 and RESP3
+
+### 4. Implement Testing Plan
+
+After completing implementation tasks:
+
+- Identify matching test file or create new one if needed
+- Implement all test cases as separate test methods
+- Ensure adding version constraint if specified in the specification
+- Ensure tests cover edge cases
+
+### 5. Run tests
+
+- Run newly added test cases
+- Get back to the Implementation stage if any test failed
+
+### 6. Final Verification
+
+Before completing:
+
+- ✅ All tasks from plan completed
+- ✅ All tests created and passing
+- ✅ Code follows project conventions
+- ✅ Documentation added/updated as needed
+
+## Output Report
+
+Provide summary:
+
+### Completed Tasks
+- List of all tasks completed
+- Files created (with paths)
+- Files modified (with paths)
+
+### Tests Added
+- Test files created
+- Test cases implemented
+- Test results

--- a/.claude/skills/add-new-command/SKILL.md
+++ b/.claude/skills/add-new-command/SKILL.md
@@ -21,7 +21,7 @@ Read specification file: `$ARGUMENTS`
 - Go through Command Description and identify command type (string, list, set, etc.)
 - Go through the Command API:
     - Identify required and optional arguments
-    - Identify how to match Redis command arguments type to Python types
+    - Identify how to match Redis command arguments type to Ruby types
     - Identify return value and possible response types
 - Check relevant Redis-Cli examples, if provided
 - Review the Test Plan
@@ -42,7 +42,6 @@ Read specification file: `$ARGUMENTS`
 - After each file change, check syntax
 - Ensure imports are correct
 - Verify types are properly defined
-- Verify that response schema is similar for RESP2 and RESP3
 
 ### 4. Implement Testing Plan
 

--- a/.claude/skills/add-new-command/examples/command-specification-template.md
+++ b/.claude/skills/add-new-command/examples/command-specification-template.md
@@ -1,0 +1,29 @@
+# $COMMAND_NAME command specification
+
+## Supported version
+
+Add supported Redis version here. For example: Redis >= 6.2.0
+
+## Command description
+
+Add a description of the command here.
+
+## Command API
+
+Specify an API for the command in the format that official docs uses. For example:
+
+```
+$COMMAND_NAME $key $member [NX|XX] [CH] [INCR]
+```
+
+## Redis-CLI examples
+
+Add relevant Redis-CLI examples here.
+
+## Test plan
+
+Specify how you want to test the command in terms of integration testing. For example:
+
+- Test only with required arguments, assert that single value returned
+- Test with required arguments and optional XX modifier, ensure that 1 returned
+- ...

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ appendonly.aof
 appendonlydir
 temp-rewriteaof-*.aof
 .history
+.bundle/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,145 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository layout
+
+This repository ships **two gems** from one tree:
+
+- `redis` — the high-level standalone/sentinel client. Source under `lib/`, gemspec at `redis.gemspec`.
+- `redis-clustering` — the cluster client, a thin subclass that depends on `redis`. Source under `cluster/lib/`, gemspec at `cluster/redis-clustering.gemspec`. It is a separate gem on purpose: passing `cluster:` to `Redis.new` raises (see `lib/redis.rb:137-139`).
+
+Cluster code, tests, and CHANGELOG live under `cluster/`. When making changes that span both, edit both — the cluster gem reuses `lib/redis/commands/**` from the main gem but has its own client class (`cluster/lib/redis/cluster/client.rb`) and transaction adapter.
+
+## Common commands
+
+The dev workflow assumes a Redis server compiled from source into `tmp/cache/`. The makefile takes care of that:
+
+```sh
+# build + start standalone, replica, sentinel quorum, and a 6-node cluster
+make start_all
+
+# run the full suite (all four test groups)
+make test
+
+# stop everything
+make stop_all
+
+# one shot: start, test, stop
+make all
+```
+
+`make test` shells out to `bundle exec rake test`, which runs four `Rake::TestTask` groups defined in `Rakefile:8-32`:
+
+```sh
+bundle exec rake test:redis        # lib/redis core
+bundle exec rake test:distributed  # lib/redis/distributed (client-side sharding)
+bundle exec rake test:sentinel     # sentinel-mode tests
+bundle exec rake test:cluster      # cluster gem (loads cluster/lib + cluster/test)
+```
+
+To run a single test file or method, use Minitest's options via `TESTOPTS`:
+
+```sh
+bundle exec rake test:redis TEST=test/redis/commands_on_strings_test.rb
+bundle exec rake test:cluster TEST=cluster/test/commands_on_strings_test.rb TESTOPTS="--name=/get/"
+```
+
+Other useful knobs:
+
+- `REDIS_BRANCH=8.4 make start_all` — build/run a specific Redis version (default `8.4`, see `makefile:1`). The `bin/build` script downloads and compiles from `github.com/redis/redis`.
+- `DRIVER=hiredis bundle exec rake test` — run the suite against the `hiredis-client` C-extension driver instead of the pure-Ruby parser (`test/helper.rb:11`).
+- `REDIS_SOCKET_PATH=...` — override the Unix socket location. The default expects `tmp/redis.sock`, which `make start` creates; tests abort with "did you run `make start`?" if it's missing (`test/helper.rb:29-37`).
+- `bundle exec rubocop` — lint. The Rubocop config is in `.rubocop.yml` (root) and `cluster/.rubocop.yml`.
+- `bin/console` — IRB session with `redis` preloaded.
+
+There's no separate cluster makefile target — `make start_all` brings up the cluster nodes too (`makefile:108-122`), and `bundle exec rake test:cluster` runs against the cluster from `make`.
+
+## Architecture
+
+### Layering
+
+```
+Redis (lib/redis.rb)                ergonomics: keyword DSL, RESP2 reshape, error translation,
+   ├ Commands (lib/redis/commands)  pub/sub second-socket, pipelined/multi wrappers
+   ├ Monitor (lock)
+   └ @client : Redis::Client < RedisClient
+                                    ↓
+              redis-client gem (external, vendored as runtime dep)
+                                    ↓
+              TCP/TLS/Unix socket
+```
+
+The `Redis` class is the public surface. It delegates all network I/O to `Redis::Client`, which inherits from `RedisClient` (in the `redis-client` gem) and only adds:
+
+1. Error translation: maps `RedisClient::*` exceptions to `Redis::*` via `ERROR_MAPPING` (`lib/redis/client.rb:5-46`). Every public method on `Redis::Client` is wrapped in a rescue that calls `Client.translate_error!`.
+2. A hard pin of `protocol: 2` (`lib/redis/client.rb:23-29`). RESP3 is intentionally not supported at this layer (see "RESP2 invariant" below).
+3. Trivial config delegators (`#host`, `#port`, `#db`, …).
+
+The full command execution flow is: `Redis#some_command` (defined in `lib/redis/commands/<category>.rb`) builds an array → `Redis#send_command` grabs `@monitor` → `Redis::Client#call_v` rescues + re-raises → `RedisClient#call_v` serializes RESP and reads the reply → optional reshape lambda runs → result returned.
+
+### Commands as a module composition
+
+Every Redis command category is a module under `lib/redis/commands/` (strings, lists, hashes, sets, sorted_sets, streams, scripting, transactions, pubsub, etc.). They are all `include`d into a parent `Redis::Commands` module (`lib/redis/commands.rb:20-37`), which is in turn mixed into:
+
+- `Redis` (`lib/redis.rb:37`)
+- `Redis::PipelinedConnection` (`lib/redis/pipeline.rb:15`) — used inside `pipelined` and `multi` blocks
+- (Indirectly) `Redis::Cluster` via inheritance from `Redis`
+
+This is the **single most important pattern in the codebase**. To add a new command, find the matching `commands/<category>.rb` and add a method that calls `send_command([:cmd, ...])` — that method automatically becomes available on every client type. The mixin classes each provide their own `send_command` and `synchronize` so the same `Commands` methods work in direct calls, pipelines, and transactions.
+
+There is also a catch-all `method_missing` (`lib/redis/commands.rb:235-237`) that forwards any unknown method as a Redis command — so unwrapped commands "just work."
+
+### Reply reshaping (RESP2 invariant)
+
+The top of `lib/redis/commands.rb:42-194` defines a family of lambdas — `Boolify`, `BoolifySet`, `Hashify`, `Floatify`, `FloatifyPairs`, `HashifyInfo`, `HashifyStreamEntries`, `HashifyClusterNodes`, … — that reshape flat RESP2 replies into idiomatic Ruby (Hash, Float, boolean, etc.). They are passed as blocks to `send_command`:
+
+```ruby
+def incrbyfloat(key, increment)
+  send_command([:incrbyfloat, key, Float(increment)], &Floatify)
+end
+```
+
+These lambdas **assume RESP2-shaped replies** — flat arrays the lambda slices into hashes, integer 0/1 it turns into booleans, etc. This is why `Redis::Client.config` hard-codes `protocol: 2`: under RESP3 the server already returns native maps/booleans/doubles and the lambdas would either double-process or break. If you're tempted to enable RESP3, the realistic path is to drop down to `RedisClient` directly rather than touch this layer.
+
+When adding a command that needs reply transformation, write or reuse one of these lambdas; do not coerce in the command method itself.
+
+### Connection lifecycle (long-lived, lazy, fork-safe)
+
+- `Redis.new` does **not** open a socket — it's lazy. The first command triggers `RedisClient#ensure_connected`, which runs the `connection_prelude` (HELLO/AUTH, SELECT, CLIENT SETINFO, then CLIENT SETNAME and ROLE) and caches the socket.
+- One `Redis` instance owns one socket, guarded by a `Monitor` (`lib/redis.rb:66`, used at `:148-150`). The reentrant lock matters for nested `watch { multi { ... } }` patterns; do not "optimize" it to `Mutex` without redesigning that API.
+- For concurrent use, wrap with `connection_pool` — the README documents this and it's the only recommended pooling story. The gem itself does not pool.
+- Fork safety is handled inside `redis-client` via `PIDCache`: a forked child detects the inherited socket and reconnects on next use. The `inherit_socket` option (`lib/redis.rb:60`, `:72-76`, `:127-129`) disables that check; almost no callers should use it.
+
+### Pub/Sub — separate socket, same process
+
+`subscribe` / `psubscribe` / `ssubscribe` open a **second** dedicated socket via `@client.pubsub` (`lib/redis.rb:172-173`) wrapped in `SubscribedClient` (`lib/redis/subscribe.rb`). This keeps the command socket usable from other threads while one thread is blocked in the `next_event` loop. The subscription loop on the calling thread is synchronous — if you want it off the main thread, the caller spawns a `Thread`. There's a separate write-monitor on the subscription socket (`lib/redis/subscribe.rb:7`). Sharded pub/sub (`SSUBSCRIBE`) subscribes one channel at a time to avoid cross-slot errors in cluster mode (`lib/redis/subscribe.rb:61-64`).
+
+### Pipelines and transactions
+
+`pipelined` and `multi` both yield a `Redis::PipelinedConnection` (or `MultiConnection`) that re-includes `Commands` (`lib/redis/pipeline.rb`). Each command inside the block returns a `Redis::Future` that resolves when the batch flushes. `MultiFuture` (`lib/redis/pipeline.rb:113-130`) splits the `EXEC` reply array back across individual command futures. Inside a `MULTI`, blocking commands degrade to non-blocking (`lib/redis/pipeline.rb:64-71`) — that's intentional, matching Redis server semantics.
+
+### Cluster gem differences
+
+`cluster/lib/redis/cluster.rb` defines `Redis::Cluster < ::Redis`, so it inherits the full `Commands` surface but swaps `initialize_client` to build a `RedisClient::Cluster` via the `redis-cluster-client` gem (`cluster/lib/redis/cluster.rb:130-133`). Cluster-specific differences worth knowing:
+
+- `Redis::Cluster::Client` (`cluster/lib/redis/cluster/client.rb`) maintains a **per-node connection pool internally** via `redis-cluster-client`. Do not wrap this in the `connection_pool` gem.
+- `watch` **requires a block with an argument** (`cluster/lib/redis/cluster/client.rb:102-128`). The block receives a `Redis::Cluster::TransactionAdapter` that pins commands to the same node/slot. Standalone `Redis#watch` accepts the no-block form; cluster does not.
+- `Redis::Cluster#connection` raises `NotImplementedError` (`cluster/lib/redis/cluster.rb:47-49`) — there's no single "connection" to report.
+- Extra error classes: `InitialSetupError`, `OrchestrationCommandNotSupported`, `CommandErrorCollection`, `AmbiguousNodeError`, `TransactionConsistencyError`, `NodeMightBeDown` (`cluster/lib/redis/cluster.rb:9-45`).
+
+### `Redis::Distributed` is not Redis Cluster
+
+`lib/redis/distributed.rb` + `lib/redis/hash_ring.rb` implement **client-side consistent-hash sharding** across N independent standalone Redis servers. It is *not* the Redis Cluster protocol — there are no slot maps, no MOVED/ASK redirects, no automatic resharding. Keys are hashed with CRC32 against an MD5-built ring (160 vnodes/server) and dispatched to one underlying `Redis` instance. Multi-key commands raise `CannotDistribute` since co-location isn't guaranteed.
+
+It is **separately maintained** from `Commands` — `Redis::Distributed` does *not* include the `Commands` mixin; every method is explicitly defined in `distributed.rb` so it can route to the right node via `node_for(key)`. When adding a new Redis command that should be available here, add a corresponding method to `lib/redis/distributed.rb` and a test under `test/distributed/`. The `test:distributed` Rake task runs as part of the default suite, so missing or broken Distributed implementations will fail CI.
+
+It is supported (recent commits add JSON, HEXPIRE/HPTTL, HSCAN, etc.) and not deprecated. For new applications needing horizontal scaling, `Redis::Cluster` is generally the better choice because the server enforces consistency; `Redis::Distributed` is the right tool when you have N independent standalone Redises and want memcache-style key distribution.
+
+## Conventions
+
+- Every file starts with `# frozen_string_literal: true`. Keep it when editing or creating files.
+- Commands take symbols for the verb (`[:incr, key]`); strings and arguments are coerced where needed (`Integer(x)`, `Float(x)`, `value.to_s`). Follow the local pattern in `lib/redis/commands/<category>.rb` when adding new methods.
+- Yard-style docstrings (`@param`, `@option`, `@return`, `@example`) are on every public command method. New methods should keep that format.
+- Error mapping is centralized in `Redis::Client::ERROR_MAPPING` (and extended in `Redis::Cluster::Client::ERROR_MAPPING`). If you add a new RedisClient error class to handle, add it there rather than catching in individual command methods.
+- Test files must live under one of `test/redis`, `test/distributed`, `test/sentinel`, `cluster/test`. The Rakefile fails the build if a `*_test.rb` exists outside those groups (`Rakefile:19-22`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 This repository ships **two gems** from one tree:
 
 - `redis` — the high-level standalone/sentinel client. Source under `lib/`, gemspec at `redis.gemspec`.
-- `redis-clustering` — the cluster client, a thin subclass that depends on `redis`. Source under `cluster/lib/`, gemspec at `cluster/redis-clustering.gemspec`. It is a separate gem on purpose: passing `cluster:` to `Redis.new` raises (see `lib/redis.rb:137-139`).
+- `redis-clustering` — the cluster client, a thin subclass that depends on `redis`. Source under `cluster/lib/`, gemspec at `cluster/redis-clustering.gemspec`. It is a separate gem on purpose: passing `cluster:` to `Redis.new` raises (see `lib/redis.rb`).
 
 Cluster code, tests, and CHANGELOG live under `cluster/`. When making changes that span both, edit both — the cluster gem reuses `lib/redis/commands/**` from the main gem but has its own client class (`cluster/lib/redis/cluster/client.rb`) and transaction adapter.
 
@@ -29,7 +29,7 @@ make stop_all
 make all
 ```
 
-`make test` shells out to `bundle exec rake test`, which runs four `Rake::TestTask` groups defined in `Rakefile:8-32`:
+`make test` shells out to `bundle exec rake test`, which runs four `Rake::TestTask` groups defined in `Rakefile`:
 
 ```sh
 bundle exec rake test:redis        # lib/redis core
@@ -47,13 +47,13 @@ bundle exec rake test:cluster TEST=cluster/test/commands_on_strings_test.rb TEST
 
 Other useful knobs:
 
-- `REDIS_BRANCH=8.4 make start_all` — build/run a specific Redis version (default `8.4`, see `makefile:1`). The `bin/build` script downloads and compiles from `github.com/redis/redis`.
-- `DRIVER=hiredis bundle exec rake test` — run the suite against the `hiredis-client` C-extension driver instead of the pure-Ruby parser (`test/helper.rb:11`).
-- `REDIS_SOCKET_PATH=...` — override the Unix socket location. The default expects `tmp/redis.sock`, which `make start` creates; tests abort with "did you run `make start`?" if it's missing (`test/helper.rb:29-37`).
+- `REDIS_BRANCH=8.4 make start_all` — build/run a specific Redis version (default is set at the top of `makefile`). The `bin/build` script downloads and compiles from `github.com/redis/redis`.
+- `DRIVER=hiredis bundle exec rake test` — run the suite against the `hiredis-client` C-extension driver instead of the pure-Ruby parser (see `test/helper.rb`).
+- `REDIS_SOCKET_PATH=...` — override the Unix socket location. The default expects `tmp/redis.sock`, which `make start` creates; `test/helper.rb` aborts with "did you run `make start`?" if it's missing.
 - `bundle exec rubocop` — lint. The Rubocop config is in `.rubocop.yml` (root) and `cluster/.rubocop.yml`.
 - `bin/console` — IRB session with `redis` preloaded.
 
-There's no separate cluster makefile target — `make start_all` brings up the cluster nodes too (`makefile:108-122`), and `bundle exec rake test:cluster` runs against the cluster from `make`.
+There's no separate cluster makefile target — `make start_all` brings up the cluster nodes too (see the `start_cluster` / `create_cluster` targets in `makefile`), and `bundle exec rake test:cluster` runs against the cluster from `make`.
 
 ## Architecture
 
@@ -72,27 +72,27 @@ Redis (lib/redis.rb)                ergonomics: keyword DSL, RESP2 reshape, erro
 
 The `Redis` class is the public surface. It delegates all network I/O to `Redis::Client`, which inherits from `RedisClient` (in the `redis-client` gem) and only adds:
 
-1. Error translation: maps `RedisClient::*` exceptions to `Redis::*` via `ERROR_MAPPING` (`lib/redis/client.rb:5-46`). Every public method on `Redis::Client` is wrapped in a rescue that calls `Client.translate_error!`.
-2. A hard pin of `protocol: 2` (`lib/redis/client.rb:23-29`). RESP3 is intentionally not supported at this layer (see "RESP2 invariant" below).
+1. Error translation: maps `RedisClient::*` exceptions to `Redis::*` via `ERROR_MAPPING` in `lib/redis/client.rb`. Every public method on `Redis::Client` is wrapped in a rescue that calls `Client.translate_error!`.
+2. A hard pin of `protocol: 2` in `lib/redis/client.rb`. RESP3 is intentionally not supported at this layer (see "RESP2 invariant" below).
 3. Trivial config delegators (`#host`, `#port`, `#db`, …).
 
 The full command execution flow is: `Redis#some_command` (defined in `lib/redis/commands/<category>.rb`) builds an array → `Redis#send_command` grabs `@monitor` → `Redis::Client#call_v` rescues + re-raises → `RedisClient#call_v` serializes RESP and reads the reply → optional reshape lambda runs → result returned.
 
 ### Commands as a module composition
 
-Every Redis command category is a module under `lib/redis/commands/` (strings, lists, hashes, sets, sorted_sets, streams, scripting, transactions, pubsub, etc.). They are all `include`d into a parent `Redis::Commands` module (`lib/redis/commands.rb:20-37`), which is in turn mixed into:
+Every Redis command category is a module under `lib/redis/commands/` (strings, lists, hashes, sets, sorted_sets, streams, scripting, transactions, pubsub, etc.). They are all `include`d into a parent `Redis::Commands` module (`lib/redis/commands.rb`), which is in turn mixed into:
 
-- `Redis` (`lib/redis.rb:37`)
-- `Redis::PipelinedConnection` (`lib/redis/pipeline.rb:15`) — used inside `pipelined` and `multi` blocks
+- `Redis` (`lib/redis.rb`)
+- `Redis::PipelinedConnection` (`lib/redis/pipeline.rb`) — used inside `pipelined` and `multi` blocks
 - (Indirectly) `Redis::Cluster` via inheritance from `Redis`
 
 This is the **single most important pattern in the codebase**. To add a new command, find the matching `commands/<category>.rb` and add a method that calls `send_command([:cmd, ...])` — that method automatically becomes available on every client type. The mixin classes each provide their own `send_command` and `synchronize` so the same `Commands` methods work in direct calls, pipelines, and transactions.
 
-There is also a catch-all `method_missing` (`lib/redis/commands.rb:235-237`) that forwards any unknown method as a Redis command — so unwrapped commands "just work."
+There is also a catch-all `method_missing` in `lib/redis/commands.rb` that forwards any unknown method as a Redis command — so unwrapped commands "just work."
 
 ### Reply reshaping (RESP2 invariant)
 
-The top of `lib/redis/commands.rb:42-194` defines a family of lambdas — `Boolify`, `BoolifySet`, `Hashify`, `Floatify`, `FloatifyPairs`, `HashifyInfo`, `HashifyStreamEntries`, `HashifyClusterNodes`, … — that reshape flat RESP2 replies into idiomatic Ruby (Hash, Float, boolean, etc.). They are passed as blocks to `send_command`:
+The top of `lib/redis/commands.rb` defines a family of lambdas — `Boolify`, `BoolifySet`, `Hashify`, `Floatify`, `FloatifyPairs`, `HashifyInfo`, `HashifyStreamEntries`, `HashifyClusterNodes`, … — that reshape flat RESP2 replies into idiomatic Ruby (Hash, Float, boolean, etc.). They are passed as blocks to `send_command`:
 
 ```ruby
 def incrbyfloat(key, increment)
@@ -107,26 +107,26 @@ When adding a command that needs reply transformation, write or reuse one of the
 ### Connection lifecycle (long-lived, lazy, fork-safe)
 
 - `Redis.new` does **not** open a socket — it's lazy. The first command triggers `RedisClient#ensure_connected`, which runs the `connection_prelude` (HELLO/AUTH, SELECT, CLIENT SETINFO, then CLIENT SETNAME and ROLE) and caches the socket.
-- One `Redis` instance owns one socket, guarded by a `Monitor` (`lib/redis.rb:66`, used at `:148-150`). The reentrant lock matters for nested `watch { multi { ... } }` patterns; do not "optimize" it to `Mutex` without redesigning that API.
+- One `Redis` instance owns one socket, guarded by a `Monitor` defined in `lib/redis.rb` and acquired in `Redis#send_command`. The reentrant lock matters for nested `watch { multi { ... } }` patterns; do not "optimize" it to `Mutex` without redesigning that API.
 - For concurrent use, wrap with `connection_pool` — the README documents this and it's the only recommended pooling story. The gem itself does not pool.
-- Fork safety is handled inside `redis-client` via `PIDCache`: a forked child detects the inherited socket and reconnects on next use. The `inherit_socket` option (`lib/redis.rb:60`, `:72-76`, `:127-129`) disables that check; almost no callers should use it.
+- Fork safety is handled inside `redis-client` via `PIDCache`: a forked child detects the inherited socket and reconnects on next use. The `inherit_socket` option in `lib/redis.rb` disables that check; almost no callers should use it.
 
 ### Pub/Sub — separate socket, same process
 
-`subscribe` / `psubscribe` / `ssubscribe` open a **second** dedicated socket via `@client.pubsub` (`lib/redis.rb:172-173`) wrapped in `SubscribedClient` (`lib/redis/subscribe.rb`). This keeps the command socket usable from other threads while one thread is blocked in the `next_event` loop. The subscription loop on the calling thread is synchronous — if you want it off the main thread, the caller spawns a `Thread`. There's a separate write-monitor on the subscription socket (`lib/redis/subscribe.rb:7`). Sharded pub/sub (`SSUBSCRIBE`) subscribes one channel at a time to avoid cross-slot errors in cluster mode (`lib/redis/subscribe.rb:61-64`).
+`subscribe` / `psubscribe` / `ssubscribe` open a **second** dedicated socket via `@client.pubsub` (in `lib/redis.rb`) wrapped in `SubscribedClient` (`lib/redis/subscribe.rb`). This keeps the command socket usable from other threads while one thread is blocked in the `next_event` loop. The subscription loop on the calling thread is synchronous — if you want it off the main thread, the caller spawns a `Thread`. There's a separate write-monitor on the subscription socket. Sharded pub/sub (`SSUBSCRIBE`) subscribes one channel at a time to avoid cross-slot errors in cluster mode.
 
 ### Pipelines and transactions
 
-`pipelined` and `multi` both yield a `Redis::PipelinedConnection` (or `MultiConnection`) that re-includes `Commands` (`lib/redis/pipeline.rb`). Each command inside the block returns a `Redis::Future` that resolves when the batch flushes. `MultiFuture` (`lib/redis/pipeline.rb:113-130`) splits the `EXEC` reply array back across individual command futures. Inside a `MULTI`, blocking commands degrade to non-blocking (`lib/redis/pipeline.rb:64-71`) — that's intentional, matching Redis server semantics.
+`pipelined` and `multi` both yield a `Redis::PipelinedConnection` (or `MultiConnection`) that re-includes `Commands` (`lib/redis/pipeline.rb`). Each command inside the block returns a `Redis::Future` that resolves when the batch flushes. `MultiFuture` (in `lib/redis/pipeline.rb`) splits the `EXEC` reply array back across individual command futures. Inside a `MULTI`, blocking commands degrade to non-blocking — that's intentional, matching Redis server semantics.
 
 ### Cluster gem differences
 
-`cluster/lib/redis/cluster.rb` defines `Redis::Cluster < ::Redis`, so it inherits the full `Commands` surface but swaps `initialize_client` to build a `RedisClient::Cluster` via the `redis-cluster-client` gem (`cluster/lib/redis/cluster.rb:130-133`). Cluster-specific differences worth knowing:
+`cluster/lib/redis/cluster.rb` defines `Redis::Cluster < ::Redis`, so it inherits the full `Commands` surface but swaps `initialize_client` to build a `RedisClient::Cluster` via the `redis-cluster-client` gem. Cluster-specific differences worth knowing:
 
 - `Redis::Cluster::Client` (`cluster/lib/redis/cluster/client.rb`) maintains a **per-node connection pool internally** via `redis-cluster-client`. Do not wrap this in the `connection_pool` gem.
-- `watch` **requires a block with an argument** (`cluster/lib/redis/cluster/client.rb:102-128`). The block receives a `Redis::Cluster::TransactionAdapter` that pins commands to the same node/slot. Standalone `Redis#watch` accepts the no-block form; cluster does not.
-- `Redis::Cluster#connection` raises `NotImplementedError` (`cluster/lib/redis/cluster.rb:47-49`) — there's no single "connection" to report.
-- Extra error classes: `InitialSetupError`, `OrchestrationCommandNotSupported`, `CommandErrorCollection`, `AmbiguousNodeError`, `TransactionConsistencyError`, `NodeMightBeDown` (`cluster/lib/redis/cluster.rb:9-45`).
+- `watch` **requires a block with an argument** in `cluster/lib/redis/cluster/client.rb`. The block receives a `Redis::Cluster::TransactionAdapter` that pins commands to the same node/slot. Standalone `Redis#watch` accepts the no-block form; cluster does not.
+- `Redis::Cluster#connection` raises `NotImplementedError` — there's no single "connection" to report.
+- Extra error classes: `InitialSetupError`, `OrchestrationCommandNotSupported`, `CommandErrorCollection`, `AmbiguousNodeError`, `TransactionConsistencyError`, `NodeMightBeDown` (defined in `cluster/lib/redis/cluster.rb`).
 
 ### `Redis::Distributed` is not Redis Cluster
 
@@ -142,4 +142,4 @@ It is supported (recent commits add JSON, HEXPIRE/HPTTL, HSCAN, etc.) and not de
 - Commands take symbols for the verb (`[:incr, key]`); strings and arguments are coerced where needed (`Integer(x)`, `Float(x)`, `value.to_s`). Follow the local pattern in `lib/redis/commands/<category>.rb` when adding new methods.
 - Yard-style docstrings (`@param`, `@option`, `@return`, `@example`) are on every public command method. New methods should keep that format.
 - Error mapping is centralized in `Redis::Client::ERROR_MAPPING` (and extended in `Redis::Cluster::Client::ERROR_MAPPING`). If you add a new RedisClient error class to handle, add it there rather than catching in individual command methods.
-- Test files must live under one of `test/redis`, `test/distributed`, `test/sentinel`, `cluster/test`. The Rakefile fails the build if a `*_test.rb` exists outside those groups (`Rakefile:19-22`).
+- Test files must live under one of `test/redis`, `test/distributed`, `test/sentinel`, `cluster/test`. The Rakefile fails the build if a `*_test.rb` exists outside those groups.

--- a/cluster/test/commands_on_geo_test.rb
+++ b/cluster/test/commands_on_geo_test.rb
@@ -112,4 +112,20 @@ class TestClusterCommandsOnGeo < Minitest::Test
       assert_equal 2, result[0][3].size
     end
   end
+
+  def test_geosearchstore
+    target_version "6.2" do
+      redis.geoadd('{tag}.src', 13.361389, 38.115556, 'Palermo', 15.087269, 37.502669, 'Catania')
+
+      stored = redis.geosearchstore('{tag}.dest', '{tag}.src', fromlonlat: [15, 37], byradius: [200, 'km'])
+      assert_equal 2, stored
+      assert_equal %w[Catania Palermo].sort, redis.zrange('{tag}.dest', 0, -1).sort
+
+      stored = redis.geosearchstore('{tag}.dist', '{tag}.src', fromlonlat: [15, 37], byradius: [200, 'km'],
+                                                               storedist: true)
+      assert_equal 2, stored
+      # STOREDIST stores distance as score, so nearest comes first.
+      assert_equal %w[Catania Palermo], redis.zrange('{tag}.dist', 0, -1)
+    end
+  end
 end

--- a/cluster/test/commands_on_geo_test.rb
+++ b/cluster/test/commands_on_geo_test.rb
@@ -86,4 +86,30 @@ class TestClusterCommandsOnGeo < Minitest::Test
     add_sicily
     assert_equal %w[Agrigento Palermo], redis.georadiusbymember('Sicily', 'Agrigento', 100, 'km')
   end
+
+  def test_geosearch
+    target_version "6.2" do
+      add_sicily
+
+      assert_equal %w[Catania Palermo],
+                   redis.geosearch('Sicily', fromlonlat: [15, 37], byradius: [200, 'km'], sort: 'asc')
+
+      assert_equal %w[Catania Palermo],
+                   redis.geosearch('Sicily', frommember: 'Catania', byradius: [200, 'km'], sort: 'asc')
+
+      assert_equal %w[Catania Palermo],
+                   redis.geosearch('Sicily', fromlonlat: [15, 37], bybox: [400, 400, 'km'], sort: 'asc')
+
+      assert_equal %w[Catania],
+                   redis.geosearch('Sicily', fromlonlat: [15, 37], byradius: [200, 'km'], sort: 'asc', count: 1)
+
+      result = redis.geosearch('Sicily', fromlonlat: [15, 37], byradius: [200, 'km'], sort: 'asc',
+                                         withcoord: true, withdist: true, withhash: true)
+      assert_equal 2, result.size
+      assert_equal 'Catania', result[0][0]
+      assert_equal '56.4413', result[0][1]
+      assert_kind_of Integer, result[0][2]
+      assert_equal 2, result[0][3].size
+    end
+  end
 end

--- a/cluster/test/helper.rb
+++ b/cluster/test/helper.rb
@@ -106,7 +106,25 @@ module Helper
     end
 
     def build_another_client(options = {})
-      _new_client(options)
+      client = _new_client(options)
+      # Replica-aware bootstrap occasionally fails on a freshly created cluster because
+      # replica nodes can briefly serve an incoherent CLUSTER SHARDS view. Pre-warm the
+      # client so the test's first real command doesn't hit a transient InitialSetupError.
+      warmup_cluster_client(client) if options[:replica]
+      client
+    end
+
+    def warmup_cluster_client(client, max_attempts: 30, backoff: 0.1)
+      attempts = 0
+      begin
+        client.ping
+      rescue Redis::Cluster::InitialSetupError
+        attempts += 1
+        raise if attempts >= max_attempts
+
+        sleep backoff
+        retry
+      end
     end
 
     def redis_cluster_mock(commands, options = {})
@@ -199,6 +217,25 @@ module Helper
 
     def _new_client(options = {})
       Redis::Cluster.new(_format_options(options).merge(driver: ENV['DRIVER']))
+    end
+
+    # ACL commands are not propagated across cluster nodes by default, so applying
+    # `ACL SETUSER` through the cluster client only creates the user on a single node.
+    # Apply it on every primary and replica directly so the test client can authenticate
+    # against any bootstrap node.
+    def with_acl
+      admins = DEFAULT_PORTS.map { |port| Redis.new(host: DEFAULT_HOST, port: port) }
+      admins.each do |admin|
+        admin.acl('SETUSER', 'johndoe', 'on',
+                  '+ping', '+select', '+command', '+cluster|slots', '+cluster|nodes', '+cluster|shards',
+                  '+readonly', '>mysecret')
+      end
+      yield('johndoe', 'mysecret')
+    ensure
+      admins&.each do |admin|
+        admin.acl('DELUSER', 'johndoe')
+        admin.close
+      end
     end
   end
 end

--- a/lib/redis/commands/geo.rb
+++ b/lib/redis/commands/geo.rb
@@ -106,6 +106,48 @@ class Redis
         send_command([:geosearch, *geoarguments])
       end
 
+      # Like GEOSEARCH, but stores the result in a destination key. By default the destination
+      # is populated with the matching members and their geospatial scores; when STOREDIST is
+      # set, the members are stored with their distance from the center point as the score.
+      # Available since Redis 6.2.
+      #
+      # @example Store the three nearest members
+      #   redis.geosearchstore("nearest", "Sicily",
+      #                        fromlonlat: [15, 37], bybox: [400, 400, "km"], sort: "asc", count: 3)
+      #     # => 3
+      #
+      # @example Store distances as scores
+      #   redis.geosearchstore("distances", "Sicily",
+      #                        fromlonlat: [15, 37], bybox: [400, 400, "km"], storedist: true)
+      #     # => 3
+      #
+      # @param [String] destination key to store the result in
+      # @param [String] source geospatial sorted set to search
+      # @param [String] frommember use the position of the given existing member as the center
+      # @param [Array<Numeric>] fromlonlat a [longitude, latitude] pair used as the center
+      # @param [Array] byradius a [radius, unit] pair where unit is one of 'm', 'km', 'ft', 'mi'
+      # @param [Array] bybox a [width, height, unit] triple where unit is one of 'm', 'km', 'ft', 'mi'
+      # @param ['asc', 'desc'] sort sort returned items from the nearest to the farthest, or vice versa
+      # @param [Integer] count limit the results to the first N matching items
+      # @param [Boolean] count_any return as soon as enough matches are found (only with count)
+      # @param [Boolean] storedist store the distance from the center point as the score
+      # @return [Integer] number of elements stored in the destination key
+      def geosearchstore(destination, source, frommember: nil, fromlonlat: nil, byradius: nil, bybox: nil,
+                         sort: nil, count: nil, count_any: false, storedist: false)
+        args = [destination, source]
+        args << "FROMMEMBER" << frommember if frommember
+        args << "FROMLONLAT" << fromlonlat[0] << fromlonlat[1] if fromlonlat
+        args << "BYRADIUS" << byradius[0] << byradius[1] if byradius
+        args << "BYBOX" << bybox[0] << bybox[1] << bybox[2] if bybox
+
+        options = []
+        options << "STOREDIST" if storedist
+
+        geoarguments = _geoarguments(*args, sort: sort, count: count, count_any: count_any, options: options)
+
+        send_command([:geosearchstore, *geoarguments])
+      end
+
       # Returns the distance between two members of a geospatial index
       #
       # @param [String ]key

--- a/lib/redis/commands/geo.rb
+++ b/lib/redis/commands/geo.rb
@@ -61,6 +61,51 @@ class Redis
         send_command([:geopos, key, member])
       end
 
+      # Return the members of a geospatial sorted set that are within the borders of the
+      # area specified by a given shape, either a circle (BYRADIUS) or a rectangle (BYBOX),
+      # starting from a center point given either by member (FROMMEMBER) or by longitude and
+      # latitude (FROMLONLAT). Available since Redis 6.2.
+      #
+      # @example Search by radius from longitude/latitude
+      #   redis.geosearch("Sicily", fromlonlat: [15, 37], byradius: [200, "km"], sort: "asc")
+      #     # => ["Catania", "Palermo"]
+      #
+      # @example Search by box from an existing member, with extras
+      #   redis.geosearch("Sicily", frommember: "Catania", bybox: [400, 400, "km"],
+      #                   sort: "asc", withcoord: true, withdist: true)
+      #     # => [["Catania", "0.0000", ["15.087...", "37.502..."]], ...]
+      #
+      # @param [String] key
+      # @param [String] frommember use the position of the given existing member as the center
+      # @param [Array<Numeric>] fromlonlat a [longitude, latitude] pair used as the center
+      # @param [Array] byradius a [radius, unit] pair where unit is one of 'm', 'km', 'ft', 'mi'
+      # @param [Array] bybox a [width, height, unit] triple where unit is one of 'm', 'km', 'ft', 'mi'
+      # @param ['asc', 'desc'] sort sort returned items from the nearest to the farthest, or vice versa
+      # @param [Integer] count limit the results to the first N matching items
+      # @param [Boolean] count_any return as soon as enough matches are found (only with count)
+      # @param [Boolean] withcoord also return the longitude and latitude of matching items
+      # @param [Boolean] withdist also return the distance from the center point
+      # @param [Boolean] withhash also return the raw geohash-encoded sorted set score of the item
+      # @return [Array<String>] may be changed with WITH* flags
+      def geosearch(key, frommember: nil, fromlonlat: nil, byradius: nil, bybox: nil,
+                    sort: nil, count: nil, count_any: false,
+                    withcoord: false, withdist: false, withhash: false)
+        args = [key]
+        args << "FROMMEMBER" << frommember if frommember
+        args << "FROMLONLAT" << fromlonlat[0] << fromlonlat[1] if fromlonlat
+        args << "BYRADIUS" << byradius[0] << byradius[1] if byradius
+        args << "BYBOX" << bybox[0] << bybox[1] << bybox[2] if bybox
+
+        options = []
+        options << "WITHCOORD" if withcoord
+        options << "WITHDIST" if withdist
+        options << "WITHHASH" if withhash
+
+        geoarguments = _geoarguments(*args, sort: sort, count: count, count_any: count_any, options: options)
+
+        send_command([:geosearch, *geoarguments])
+      end
+
       # Returns the distance between two members of a geospatial index
       #
       # @param [String ]key
@@ -73,10 +118,13 @@ class Redis
 
       private
 
-      def _geoarguments(*args, options: nil, sort: nil, count: nil)
+      def _geoarguments(*args, options: nil, sort: nil, count: nil, count_any: false)
         args << sort if sort
-        args << 'COUNT' << Integer(count) if count
-        args << options if options
+        if count
+          args << 'COUNT' << Integer(count)
+          args << 'ANY' if count_any
+        end
+        args.concat(Array(options))
         args
       end
     end

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -986,6 +986,14 @@ class Redis
       node_for(key).geosearch(key, **options)
     end
 
+    # Like #geosearch, but stores the result in a destination key.
+    # Destination and source must hash to the same node; use a key tag to ensure that.
+    def geosearchstore(destination, source, **options)
+      ensure_same_node(:geosearchstore, [destination, source]) do |node|
+        node.geosearchstore(destination, source, **options)
+      end
+    end
+
     # Post a message to a channel.
     def publish(channel, message)
       node_for(channel).publish(channel, message)

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -949,6 +949,11 @@ class Redis
       node_for(key).hpttl(key, *fields)
     end
 
+    # Search a geospatial index for members within a given shape from a center point.
+    def geosearch(key, **options)
+      node_for(key).geosearch(key, **options)
+    end
+
     # Post a message to a channel.
     def publish(channel, message)
       node_for(channel).publish(channel, message)

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -949,6 +949,38 @@ class Redis
       node_for(key).hpttl(key, *fields)
     end
 
+    # Add one or more geospatial items to a sorted set.
+    def geoadd(key, *member)
+      node_for(key).geoadd(key, *member)
+    end
+
+    # Get geohash strings representing the position of one or more members.
+    def geohash(key, member)
+      node_for(key).geohash(key, member)
+    end
+
+    # Get longitude and latitude of one or more members of a geospatial index.
+    def geopos(key, member)
+      node_for(key).geopos(key, member)
+    end
+
+    # Get the distance between two members of a geospatial index.
+    def geodist(key, member1, member2, unit = 'm')
+      node_for(key).geodist(key, member1, member2, unit)
+    end
+
+    # Query a geospatial index for members within a given radius from a point.
+    def georadius(*args, **geoptions)
+      key = args.first
+      node_for(key).georadius(*args, **geoptions)
+    end
+
+    # Query a geospatial index for members within a given radius from an existing member.
+    def georadiusbymember(*args, **geoptions)
+      key = args.first
+      node_for(key).georadiusbymember(*args, **geoptions)
+    end
+
     # Search a geospatial index for members within a given shape from a center point.
     def geosearch(key, **options)
       node_for(key).geosearch(key, **options)

--- a/specs/adding-commands.md
+++ b/specs/adding-commands.md
@@ -1,0 +1,638 @@
+# Adding a New Command to redis-rb
+
+A practical, end-to-end guide for adding support for a new Redis command (or a new wrapper around an existing one). Covers every place you need to touch, the patterns to follow, and the testing matrix that will catch the mistakes most contributors make.
+
+If you read only one thing: in the typical case you edit **two files** (the command module and `distributed.rb`) and add **two or three test files** (one lint module + per-client test stubs). Everything else is automated by the project's structure.
+
+---
+
+## 1. Where the command DSL lives
+
+### File layout
+
+The high-level command DSL is split per Redis category under `lib/redis/commands/`:
+
+```
+lib/redis/commands.rb              # the umbrella Commands module
+lib/redis/commands/bitmaps.rb
+lib/redis/commands/cluster.rb
+lib/redis/commands/connection.rb
+lib/redis/commands/geo.rb
+lib/redis/commands/hashes.rb
+lib/redis/commands/hyper_log_log.rb
+lib/redis/commands/keys.rb
+lib/redis/commands/lists.rb
+lib/redis/commands/pubsub.rb
+lib/redis/commands/scripting.rb
+lib/redis/commands/server.rb
+lib/redis/commands/sets.rb
+lib/redis/commands/sorted_sets.rb
+lib/redis/commands/streams.rb
+lib/redis/commands/strings.rb
+lib/redis/commands/transactions.rb
+```
+
+Match the category to what the [Redis command reference](https://redis.io/commands/) groups the command under. If in doubt, look at the existing neighbors of the most similar command.
+
+### How they compose
+
+Each file defines a `module` namespaced under `Redis::Commands::<Category>` containing plain instance methods. The umbrella module (`lib/redis/commands.rb:20-37`) `include`s all of them:
+
+```ruby
+module Commands
+  include Bitmaps
+  include Cluster
+  include Connection
+  include Geo
+  include Hashes
+  include HyperLogLog
+  include Keys
+  include Lists
+  include Pubsub
+  include Scripting
+  include Server
+  include Sets
+  include SortedSets
+  include Streams
+  include Strings
+  include Transactions
+  ...
+end
+```
+
+`Commands` is then mixed in to:
+
+- `Redis` (`lib/redis.rb:37`) — standalone and sentinel-configured clients
+- `Redis::PipelinedConnection` and `Redis::MultiConnection` (`lib/redis/pipeline.rb:15`, `:59`) — the block-yielded objects inside `pipelined` / `multi`
+- Transitively into `Redis::Cluster` via inheritance (`cluster/lib/redis/cluster.rb:6`: `class Redis::Cluster < ::Redis`)
+
+**Practical consequence:** one method definition in `lib/redis/commands/<category>.rb` becomes callable on every client type and inside every pipeline/transaction. The one exception is `Redis::Distributed`, which does **not** include `Commands` — see §6.
+
+### Anatomy of a command method
+
+The simplest possible command takes a key and returns whatever the server returns:
+
+```ruby
+# lib/redis/commands/strings.rb
+def get(key)
+  send_command([:get, key])
+end
+```
+
+Three rules apply to every command method:
+
+1. **Build a command array** of the form `[:verb, *args]`. The verb is a `Symbol`; the rest are positional args in the order they go on the wire. `redis-client` will serialize symbols and integers/floats to strings.
+2. **Call `send_command`** (or `send_blocking_command` if blocking) — never reach for `@client` directly. The mixing class provides the right implementation: `Redis#send_command` synchronizes and translates errors; `PipelinedConnection#send_command` buffers and returns a `Future`.
+3. **Coerce arguments at the boundary** when the type matters. Use `Integer(x)`, `Float(x)`, `value.to_s` to fail fast on bad input. Examples in `lib/redis/commands/strings.rb:27-29`:
+
+   ```ruby
+   def decrby(key, decrement)
+     send_command([:decrby, key, Integer(decrement)])
+   end
+   ```
+
+   The `Integer(decrement)` raises `TypeError` for non-numeric input, which is better than letting the server return a confusing protocol error.
+
+### Adding keyword-flag commands
+
+For commands with optional flags (most Redis 6+ commands), follow the `SET` pattern (`lib/redis/commands/strings.rb:83-99`):
+
+```ruby
+def set(key, value, ex: nil, px: nil, exat: nil, pxat: nil, nx: nil, xx: nil, keepttl: nil, get: nil)
+  args = [:set, key, value.to_s]
+  args << "EX" << Integer(ex) if ex
+  args << "PX" << Integer(px) if px
+  args << "EXAT" << Integer(exat) if exat
+  args << "PXAT" << Integer(pxat) if pxat
+  args << "NX" if nx
+  args << "XX" if xx
+  args << "KEEPTTL" if keepttl
+  args << "GET" if get
+
+  if nx || xx
+    send_command(args, &BoolifySet)
+  else
+    send_command(args)
+  end
+end
+```
+
+- Use keyword args (`ex: nil`) for flags. Avoid positional booleans.
+- Build the array imperatively with `args << "FLAG"`. Don't use conditional array literals — they get unreadable fast.
+- Capitalize flag names (`"EX"`, `"NX"`, `"WITHSCORES"`) — Redis is case-insensitive on the wire but the convention is uppercase.
+- If the **return shape depends on flags** (e.g., `SET NX` returns `nil` instead of `"OK"` on conflict), branch the `send_command` call as `set` does — pass the appropriate reshape lambda (§4) per branch.
+
+### YARD docstrings
+
+Every public command method carries a YARD docstring with `@param`, `@option` (for keyword args), `@return`, `@example`, and `@see` where relevant. This drives `rubydoc.info` documentation. Match the style of the surrounding methods exactly; the docs are how users learn the API surface.
+
+```ruby
+# Increment the integer value of a key by one.
+#
+# @example
+#   redis.incr("value")
+#     # => 6
+#
+# @param [String] key
+# @return [Integer] value after incrementing it
+def incr(key)
+  send_command([:incr, key])
+end
+```
+
+### What goes in `Commands::<Category>` vs elsewhere
+
+- **Per-key Redis verbs** → the appropriate `Commands::<Category>` module.
+- **Connection-lifecycle commands** (AUTH, PING, ECHO, SELECT, QUIT) → `Commands::Connection`. Note that `quit` (`lib/redis/commands/connection.rb:43-50`) deliberately uses `synchronize` directly and swallows `ConnectionError` — these patterns exist for the connection layer specifically.
+- **Server-wide commands** (FLUSHALL, BGSAVE, INFO, DEBUG) → `Commands::Server`.
+- **Pub/Sub** is special — it goes in `Commands::Pubsub` and routes through `Redis#_subscription` (`lib/redis.rb:166-189`) rather than `send_command`. Only add to this module if you understand the second-socket model; see §3.
+
+---
+
+## 2. Command execution flow
+
+Trace a single `redis.incr("k")` through the stack so you know what each layer does and where to intervene if something is wrong.
+
+```
+User call:   redis.incr("k")
+              │
+              ▼
+Commands::Strings#incr                     lib/redis/commands/strings.rb:39
+   builds [:incr, "k"], calls send_command
+              │
+              ▼
+Redis#send_command                         lib/redis.rb:152-158
+   - acquires @monitor (reentrant lock)
+   - rescues RedisClient::Error → Redis::* translation
+              │
+              ▼
+Redis::Client#call_v                       lib/redis/client.rb:96-100
+   - rescues RedisClient::Error → translate_error!
+              │
+              ▼
+RedisClient#call_v                         (redis-client gem, external)
+   - ensure_connected: opens socket on first use, runs handshake
+   - serializes [:incr, "k"] to RESP bytes
+   - writes to socket
+   - reads RESP reply, returns native Ruby value
+              │
+              ▼ (raw reply, e.g. Integer 7)
+optional reshape block (lambda passed via &)
+   e.g. &Floatify, &Hashify, &BoolifySet
+              │
+              ▼
+return value to caller
+```
+
+Two important facts about this flow:
+
+- **Connect is lazy.** The first call triggers `RedisClient#ensure_connected`, which opens the socket, runs the `connection_prelude` (HELLO/AUTH, SELECT, CLIENT SETINFO, then CLIENT SETNAME and ROLE), and caches the connection. Subsequent calls reuse it. Don't try to "warm" a connection by calling `Redis.new` and assume the socket is open.
+- **`send_command` is private and protocol-coupled.** Don't expose it. If a command needs special pre/post processing, put the logic in the public command method, not by overriding `send_command`.
+
+### Pipelines and transactions
+
+Inside `redis.pipelined { |p| p.incr("k") }`, `p` is a `Redis::PipelinedConnection` that also `include`s `Commands` (`lib/redis/pipeline.rb:15`). The same `incr` method is invoked, but `PipelinedConnection#send_command` (`lib/redis/pipeline.rb:40-47`) buffers the command and returns a `Redis::Future` instead of the value:
+
+```ruby
+def send_command(command, &block)
+  future = Future.new(command, block, @exception)
+  @pipeline.call_v(command) do |result|
+    future._set(result)
+  end
+  @futures << future
+  future
+end
+```
+
+**Implication:** if your command method does *anything* other than `send_command(args, &block)` — for instance, calls a second command, transforms the result before reshape, or branches based on the reply — that logic will execute differently in pipelines. Test the pipelined path explicitly (§6).
+
+### Blocking commands
+
+For commands that block on the server side (BLPOP, BRPOP, XREAD with BLOCK, etc.), use `send_blocking_command` instead of `send_command`. It accepts a `timeout` parameter that's added on top of the connection's read timeout to avoid spurious timeouts:
+
+```ruby
+def blpop(*args)
+  timeout = args.last.is_a?(Numeric) ? args.pop : 0
+  send_blocking_command([:blpop, *args, timeout], timeout)
+end
+```
+
+`Redis#send_blocking_command` (`lib/redis.rb:160-164`) inflates the client read timeout for the duration of the call. Inside a `multi { }` block, blocking commands are downgraded to non-blocking (`lib/redis/pipeline.rb:64-71`) per Redis server semantics — you don't need to handle that.
+
+---
+
+## 3. Relations with downstream libraries
+
+### The dependency tree
+
+```
+redis-rb (this repo, lib/)                  ← high-level DSL
+  └─ redis-client (Shopify)                 ← RESP parser, sockets, sentinel, pipelines
+
+redis-clustering (this repo, cluster/)      ← Redis::Cluster < Redis
+  ├─ redis (above)                          ← pinned to exact same version
+  └─ redis-cluster-client (Shopify)         ← cluster topology, slot routing
+       └─ redis-client                      ← shared base
+```
+
+Important facts:
+
+- The cluster gem **depends on `redis`** (`cluster/redis-clustering.gemspec:49`: `s.add_runtime_dependency('redis', s.version)`), pinned to the exact same version. Both gemspecs read from the same `lib/redis/version.rb`, so one version bump moves both gems together — you never edit the dependency line by hand.
+- `redis-cluster-client` does **not** depend on `redis-rb`. It is a peer driver, not a downstream consumer.
+- `redis-cluster-client` is unaware of the redis-rb DSL. It receives command arrays (e.g. `["INCR", "k"]`) and routes them based on the command name, looking up key positions in a catalog built from the Redis server's own `COMMAND` introspection.
+
+### What this means when you add a command
+
+| You add… | Where the change lives | Coordination needed with downstream? |
+| --- | --- | --- |
+| A Ruby wrapper around an existing Redis verb | `lib/redis/commands/<category>.rb` | None. `redis-client` already knows how to serialize/parse it; `redis-cluster-client` already knows how to route it. |
+| A Ruby wrapper around a brand-new Redis verb (newly added in some Redis version) | Same as above | None *at runtime*, provided your Redis server is recent enough that `COMMAND` describes the new verb. For routing-fast-path optimization, `redis-cluster-client` may need a catalog update, but routing is correct either way (it falls back to MOVED-follow). |
+| A new client-side reshape of an existing verb | Same as above + a reshape lambda (§4) | None. Reshapes live entirely in redis-rb. |
+| Behavior that needs RESP3 protocol features (push messages, native maps, client tracking) | Not supported in redis-rb. Drop down to `RedisClient` directly. | n/a — see CLAUDE.md "RESP2 invariant" |
+
+### The error translation contract
+
+Every error class that crosses the boundary from `redis-client` into `redis-rb` is remapped via `Redis::Client::ERROR_MAPPING` (`lib/redis/client.rb:5-20`). If your new command can raise a `RedisClient::Error` subclass that's not already in the mapping, add an entry. The cluster gem extends this in `Redis::Cluster::Client::ERROR_MAPPING` (`cluster/lib/redis/cluster/client.rb:9-16`) for cluster-only error types — add there too if cluster has a specific case.
+
+Do not catch `RedisClient::Error` inside a command method. Let it propagate to `Redis::Client#call_v` and be translated centrally.
+
+---
+
+## 4. The reshape callback layer
+
+### What it is
+
+Many Redis commands return reply shapes that aren't idiomatic Ruby — flat arrays where a Hash would be natural, string `"3.14"` where a `Float` would be natural, integer `0`/`1` where a `Boolean` would be natural. redis-rb shapes these at the redis-rb layer via small lambda constants at the top of `lib/redis/commands.rb:42-194`.
+
+The lambdas are passed as block arguments to `send_command`:
+
+```ruby
+def incrbyfloat(key, increment)
+  send_command([:incrbyfloat, key, Float(increment)], &Floatify)
+end
+```
+
+`send_command` forwards the block to `redis-client`, which calls it on the raw reply before returning. So the user sees `1.23` (a Float), not `"1.23"` (a string).
+
+### The catalog
+
+These are the existing reshape lambdas. **Reuse before you invent.**
+
+| Lambda | Use case | Example |
+| --- | --- | --- |
+| `Boolify` | Integer `0`/`1` reply → `false`/`true`. Passes `nil` through. | `EXISTS`, `EXPIRE`, `SETNX` |
+| `BoolifySet` | `"OK"` → `true`, `nil` → `false`, anything else passes through. For commands like `SET NX/XX` that may not execute. | `SET nx: true` |
+| `Hashify` | Flat `[k1, v1, k2, v2]` array → `{ k1 => v1, k2 => v2 }`. | `HGETALL`, `CONFIG GET` |
+| `Pairify` | Flat array → array of `[k, v]` pairs. Like `Hashify` but preserves duplicates and ordering. | (less common) |
+| `Floatify` | `"inf"`/`"-inf"`/numeric string → `Float`. Pass-through for non-strings. | `INCRBYFLOAT`, `ZSCORE`, `HINCRBYFLOAT` |
+| `FloatifyPair` | `[member, score_str]` → `[member, Float]`. | Used inside `FloatifyPairs`. |
+| `FloatifyPairs` | Flat `[m1, s1, m2, s2]` → `[[m1, f1], [m2, f2]]`. | `ZRANGE WITHSCORES`, `ZRANGEBYSCORE WITHSCORES` |
+| `HashifyInfo` | Parses the `INFO` text format into a Hash. | `INFO` |
+| `HashifyStreamEntries` | `XRANGE`/`XREVRANGE` array → array of `[id, {field=>value,...}]`. | `XRANGE` family |
+| `HashifyStreams` | `XREAD` reply → `{ stream_name => [entries] }`. | `XREAD`, `XREADGROUP` |
+| `HashifyStreamAutoclaim` / `HashifyStreamAutoclaimJustId` | `XAUTOCLAIM` reply shaping. | `XAUTOCLAIM` |
+| `HashifyStreamPendings` / `HashifyStreamPendingDetails` | `XPENDING` reply shaping. | `XPENDING` |
+| `HashifyClusterNodes` / `HashifyClusterSlots` / `HashifyClusterSlaves` / `HashifyClusterNodeInfo` | Parse `CLUSTER *` replies. | `CLUSTER NODES`, `CLUSTER SLOTS` |
+| `Noop` | Identity. Used to satisfy interfaces that require a block. | rare |
+
+### Adding a new lambda
+
+If — and only if — none of the above fits, add a new lambda constant to `lib/redis/commands.rb` near the existing family. Conventions:
+
+- Name it after the *shape* it produces, not the command it belongs to. `Hashify`, `Floatify`, `Pairify` — these names imply the transformation. Naming a lambda `XInfoifier` is wrong; if it parses XINFO, call it `HashifyStreamInfo`.
+- Make it a `lambda { |value| ... }` — not a `proc`, not a `Proc.new`. Match the style.
+- Handle `nil` explicitly. Most Redis replies can be `nil` (key didn't exist), and your lambda will be called on `nil`. Either pass `nil` through (`return nil if value.nil?`) or define its semantics deliberately.
+- Don't depend on instance state. The lambdas are class-level constants — they receive only the reply value, nothing else.
+
+### When to inline vs use a lambda
+
+Use a lambda when:
+
+- The transformation is reused by multiple commands (`Hashify` is shared by HGETALL, CONFIG GET, etc.)
+- The transformation is one expression (slice, hash, parse)
+- You want it to run inside pipelines automatically (the lambda is invoked when the Future resolves)
+
+Do the work inside the command method instead when:
+
+- The transformation needs other arguments (e.g., `mapped_mget` zips the keys with the reply — see `lib/redis/commands/strings.rb:219-227`):
+
+  ```ruby
+  def mapped_mget(*keys)
+    mget(*keys) do |reply|
+      if reply.is_a?(Array)
+        Hash[keys.zip(reply)]
+      else
+        reply
+      end
+    end
+  end
+  ```
+
+  Here the block closes over `keys`, so it can't be a stateless constant lambda.
+
+### Important: do NOT coerce raw bytes back to strings
+
+`redis-client` already decodes RESP strings to Ruby strings. Don't call `value.to_s` or `String(value)` inside a reshape lambda for reply data — it's already a string. Coerce *arguments* before they hit the wire (`value.to_s`, `Integer(x)`); never coerce replies post-hoc.
+
+---
+
+## 5. Redis::Distributed
+
+`Redis::Distributed` is a separate top-level class (`lib/redis/distributed.rb`) implementing client-side consistent-hash sharding across N independent standalone Redis servers. It is **not** the Redis Cluster protocol — there are no slot maps, no MOVED redirects, no automatic resharding. It is supported and actively maintained (it gets new commands in roughly every release).
+
+### Why it needs its own implementation
+
+`Redis::Distributed` does **not** `include Commands`. Every command is hand-written, because each command needs to be explicitly routed to the right underlying `Redis` instance via `node_for(key)`. The ring uses `Zlib.crc32` of the key against an MD5-hashed virtual-node ring (160 vnodes per server, `lib/redis/hash_ring.rb:8`).
+
+Multi-key commands raise `Redis::Distributed::CannotDistribute` because keys may live on different nodes and the operation isn't atomic across nodes.
+
+### The two patterns
+
+**Single-key commands** route to one node:
+
+```ruby
+# lib/redis/distributed.rb (typical pattern)
+def incr(key)
+  node_for(key).incr(key)
+end
+
+def set(key, value, **options)
+  node_for(key).set(key, value, **options)
+end
+```
+
+**Multi-key commands** either iterate or raise. Look at how `mget` handles it (in `lib/redis/distributed.rb`, search for `mget`) — it groups keys by node, calls `mget` on each, and reassembles results in original order. If your command can't be safely split across nodes, raise:
+
+```ruby
+def sinterstore(destination, *keys)
+  ensure_same_node(:sinterstore, [destination, *keys]) do |node|
+    node.sinterstore(destination, *keys)
+  end
+end
+```
+
+`ensure_same_node` (defined in `Redis::Distributed`) checks that all keys hash to the same node — if not, it raises `CannotDistribute`. Users can force same-node placement using key tags (`"{group}:key1"`, `"{group}:key2"`) — see `node_for` (`lib/redis/distributed.rb:30-35`).
+
+### Server-wide commands
+
+For commands that don't take a key (FLUSHALL, BGSAVE, INFO, etc.), apply to every node and return a collection:
+
+```ruby
+def flushall
+  on_each_node :flushall
+end
+```
+
+`on_each_node` returns an Array with one entry per node, in `@ring.nodes` order. Existing examples at `lib/redis/distributed.rb:55-115`.
+
+### Pub/Sub in Distributed
+
+Pub/Sub in `Redis::Distributed` pins the subscription to a single node based on the channel name. This is structurally limited — patterns that span channels across nodes don't work. If your command interacts with pub/sub, follow the existing `subscribe` / `unsubscribe` patterns in `distributed.rb`.
+
+### Skipping Distributed
+
+Some commands genuinely make no sense in a distributed setting — `MIGRATE`, `WAIT`, `MONITOR`. The convention is to raise `NotImplementedError` (`lib/redis/distributed.rb:104-106`):
+
+```ruby
+def monitor
+  raise NotImplementedError
+end
+```
+
+If you're adding a command that fundamentally doesn't work in Distributed, do this rather than omitting it (omission becomes a `NoMethodError` for users, which is worse than an explicit `NotImplementedError`).
+
+---
+
+## 6. Testing
+
+### The four test groups
+
+The Rakefile (`Rakefile:8-32`) defines four `Rake::TestTask` groups, all required to pass by the default `rake test` task:
+
+```
+test/redis/              → bundle exec rake test:redis        # standalone
+test/distributed/        → bundle exec rake test:distributed  # Redis::Distributed
+test/sentinel/           → bundle exec rake test:sentinel     # sentinel mode
+cluster/test/            → bundle exec rake test:cluster      # redis-clustering gem
+```
+
+The Rakefile **fails the build** if a `*_test.rb` file exists outside these directories (`Rakefile:19-22`). Don't drop tests anywhere else.
+
+### The lint-module pattern (the key idea)
+
+Tests for command behavior are written **once** in a shared lint module under `test/lint/<category>.rb`, then included by each per-client test class. This is the project's most important testing pattern — it lets the same assertions run against standalone, distributed, sentinel, and cluster topologies without copy-paste.
+
+The lint modules already exist for each category:
+
+```
+test/lint/strings.rb
+test/lint/hashes.rb
+test/lint/lists.rb
+test/lint/sets.rb
+test/lint/sorted_sets.rb
+test/lint/hyper_log_log.rb
+test/lint/streams.rb
+test/lint/value_types.rb
+test/lint/blocking_commands.rb
+test/lint/authentication.rb
+```
+
+A lint module looks like (`test/lint/strings.rb`):
+
+```ruby
+module Lint
+  module Strings
+    def test_set_and_get
+      r.set("foo", "s1")
+      assert_equal "s1", r.get("foo")
+    end
+
+    def test_set_with_ex
+      r.set("foo", "bar", ex: 2)
+      assert_in_range 0..2, r.ttl("foo")
+    end
+    ...
+  end
+end
+```
+
+It uses `r` (the test helper's alias for `@redis`, set up in `test/helper.rb:96`). Per-client tests then mix the lint module in alongside the helper for that topology:
+
+```ruby
+# test/redis/commands_on_strings_test.rb
+class TestCommandsOnStrings < Minitest::Test
+  include Helper::Client
+  include Lint::Strings
+end
+
+# test/distributed/commands_on_strings_test.rb
+class TestDistributedCommandsOnStrings < Minitest::Test
+  include Helper::Distributed
+  include Lint::Strings
+
+  # Plus distributed-specific tests that don't apply to standalone
+  def test_mget
+    ...
+  end
+end
+
+# cluster/test/commands_on_strings_test.rb
+class TestClusterCommandsOnStrings < Minitest::Test
+  include Helper::Cluster
+  include Lint::Strings
+
+  def mock(*args, &block)
+    redis_cluster_mock(*args, &block)
+  end
+end
+```
+
+**The sentinel test group does not include lint modules** for command behavior — sentinel mode shares the standalone client implementation, so re-running every string test against a sentinel-resolved master adds CI time without finding new bugs. Sentinel tests focus on failover, role checks, and config resolution (see `test/sentinel/`).
+
+### Where to add what
+
+When you add a new command, add tests in this order:
+
+1. **Add lint-module test(s) to `test/lint/<category>.rb`.** Cover:
+   - The happy path with a representative argument.
+   - Each optional flag your method accepts (one test per non-trivial flag combination).
+   - The empty / nil / missing-key case (most Redis commands have a defined nil-reply behavior).
+   - Any reshape: assert on the *Ruby type* the user gets, not the raw reply.
+2. **Verify the lint module is reused.** Open `test/redis/commands_on_<category>_test.rb` and `cluster/test/commands_on_<category>_test.rb` — they should already `include Lint::<Category>`. If they do, you get standalone + cluster coverage automatically.
+3. **Add Distributed-specific tests under `test/distributed/`.** Because Distributed has its own method implementation, the lint module isn't always enough — write tests that exercise routing, the `CannotDistribute` path for unsafe multi-key uses, and any key-tag scenarios.
+4. **If the command has cluster-specific behavior** (atypical for ordinary single-key commands), add tests to `cluster/test/commands_on_<category>_test.rb` beyond the included lint module.
+
+### Version constraints
+
+The makefile defaults to building Redis `8.4` from source (`makefile:1`: `REDIS_BRANCH ?= 8.4`), but tests still need to skip cleanly on older versions where appropriate. Two helpers in `test/helper.rb`:
+
+- **`target_version(version) { ... }`** (`test/helper.rb:153-159`) — runs the block only if the server is at least that version, skips otherwise. Use this when most of a test depends on a newer feature:
+
+  ```ruby
+  def test_set_with_exat
+    target_version "6.2" do
+      r.set("foo", "bar", exat: Time.now.to_i + 2)
+      assert_in_range 0..2, r.ttl("foo")
+    end
+  end
+  ```
+
+- **`omit_version(min_ver)`** (`test/helper.rb:166-168`) — early-skip the whole test:
+
+  ```ruby
+  def test_my_command
+    omit_version("7.4")
+    r.my_new_command(...)
+  end
+  ```
+
+Both rely on `version` (which reads `INFO redis_version`, `test/helper.rb:170-172`) and `Helper::Version` for comparison.
+
+**Always gate tests for commands introduced in a specific Redis version.** CI runs against multiple Redis versions (see `.github/workflows/`); ungated tests will break older-version runs.
+
+### Running tests locally
+
+```sh
+# Bring up servers (standalone, replica, sentinel quorum, 6-node cluster)
+make start_all
+
+# Run everything
+make test
+
+# One group
+bundle exec rake test:redis
+bundle exec rake test:distributed
+bundle exec rake test:sentinel
+bundle exec rake test:cluster
+
+# Single file
+bundle exec rake test:redis TEST=test/redis/commands_on_strings_test.rb
+
+# Single test method (Minitest regex)
+bundle exec rake test:redis TEST=test/redis/commands_on_strings_test.rb \
+  TESTOPTS="--name=/test_set_with_ex/"
+
+# Run with hiredis instead of pure-Ruby parser
+DRIVER=hiredis bundle exec rake test
+
+# Target a different Redis version
+REDIS_BRANCH=7.2 make start_all && make test
+
+make stop_all
+```
+
+If you see `Couldn't locate the redis unix socket, did you run \`make start\`?`, the test helper checks for `tmp/redis.sock` (`test/helper.rb:29-37`). `make start_all` creates it.
+
+### Mocking when you can't use a real server
+
+For testing protocol edge cases (unexpected replies, parser errors), `test/support/redis_mock.rb` provides `RedisMock.start_with_handler { |port| ... }`. Use it sparingly — most tests benefit from running against real Redis. Look at `test/redis/error_replies_test.rb` for the pattern.
+
+### Pipelined and transactional behavior
+
+If your command does anything beyond a single `send_command` call (multiple commands, post-processing, branching on reply), **add a pipelined test**. Inside a `pipelined` block, intermediate side effects are deferred and the reply is a `Future`, not a value. Bugs here are subtle and easy to miss:
+
+```ruby
+def test_my_command_in_pipeline
+  result = r.pipelined do |pipe|
+    pipe.my_command(...)
+  end
+  assert_equal expected, result.first
+end
+```
+
+The same applies to `multi`.
+
+---
+
+## 7. Other conventions
+
+### Frozen string literals
+
+Every Ruby file in the project starts with `# frozen_string_literal: true`. Keep this when editing existing files and add it to new ones. The reshape lambdas and command-array symbols rely on string immutability.
+
+### Symbols vs strings for the verb
+
+By convention the first element of a command array is a **Symbol** (`:incr`, `:set`, `:hgetall`). The rest are strings (or values coerced to strings by `redis-client`'s serializer). Stick to this convention even though strings would work — it's how the existing 100+ commands are written and grep'ing for `:foo` finds the verb usage.
+
+### Rubocop
+
+The project uses Rubocop with `rubocop ~> 1.25.1` (intentionally pinned to an older version — see Gemfile). Run before sending a PR:
+
+```sh
+bundle exec rubocop
+```
+
+The cluster gem has its own `.rubocop.yml` under `cluster/`; lint both trees if you touched both.
+
+### Deprecation
+
+If your change deprecates an existing method or signature, use `Redis.deprecate!` (`lib/redis.rb:13-25`) to emit a warning. The infrastructure is already there — `Redis.silence_deprecations=` and `Redis.raise_deprecations=` exist to control behavior. Don't roll your own deprecation mechanism.
+
+---
+
+## 8. End-to-end checklist
+
+Use this when adding a new command:
+
+- [ ] Identify the right category file under `lib/redis/commands/`.
+- [ ] Implement the method:
+  - [ ] Use keyword args for flags.
+  - [ ] Coerce inputs (`Integer`, `Float`, `to_s`) at the boundary.
+  - [ ] Use `send_command` (or `send_blocking_command`).
+  - [ ] Pass an existing reshape lambda if the reply needs shaping; otherwise add a new lambda only if no existing one fits.
+  - [ ] Write a YARD docstring with `@param`, `@return`, `@example`.
+- [ ] Add Distributed support in `lib/redis/distributed.rb`:
+  - [ ] Single-key: `node_for(key).method(...)`.
+  - [ ] Multi-key: group by node, use `ensure_same_node`, or raise `CannotDistribute`.
+  - [ ] Server-wide: `on_each_node`.
+  - [ ] Conceptually incompatible: raise `NotImplementedError`.
+- [ ] Add tests:
+  - [ ] Add test methods to `test/lint/<category>.rb` (these run for standalone + cluster).
+  - [ ] Verify `test/redis/commands_on_<category>_test.rb` and `cluster/test/commands_on_<category>_test.rb` already `include Lint::<Category>`.
+  - [ ] Add distributed-specific tests to `test/distributed/commands_on_<category>_test.rb`.
+  - [ ] Gate version-specific tests with `target_version` / `omit_version`.
+  - [ ] Add a pipelined test if the command does more than `send_command(args, &block)`.
+- [ ] If a new error class is needed, add it to `lib/redis/errors.rb` and `Redis::Client::ERROR_MAPPING` (and the cluster equivalent if relevant).
+- [ ] Run locally: `make start_all && make test && bundle exec rubocop && make stop_all`.
+
+That's it. The two-gem structure and the lint-module sharing conspire to make the common case (a single Ruby method definition plus tests) the only thing you actually have to write.

--- a/test/distributed/commands_on_geo_test.rb
+++ b/test/distributed/commands_on_geo_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestDistributedCommandsOnGeo < Minitest::Test
+  include Helper::Distributed
+
+  def setup
+    super
+
+    added = r.geoadd("Sicily", 13.361389, 38.115556, "Palermo", 15.087269, 37.502669, "Catania")
+    assert_equal 2, added
+  end
+
+  def test_geoadd_with_array_params
+    added = r.geoadd("SicilyArray", [13.361389, 38.115556, "Palermo", 15.087269, 37.502669, "Catania"])
+    assert_equal 2, added
+  end
+
+  def test_geohash
+    assert_equal %w(sqc8b49rny0 sqdtr74hyu0), r.geohash("Sicily", %w(Palermo Catania))
+  end
+
+  def test_geopos
+    location = r.geopos("Sicily", "Palermo")
+    assert_equal 1, location.size
+    assert_equal 2, location.first.size
+  end
+
+  def test_geodist
+    assert_equal "166274.1516", r.geodist("Sicily", "Palermo", "Catania")
+    assert_equal "166.2742", r.geodist("Sicily", "Palermo", "Catania", "km")
+  end
+
+  def test_georadius
+    nearest = r.georadius("Sicily", 15, 37, 200, "km", sort: "asc")
+    assert_equal %w(Catania Palermo), nearest
+  end
+
+  def test_georadiusbymember
+    nearest = r.georadiusbymember("Sicily", "Catania", 200, "km", sort: "asc")
+    assert_equal %w(Catania Palermo), nearest
+  end
+
+  def test_geosearch
+    target_version "6.2" do
+      members = r.geosearch("Sicily", fromlonlat: [15, 37], byradius: [200, "km"], sort: "asc")
+      assert_equal %w(Catania Palermo), members
+    end
+  end
+end

--- a/test/distributed/commands_on_geo_test.rb
+++ b/test/distributed/commands_on_geo_test.rb
@@ -48,4 +48,20 @@ class TestDistributedCommandsOnGeo < Minitest::Test
       assert_equal %w(Catania Palermo), members
     end
   end
+
+  def test_geosearchstore_same_node
+    target_version "6.2" do
+      r.geoadd("{tag}.src", 13.361389, 38.115556, "Palermo", 15.087269, 37.502669, "Catania")
+      stored = r.geosearchstore("{tag}.dest", "{tag}.src", fromlonlat: [15, 37], byradius: [200, "km"])
+      assert_equal 2, stored
+    end
+  end
+
+  def test_geosearchstore_cross_node_raises
+    target_version "6.2" do
+      assert_raises(Redis::Distributed::CannotDistribute) do
+        r.geosearchstore("dest", "Sicily", fromlonlat: [15, 37], byradius: [200, "km"])
+      end
+    end
+  end
 end

--- a/test/redis/commands_on_geo_test.rb
+++ b/test/redis/commands_on_geo_test.rb
@@ -116,4 +116,76 @@ class TestCommandsGeo < Minitest::Test
     geohashes = r.geohash("Sicily", ["Palermo", "Rome"])
     assert_equal ["sqc8b49rny0", nil], geohashes
   end
+
+  def test_geosearch_with_frommember
+    target_version "6.2" do
+      members = r.geosearch("Sicily", frommember: "Catania", byradius: [200, "km"], sort: "asc")
+      assert_equal %w(Catania Palermo), members
+    end
+  end
+
+  def test_geosearch_with_fromlonlat
+    target_version "6.2" do
+      members = r.geosearch("Sicily", fromlonlat: [15, 37], byradius: [200, "km"], sort: "asc")
+      assert_equal %w(Catania Palermo), members
+    end
+  end
+
+  def test_geosearch_with_byradius
+    target_version "6.2" do
+      members = r.geosearch("Sicily", fromlonlat: [15, 37], byradius: [100, "km"])
+      assert_equal %w(Catania), members
+    end
+  end
+
+  def test_geosearch_with_bybox
+    target_version "6.2" do
+      members = r.geosearch("Sicily", fromlonlat: [15, 37], bybox: [400, 400, "km"], sort: "asc")
+      assert_equal %w(Catania Palermo), members
+    end
+  end
+
+  def test_geosearch_with_sort
+    target_version "6.2" do
+      nearest = r.geosearch("Sicily", fromlonlat: [15, 37], byradius: [200, "km"], sort: "asc")
+      assert_equal %w(Catania Palermo), nearest
+
+      farthest = r.geosearch("Sicily", fromlonlat: [15, 37], byradius: [200, "km"], sort: "desc")
+      assert_equal %w(Palermo Catania), farthest
+    end
+  end
+
+  def test_geosearch_with_count
+    target_version "6.2" do
+      members = r.geosearch("Sicily", fromlonlat: [15, 37], byradius: [200, "km"], sort: "asc", count: 1)
+      assert_equal %w(Catania), members
+    end
+  end
+
+  def test_geosearch_with_count_any
+    target_version "6.2" do
+      members = r.geosearch("Sicily", fromlonlat: [15, 37], byradius: [200, "km"], count: 1, count_any: true)
+      assert_equal 1, members.size
+    end
+  end
+
+  def test_geosearch_with_withcoord_withdist_withhash
+    target_version "6.2" do
+      result = r.geosearch("Sicily", fromlonlat: [15, 37], byradius: [200, "km"],
+                                     sort: "asc", withcoord: true, withdist: true, withhash: true)
+      assert_equal 2, result.size
+
+      catania = result[0]
+      assert_equal "Catania", catania[0]
+      assert_equal "56.4413", catania[1]
+      assert_kind_of Integer, catania[2]
+      assert_equal coordinates_catania, catania[3]
+
+      palermo = result[1]
+      assert_equal "Palermo", palermo[0]
+      assert_equal "190.4424", palermo[1]
+      assert_kind_of Integer, palermo[2]
+      assert_equal coordinates_palermo, palermo[3]
+    end
+  end
 end

--- a/test/redis/commands_on_geo_test.rb
+++ b/test/redis/commands_on_geo_test.rb
@@ -188,4 +188,58 @@ class TestCommandsGeo < Minitest::Test
       assert_equal coordinates_palermo, palermo[3]
     end
   end
+
+  def test_geosearchstore_with_frommember
+    target_version "6.2" do
+      stored = r.geosearchstore("dest", "Sicily", frommember: "Catania", byradius: [200, "km"])
+      assert_equal 2, stored
+      assert_equal %w(Catania Palermo).sort, r.zrange("dest", 0, -1).sort
+    end
+  end
+
+  def test_geosearchstore_with_fromlonlat
+    target_version "6.2" do
+      stored = r.geosearchstore("dest", "Sicily", fromlonlat: [15, 37], byradius: [200, "km"])
+      assert_equal 2, stored
+      assert_equal %w(Catania Palermo).sort, r.zrange("dest", 0, -1).sort
+    end
+  end
+
+  def test_geosearchstore_with_byradius
+    target_version "6.2" do
+      stored = r.geosearchstore("dest", "Sicily", fromlonlat: [15, 37], byradius: [100, "km"])
+      assert_equal 1, stored
+      assert_equal %w(Catania), r.zrange("dest", 0, -1)
+    end
+  end
+
+  def test_geosearchstore_with_bybox
+    target_version "6.2" do
+      stored = r.geosearchstore("dest", "Sicily", fromlonlat: [15, 37], bybox: [400, 400, "km"])
+      assert_equal 2, stored
+      assert_equal %w(Catania Palermo).sort, r.zrange("dest", 0, -1).sort
+    end
+  end
+
+  def test_geosearchstore_with_sort_and_count
+    target_version "6.2" do
+      stored = r.geosearchstore("dest", "Sicily", fromlonlat: [15, 37], byradius: [200, "km"],
+                                                  sort: "asc", count: 1)
+      assert_equal 1, stored
+      assert_equal %w(Catania), r.zrange("dest", 0, -1)
+    end
+  end
+
+  def test_geosearchstore_with_storedist
+    target_version "6.2" do
+      stored = r.geosearchstore("dest", "Sicily", fromlonlat: [15, 37], byradius: [200, "km"],
+                                                  storedist: true)
+      assert_equal 2, stored
+      with_scores = r.zrange("dest", 0, -1, withscores: true)
+      assert_equal "Catania", with_scores[0][0]
+      assert_in_delta 56.44, with_scores[0][1], 0.01
+      assert_equal "Palermo", with_scores[1][0]
+      assert_in_delta 190.44, with_scores[1][1], 0.01
+    end
+  end
 end


### PR DESCRIPTION
Added one of the missing command API mentioned in #978. Also added Claude related context + custom skills for adding new commands. Also added a general spec for adding new commands best practices that both users and AI agents would follow to simplify contributions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive geo command API and tests; Distributed multi-key routing for GEOSEARCHSTORE is the main behavioral edge case, with no auth or data-migration impact.
> 
> **Overview**
> Adds **Redis 6.2+** client support for **`GEOSEARCH`** and **`GEOSEARCHSTORE`** via keyword options (`frommember` / `fromlonlat`, `byradius` / `bybox`, sort, count/`count_any`, `WITH*` flags, `storedist`), reusing an extended **`_geoarguments`** helper (including **`COUNT … ANY`**).
> 
> **`Redis::Distributed`** gains geo wrappers (including **`geosearchstore`** with **`ensure_same_node`** / **`CannotDistribute`** when destination and source shard apart). Integration tests cover standalone, cluster (tagged keys), and distributed routing.
> 
> Also ships contributor/AI workflow docs (**`CLAUDE.md`**, **`specs/adding-commands.md`**, Claude **add-new-command** skill), ignores **`.bundle/`**, and hardens cluster tests (**replica client warmup**, **`with_acl`** on all nodes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84cd4713794dc04c47e6eeca0a82185e412fdc8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->