### PR TITLE
Added missing Redis 6.2 compatibility

### DIFF
--- a/lib/redis/commands/geo.rb
+++ b/lib/redis/commands/geo.rb
@@ -7,9 +7,19 @@ class Redis
       #
       # @param [String] key
       # @param [Array] member arguemnts for member or members: longitude, latitude, name
-      # @return [Integer] number of elements added to the sorted set
-      def geoadd(key, *member)
-        send_command([:geoadd, key, *member])
+      # @param [Boolean] nx don't update already existing elements, always add new ones (since Redis 6.2)
+      # @param [Boolean] xx only update elements that already exist, never add new ones (since Redis 6.2)
+      # @param [Boolean] ch modify the return value to the number of changed elements (since Redis 6.2)
+      # @return [Integer] number of elements added to the sorted set, or changed when `ch` is set
+      def geoadd(key, *member, nx: false, xx: false, ch: false)
+        raise ArgumentError, "can't supply both nx and xx" if nx && xx
+
+        args = [:geoadd, key]
+        args << "NX" if nx
+        args << "XX" if xx
+        args << "CH" if ch
+        args.concat(member)
+        send_command(args)
       end
 
       # Returns geohash string representing position for specified members of the specified key.
@@ -28,6 +38,7 @@ class Redis
       # @param ['asc', 'desc'] sort sort returned items from the nearest to the farthest
       #   or the farthest to the nearest relative to the center
       # @param [Integer] count limit the results to the first N matching items
+      # @param [Boolean] count_any return as soon as enough matches found (only with count, since Redis 6.2)
       # @param ['WITHDIST', 'WITHCOORD', 'WITHHASH'] options to return additional information
       # @return [Array<String>] may be changed with `options`
       def georadius(*args, **geoptions)
@@ -43,6 +54,7 @@ class Redis
       # @param ['asc', 'desc'] sort sort returned items from the nearest to the farthest or the farthest
       #   to the nearest relative to the center
       # @param [Integer] count limit the results to the first N matching items
+      # @param [Boolean] count_any return as soon as enough matches found (only with count, since Redis 6.2)
       # @param ['WITHDIST', 'WITHCOORD', 'WITHHASH'] options to return additional information
       # @return [Array<String>] may be changed with `options`
       def georadiusbymember(*args, **geoptions)

--- a/lib/redis/commands/streams.rb
+++ b/lib/redis/commands/streams.rb
@@ -44,10 +44,11 @@ class Redis
       # @option opts [Integer] :maxlen      max length of entries to keep
       # @option opts [Integer] :minid       min id of entries to keep
       # @option opts [Boolean] :approximate whether to add `~` modifier of maxlen/minid or not
+      # @option opts [Integer] :limit       maximum count of entries to be evicted, requires approximate trimming
       # @option opts [Boolean] :nomkstream  whether to add NOMKSTREAM, default is not to add
       #
       # @return [String] the entry id
-      def xadd(key, entry, approximate: nil, maxlen: nil, minid: nil, nomkstream: nil, id: '*')
+      def xadd(key, entry, approximate: nil, maxlen: nil, minid: nil, limit: nil, nomkstream: nil, id: '*')
         args = [:xadd, key]
         args << 'NOMKSTREAM' if nomkstream
         if maxlen
@@ -61,6 +62,7 @@ class Redis
           args << "~" if approximate
           args << minid
         end
+        args.concat(['LIMIT', limit]) if limit
         args << id
         args.concat(entry.flatten)
         send_command(args)

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -950,8 +950,8 @@ class Redis
     end
 
     # Add one or more geospatial items to a sorted set.
-    def geoadd(key, *member)
-      node_for(key).geoadd(key, *member)
+    def geoadd(key, *member, **options)
+      node_for(key).geoadd(key, *member, **options)
     end
 
     # Get geohash strings representing the position of one or more members.

--- a/test/distributed/commands_on_geo_test.rb
+++ b/test/distributed/commands_on_geo_test.rb
@@ -17,6 +17,14 @@ class TestDistributedCommandsOnGeo < Minitest::Test
     assert_equal 2, added
   end
 
+  def test_geoadd_with_nx_xx_ch_options
+    target_version "6.2" do
+      assert_equal 0, r.geoadd("Sicily", 14, 38, "Palermo", nx: true)
+      assert_equal 1, r.geoadd("Sicily", 2.349014, 48.864716, "Paris", ch: true)
+      assert_equal 0, r.geoadd("Sicily", 1, 1, "Rome", xx: true)
+    end
+  end
+
   def test_geohash
     assert_equal %w(sqc8b49rny0 sqdtr74hyu0), r.geohash("Sicily", %w(Palermo Catania))
   end
@@ -40,6 +48,14 @@ class TestDistributedCommandsOnGeo < Minitest::Test
   def test_georadiusbymember
     nearest = r.georadiusbymember("Sicily", "Catania", 200, "km", sort: "asc")
     assert_equal %w(Catania Palermo), nearest
+  end
+
+  def test_georadius_with_count_any
+    target_version "6.2" do
+      cities = r.georadius("Sicily", 15, 37, 200, "km", count: 1, count_any: true)
+      assert_equal 1, cities.size
+      assert_includes %w(Catania Palermo), cities.first
+    end
   end
 
   def test_geosearch

--- a/test/lint/streams.rb
+++ b/test/lint/streams.rb
@@ -99,6 +99,29 @@ module Lint
       assert_raises(ArgumentError) { redis.xadd('s1', { f1: 'v1', f2: 'v2' }, maxlen: 2, minid: '0-1', approximate: true) }
     end
 
+    def test_xadd_with_limit_option
+      omit_version('6.2.0')
+
+      begin
+        original = redis.config(:get, 'stream-node-max-entries')['stream-node-max-entries']
+        redis.config(:set, 'stream-node-max-entries', 1)
+
+        redis.xadd('s1', { f: 'v1' }, id: '1-1')
+        redis.xadd('s1', { f: 'v2' }, id: '2-1')
+        redis.xadd('s1', { f: 'v3' }, id: '3-1')
+
+        actual = redis.xadd('s1', { f: 'v4' }, maxlen: 1, approximate: true, limit: 2)
+        assert_match ENTRY_ID_FORMAT, actual
+
+        error = assert_raises(Redis::CommandError) do
+          redis.xadd('s1', { f: 'v5' }, maxlen: 1, limit: 2)
+        end
+        assert_includes error.message, "ERR syntax error, LIMIT cannot be used without the special ~ option"
+      ensure
+        redis.config(:set, 'stream-node-max-entries', original)
+      end
+    end
+
     def test_xadd_with_nomkstream_option
       omit_version('6.2.0')
 
@@ -286,6 +309,18 @@ module Lint
       assert_equal %w(0-1 0-2), actual.map(&:first)
     end
 
+    def test_xrange_with_exclusive_range_options
+      target_version "6.2" do
+        redis.xadd('s1', { f: 'v' }, id: '0-1')
+        redis.xadd('s1', { f: 'v' }, id: '0-2')
+        redis.xadd('s1', { f: 'v' }, id: '0-3')
+
+        actual = redis.xrange('s1', '(0-1', '(0-3')
+
+        assert_equal %w(0-2), actual.map(&:first)
+      end
+    end
+
     def test_xrange_with_not_existed_stream_key
       assert_equal([], redis.xrange('not-existed'))
     end
@@ -360,6 +395,18 @@ module Lint
 
       assert_equal 2, actual.size
       assert_equal '0-3', actual.first.first
+    end
+
+    def test_xrevrange_with_exclusive_range_options
+      target_version "6.2" do
+        redis.xadd('s1', { f: 'v' }, id: '0-1')
+        redis.xadd('s1', { f: 'v' }, id: '0-2')
+        redis.xadd('s1', { f: 'v' }, id: '0-3')
+
+        actual = redis.xrevrange('s1', '(0-3', '(0-1')
+
+        assert_equal %w(0-2), actual.map(&:first)
+      end
     end
 
     def test_xrevrange_with_not_existed_stream_key
@@ -840,6 +887,23 @@ module Lint
       assert_equal 'c2', actual[2]['consumer']
       assert_equal true, actual[2]['elapsed'] >= 0
       assert_equal 1, actual[2]['count']
+    end
+
+    def test_xpending_with_exclusive_range_options
+      target_version "6.2" do
+        redis.xadd('s1', { f: 'v1' }, id: '0-1')
+        redis.xgroup(:create, 's1', 'g1', '$')
+        redis.xadd('s1', { f: 'v2' }, id: '0-2')
+        redis.xadd('s1', { f: 'v3' }, id: '0-3')
+        redis.xadd('s1', { f: 'v4' }, id: '0-4')
+        redis.xreadgroup('g1', 'c1', 's1', '>')
+
+        actual = redis.xpending('s1', 'g1', '(0-2', '(0-4', 10)
+
+        assert_equal 1, actual.size
+        assert_equal '0-3', actual[0]['entry_id']
+        assert_equal 'c1', actual[0]['consumer']
+      end
     end
 
     def test_xpending_with_range_and_idle_options

--- a/test/redis/commands_on_geo_test.rb
+++ b/test/redis/commands_on_geo_test.rb
@@ -17,6 +17,44 @@ class TestCommandsGeo < Minitest::Test
     assert_equal 2, added_items_count
   end
 
+  def test_geoadd_with_nx_option
+    target_version "6.2" do
+      # NX only adds new members, never updates existing ones
+      added = r.geoadd("Sicily", 14, 38, "Palermo", nx: true)
+      assert_equal 0, added
+      assert_equal [coordinates_palermo], r.geopos("Sicily", "Palermo")
+
+      added = r.geoadd("Sicily", 2.349014, 48.864716, "Paris", nx: true)
+      assert_equal 1, added
+    end
+  end
+
+  def test_geoadd_with_xx_option
+    target_version "6.2" do
+      # XX only updates existing members, never adds new ones
+      added = r.geoadd("Sicily", 2.349014, 48.864716, "Paris", xx: true)
+      assert_equal 0, added
+      assert_equal [nil], r.geopos("Sicily", "Paris")
+
+      r.geoadd("Sicily", 14, 38, "Palermo", xx: true)
+      refute_equal [coordinates_palermo], r.geopos("Sicily", "Palermo")
+    end
+  end
+
+  def test_geoadd_with_ch_option
+    target_version "6.2" do
+      # CH returns the count of changed (added or updated) elements
+      changed = r.geoadd("Sicily", 14, 38, "Palermo", 2.349014, 48.864716, "Paris", ch: true)
+      assert_equal 2, changed
+    end
+  end
+
+  def test_geoadd_with_both_nx_and_xx
+    assert_raises(ArgumentError) do
+      r.geoadd("Sicily", 14, 38, "Palermo", nx: true, xx: true)
+    end
+  end
+
   def test_georadius_with_same_params
     r.geoadd("Chad", 15, 15, "Kanem")
     nearest_cities = r.georadius("Chad", 15, 15, 15, 'km', sort: 'asc')
@@ -41,6 +79,14 @@ class TestCommandsGeo < Minitest::Test
     assert_equal [["Palermo", "190.4424"]], city
   end
 
+  def test_georadius_with_count_any
+    target_version "6.2" do
+      cities = r.georadius("Sicily", 15, 37, 200, 'km', count: 1, count_any: true)
+      assert_equal 1, cities.size
+      assert_includes %w(Catania Palermo), cities.first
+    end
+  end
+
   def test_georadiusbymember_with_sort
     nearest_cities = r.georadiusbymember("Sicily", "Catania", 200, 'km', sort: 'asc')
     assert_equal %w(Catania Palermo), nearest_cities
@@ -57,6 +103,14 @@ class TestCommandsGeo < Minitest::Test
   def test_georadiusbymember_with_options_count_sort
     city = r.georadiusbymember("Sicily", "Catania", 200, 'km', sort: :desc, options: :WITHDIST, count: 1)
     assert_equal [["Palermo", "166.2742"]], city
+  end
+
+  def test_georadiusbymember_with_count_any
+    target_version "6.2" do
+      cities = r.georadiusbymember("Sicily", "Catania", 200, 'km', count: 1, count_any: true)
+      assert_equal 1, cities.size
+      assert_includes %w(Catania Palermo), cities.first
+    end
   end
 
   def coordinates_catania


### PR DESCRIPTION
List of changes:

- Add exclusive range query to XPENDING (testing only)
- Add exclusive range query to X[REV]RANGE (testing only)
- Add the MINID trimming strategy and the LIMIT argument to XADD and XTRIM (only touched XADD command and missing LIMIT)
- Add the ANY argument to GEOSEARCH and GEORADIUS (testing only)
- Add the CH, NX, XX arguments to GEOADD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API options and test-only exclusive range strings; client-side validation on geoadd is limited to mutually exclusive nx/xx.
> 
> **Overview**
> Adds **Redis 6.2** client support for geo and stream commands, with matching tests and distributed forwarding.
> 
> **Geo:** `geoadd` now accepts keyword options **`nx`**, **`xx`**, and **`ch`** (with validation when both `nx` and `xx` are set). `Redis::Distributed#geoadd` forwards those options to the correct node. Docs note **`count_any`** for `georadius` / `georadiusbymember`; new tests cover `count_any` alongside existing `geosearch` behavior.
> 
> **Streams:** `xadd` gains an optional **`limit`** argument for approximate `MAXLEN`/`MINID` trimming. Lint tests add **`limit`** on `xadd` (including Redis error when `~` is missing) and **exclusive ID ranges** for `xrange`, `xrevrange`, and `xpending` by passing parenthesized start/end IDs (no new Ruby parameters).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62e3de0f38e9900fa5dd6be5108326c9e3e26e77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->