### PR TITLE
Added initial support for JSON module (JSON.SET/GET)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,6 +47,12 @@ jobs:
           - { ruby_distribution: TruffleRuby, ruby_version: "4.0" }
     env:
       REDIS_VERSION: ${{ matrix.redis_version }}
+      # RedisJSON et al. ship in Redis core only from 8.0. On the 7.2/7.4 rows the module tests
+      # run against a Redis Stack instance (port 6383) booted from the version-matched rs- tag;
+      # on >= 8 REDIS_STACK_VERSION is empty (no Stack booted) and the module tests run against
+      # the standalone instance (port 6381).
+      REDIS_STACK_VERSION: ${{ startsWith(matrix.redis_version, '7.2') && 'rs-7.2.0-v20' || startsWith(matrix.redis_version, '7.4') && 'rs-7.4.0-v8' || '' }}
+      REDIS_MODULES_PORT: ${{ (startsWith(matrix.redis_version, '7.2') || startsWith(matrix.redis_version, '7.4')) && '6383' || '6381' }}
       DRIVER: ${{ matrix.driver == 'hiredis' && 'hiredis' || 'ruby' }}
       LOW_TIMEOUT: "0.14"
       # TruffleRuby defaults to a throughput-tuned JIT mode that warms up slowly;
@@ -79,8 +85,13 @@ jobs:
       - name: Boot Redis (all topologies)
         run: docker compose --profile all up -d --wait
 
-      - name: Run standalone, distributed, sentinel suites
-        run: bundle exec rake test:redis test:distributed test:sentinel
+      # Only on Redis < 8, where modules aren't in core; on >= 8 the module tests use standalone.
+      - name: Boot Redis Stack (module tests on Redis < 8)
+        if: env.REDIS_STACK_VERSION != ''
+        run: docker compose --profile modules up -d --wait
+
+      - name: Run standalone, distributed, sentinel, module suites
+        run: bundle exec rake test:redis test:distributed test:sentinel test:modules
 
       - name: Run cluster suite
         env:
@@ -90,4 +101,4 @@ jobs:
 
       - name: Tear down Redis
         if: always()
-        run: docker compose --profile all down -v
+        run: docker compose --profile all --profile modules down -v

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,9 @@ Bundler::GemHelper.install_tasks(dir: "cluster", name: "redis-clustering")
 require 'rake/testtask'
 
 namespace :test do
-  groups = %i(redis distributed sentinel)
+  # `modules` (Redis module commands, e.g. RedisJSON) gets its own task and runs against the
+  # dedicated Redis Stack instance brought up by the `modules`/`all` compose profile.
+  groups = %i(redis distributed sentinel modules)
   groups.each do |group|
     Rake::TestTask.new(group) do |t|
       t.libs << "test"
@@ -29,6 +31,6 @@ namespace :test do
   end
 end
 
-task test: ["test:redis", "test:distributed", "test:sentinel", "test:cluster"]
+task test: ["test:redis", "test:distributed", "test:sentinel", "test:modules", "test:cluster"]
 
 task default: :test

--- a/Rakefile
+++ b/Rakefile
@@ -6,8 +6,8 @@ Bundler::GemHelper.install_tasks(dir: "cluster", name: "redis-clustering")
 require 'rake/testtask'
 
 namespace :test do
-  # `modules` (Redis module commands, e.g. RedisJSON) gets its own task and runs against the
-  # dedicated Redis Stack instance brought up by the `modules`/`all` compose profile.
+  # `modules` (Redis module commands, e.g. RedisJSON) gets its own task; in CI this runs against
+  # standalone on Redis >= 8, or a Redis Stack service started with the `modules` compose profile on older Redis.
   groups = %i(redis distributed sentinel modules)
   groups.each do |group|
     Rake::TestTask.new(group) do |t|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,14 @@
 #   docker compose --profile replica    up -d --wait   (master + replica, no sentinels)
 #   docker compose --profile sentinel   up -d --wait   (master + replica + 3 sentinels)
 #   docker compose --profile cluster    up -d --wait   (6-node cluster)
+#   docker compose --profile modules    up -d --wait   (Redis Stack instance for module tests)
 #   docker compose --profile all        up -d --wait   (everything)
 #
 # Override the Redis version with REDIS_VERSION=8.X.Y. The image is amd64-only,
 # so on Apple Silicon the platform is pinned via Rosetta emulation.
 #
 # Uses host networking so the test runner reaches services via 127.0.0.1 at the
-# ports redis-rb has used historically: 6381 / 6382 / 6400-6402 / 16380-16385.
+# ports redis-rb has used historically: 6381 / 6382 / 6383 / 6400-6402 / 16380-16385.
 # This is the simplest model that keeps sentinel and cluster reporting host-
 # reachable addresses.
 #
@@ -95,6 +96,29 @@ services:
       - ./dockers/sentinel:/redis/work
     healthcheck:
       test: ["CMD", "redis-cli", "-p", "6400", "ping"]
+      interval: 1s
+      timeout: 3s
+      retries: 30
+
+  # A standalone instance with Redis modules (e.g. RedisJSON) loaded, dedicated to the module
+  # test suite on Redis < 8 — where modules are NOT in core and need a Redis Stack image.
+  modules:
+    <<: *redis-image
+    image: redislabs/client-libs-test:${REDIS_STACK_VERSION:-rs-7.4.0-v8}
+    container_name: redis-rb-modules
+    profiles: [modules]
+    environment:
+      PORT: "6383"
+      REDIS_CLUSTER: "no"
+      PROTECTED_MODE: "no"
+    command:
+      - --include
+      - /redis/extra.conf
+    volumes:
+      - ./test/support/redis.conf:/redis/extra.conf:ro
+      - ./dockers/modules:/redis/work
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "6383", "ping"]
       interval: 1s
       timeout: 3s
       retries: 30

--- a/lib/redis/commands.rb
+++ b/lib/redis/commands.rb
@@ -8,6 +8,7 @@ require "redis/commands/hashes"
 require "redis/commands/hyper_log_log"
 require "redis/commands/keys"
 require "redis/commands/lists"
+require "redis/commands/modules/json"
 require "redis/commands/pubsub"
 require "redis/commands/scripting"
 require "redis/commands/server"
@@ -27,6 +28,7 @@ class Redis
     include HyperLogLog
     include Keys
     include Lists
+    include Json
     include Pubsub
     include Scripting
     include Server

--- a/lib/redis/commands/modules/json.rb
+++ b/lib/redis/commands/modules/json.rb
@@ -16,19 +16,30 @@ class Redis
     module Json
       # Set the JSON value at +path+ in the document stored under +key+.
       #
+      # By default +value+ is a Ruby object that is serialized to JSON text with
+      # JSON.generate. Pass +raw: true+ to send an already-encoded JSON string through
+      # untouched (no re-serialization), which avoids double-encoding pre-built JSON.
+      #
       # @example
       #   redis.json_set("doc", "$", { "a" => 1, "nested" => { "b" => 2 } })
       #     # => true
       #
+      # @example pre-encoded JSON
+      #   redis.json_set("doc", "$", '{"a":1}', raw: true)
+      #     # => true
+      #
       # @param [String] key
       # @param [String] path a JSONPath, e.g. "$" for the document root
-      # @param [Object] value any JSON-serializable Ruby object
+      # @param [Object] value a JSON-serializable Ruby object, or a pre-encoded JSON string
+      #   when +raw+ is true
       # @param [Boolean] nx only set when the path does not already exist
       # @param [Boolean] xx only set when the path already exists
+      # @param [Boolean] raw treat +value+ as an already-encoded JSON string and send it as-is
       # @return [Boolean, String] when +nx+ or +xx+ is given, +true+ on success and +false+
       #   when the condition was not met; otherwise the raw +"OK"+ reply
-      def json_set(key, path, value, nx: false, xx: false)
-        args = [:"JSON.SET", key, path, ::JSON.generate(value)]
+      def json_set(key, path, value, nx: false, xx: false, raw: false)
+        value = ::JSON.generate(value) unless raw
+        args = [:"JSON.SET", key, path, value]
         args << "NX" if nx
         args << "XX" if xx
 
@@ -41,17 +52,30 @@ class Redis
 
       # Get the JSON value(s) at one or more +paths+ in the document stored under +key+.
       #
+      # By default the reply is parsed from JSON text into a Ruby object. Pass +raw: true+ to
+      # get the unparsed JSON string back instead (no JSON.parse).
+      #
       # @example
       #   redis.json_get("doc")
       #     # => { "a" => 1, "nested" => { "b" => 2 } }
       #
+      # @example raw JSON string
+      #   redis.json_get("doc", raw: true)
+      #     # => '{"a":1,"nested":{"b":2}}'
+      #
       # @param [String] key
       # @param [Array<String>] paths zero or more JSONPath expressions; with none the whole
       #   document is returned
-      # @return [Object, nil] the parsed JSON value, or nil if the key does not exist
-      def json_get(key, *paths)
+      # @param [Boolean] raw return the unparsed JSON string instead of a parsed Ruby object
+      # @return [Object, String, nil] the parsed JSON value (or the raw JSON string when +raw+
+      #   is true), or nil if the key does not exist
+      def json_get(key, *paths, raw: false)
         send_command([:"JSON.GET", key, *paths]) do |reply|
-          reply.nil? ? nil : ::JSON.parse(reply)
+          if reply.nil? || raw
+            reply
+          else
+            ::JSON.parse(reply)
+          end
         end
       end
     end

--- a/lib/redis/commands/modules/json.rb
+++ b/lib/redis/commands/modules/json.rb
@@ -22,11 +22,15 @@ class Redis
       #
       # @example
       #   redis.json_set("doc", "$", { "a" => 1, "nested" => { "b" => 2 } })
-      #     # => true
+      #     # => "OK"
       #
       # @example pre-encoded JSON
       #   redis.json_set("doc", "$", '{"a":1}', raw: true)
-      #     # => true
+      #     # => "OK"
+      #
+      # @example conditional set with NX/XX returns a boolean
+      #   redis.json_set("doc", "$.a", 2, nx: true)
+      #     # => false
       #
       # @param [String] key
       # @param [String] path a JSONPath, e.g. "$" for the document root
@@ -37,7 +41,10 @@ class Redis
       # @param [Boolean] raw treat +value+ as an already-encoded JSON string and send it as-is
       # @return [Boolean, String] when +nx+ or +xx+ is given, +true+ on success and +false+
       #   when the condition was not met; otherwise the raw +"OK"+ reply
+      # @raise [ArgumentError] if both +nx+ and +xx+ are given (they are mutually exclusive)
       def json_set(key, path, value, nx: false, xx: false, raw: false)
+        raise ArgumentError, "nx and xx are mutually exclusive" if nx && xx
+
         value = ::JSON.generate(value) unless raw
         args = [:"JSON.SET", key, path, value]
         args << "NX" if nx

--- a/lib/redis/commands/modules/json.rb
+++ b/lib/redis/commands/modules/json.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "json"
+
+class Redis
+  module Commands
+    # Commands for the RedisJSON module (built into Redis core since 8.0, or available
+    # earlier through the RedisJSON module in Redis Stack).
+    #
+    # Values are serialized to JSON text on the client before they are sent, and replies
+    # that carry JSON text are parsed back into Ruby objects. The serialized form of these
+    # replies is identical under RESP2 and RESP3 (RESP3 has no native JSON type), so the
+    # handling here is protocol-independent. Note that some other RedisJSON commands — e.g.
+    # JSON.NUMINCRBY — DO return differently shaped replies under RESP3 and will need
+    # protocol-aware reshaping once RESP3 is supported at this layer.
+    module Json
+      # Set the JSON value at +path+ in the document stored under +key+.
+      #
+      # @example
+      #   redis.json_set("doc", "$", { "a" => 1, "nested" => { "b" => 2 } })
+      #     # => true
+      #
+      # @param [String] key
+      # @param [String] path a JSONPath, e.g. "$" for the document root
+      # @param [Object] value any JSON-serializable Ruby object
+      # @param [Boolean] nx only set when the path does not already exist
+      # @param [Boolean] xx only set when the path already exists
+      # @return [Boolean, String] when +nx+ or +xx+ is given, +true+ on success and +false+
+      #   when the condition was not met; otherwise the raw +"OK"+ reply
+      def json_set(key, path, value, nx: false, xx: false)
+        args = [:"JSON.SET", key, path, ::JSON.generate(value)]
+        args << "NX" if nx
+        args << "XX" if xx
+
+        if nx || xx
+          send_command(args, &BoolifySet)
+        else
+          send_command(args)
+        end
+      end
+
+      # Get the JSON value(s) at one or more +paths+ in the document stored under +key+.
+      #
+      # @example
+      #   redis.json_get("doc")
+      #     # => { "a" => 1, "nested" => { "b" => 2 } }
+      #
+      # @param [String] key
+      # @param [Array<String>] paths zero or more JSONPath expressions; with none the whole
+      #   document is returned
+      # @return [Object, nil] the parsed JSON value, or nil if the key does not exist
+      def json_get(key, *paths)
+        send_command([:"JSON.GET", key, *paths]) do |reply|
+          reply.nil? ? nil : ::JSON.parse(reply)
+        end
+      end
+    end
+  end
+end

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -340,6 +340,16 @@ class Redis
       node_for(key).getex(key, **options)
     end
 
+    # Set the JSON value at a path in the document stored under a key.
+    def json_set(key, path, value, **options)
+      node_for(key).json_set(key, path, value, **options)
+    end
+
+    # Get the JSON value(s) at one or more paths in the document stored under a key.
+    def json_get(key, *paths)
+      node_for(key).json_get(key, *paths)
+    end
+
     # Get the values of all the given keys as an Array.
     def mget(*keys)
       keys.flatten!(1)

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -346,8 +346,8 @@ class Redis
     end
 
     # Get the JSON value(s) at one or more paths in the document stored under a key.
-    def json_get(key, *paths)
-      node_for(key).json_get(key, *paths)
+    def json_get(key, *paths, **options)
+      node_for(key).json_get(key, *paths, **options)
     end
 
     # Get the values of all the given keys as an Array.

--- a/makefile
+++ b/makefile
@@ -51,6 +51,14 @@ stop_cluster:
 create_cluster:
 	@true
 
+# Standalone instance with Redis modules (Redis Stack) for the module test suite. Override
+# the image with REDIS_STACK_VERSION=rs-7.2.0-v20 (etc).
+start_modules: ${TMP}
+	@docker compose --profile modules up -d --wait
+
+stop_modules:
+	@docker compose --profile modules down -v
+
 start_all: ${TMP}
 	@docker compose --profile all up -d --wait
 
@@ -65,4 +73,4 @@ clean: stop_all
 
 .PHONY: all test stop start stop_slave start_slave stop_sentinel start_sentinel \
 	wait_for_sentinel stop_cluster start_cluster create_cluster stop_all \
-	start_all clean
+	start_all start_modules stop_modules clean

--- a/test/distributed/commands_on_json_test.rb
+++ b/test/distributed/commands_on_json_test.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestDistributedCommandsOnJson < Minitest::Test
+  include Helper::Distributed
+  include Lint::Json
+end

--- a/test/distributed/commands_on_json_test.rb
+++ b/test/distributed/commands_on_json_test.rb
@@ -3,6 +3,6 @@
 require "helper"
 
 class TestDistributedCommandsOnJson < Minitest::Test
-  include Helper::Distributed
+  include Helper::DistributedModules
   include Lint::Json
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -20,11 +20,15 @@ if ENV["DRIVER"] == "hiredis"
   require "hiredis-client"
 end
 
-PORT        = 6381
-DB          = 15
-TIMEOUT     = Float(ENV['TIMEOUT'] || 1.0)
-LOW_TIMEOUT = Float(ENV['LOW_TIMEOUT'] || 0.01) # for blocking-command tests
-OPTIONS     = { port: PORT, db: DB, timeout: TIMEOUT }.freeze
+PORT         = 6381
+# Port the module test suite connects to. On Redis >= 8 the modules are in core, so this is
+# the standalone instance (6381); on 7.2/7.4 CI points it at the dedicated Redis Stack
+# instance (6383) via REDIS_MODULES_PORT.
+MODULES_PORT = Integer(ENV['REDIS_MODULES_PORT'] || PORT)
+DB           = 15
+TIMEOUT      = Float(ENV['TIMEOUT'] || 1.0)
+LOW_TIMEOUT  = Float(ENV['LOW_TIMEOUT'] || 0.01) # for blocking-command tests
+OPTIONS      = { port: PORT, db: DB, timeout: TIMEOUT }.freeze
 
 if ENV['REDIS_SOCKET_PATH'].nil?
   sock_file = File.expand_path('../tmp/redis.sock', __dir__)
@@ -167,6 +171,16 @@ module Helper
       skip("Requires Redis > #{min_ver}") if version < min_ver
     end
 
+    # Skip unless the named Redis module is loaded (e.g. "ReJSON" for RedisJSON). Module
+    # presence depends on the server image, not the Redis version number — on Redis >= 8 the
+    # module ships in core, on earlier versions it requires Redis Stack — so check MODULE LIST
+    # rather than the version. Redis::Distributed doesn't expose #call, so probe one node.
+    def omit_unless_module(name)
+      client = redis.respond_to?(:call) ? redis : redis.nodes.first
+      loaded = client.call("MODULE", "LIST").map { |mod| Hash[*mod]["name"] }
+      skip("Requires the #{name} module") unless loaded.include?(name)
+    end
+
     def version
       Version.new(redis.info['redis_version'])
     end
@@ -199,6 +213,22 @@ module Helper
 
     def _format_options(options)
       OPTIONS.merge(options)
+    end
+
+    def _new_client(options = {})
+      Redis.new(_format_options(options).merge(driver: ENV["DRIVER"]))
+    end
+  end
+
+  # Client for the module test suite. Connects to MODULES_PORT: the core `standalone` instance
+  # on Redis >= 8 (modules in core), or the dedicated Redis Stack instance on 7.2/7.4.
+  module Modules
+    include Generic
+
+    private
+
+    def _format_options(options)
+      OPTIONS.merge(port: MODULES_PORT).merge(options)
     end
 
     def _new_client(options = {})

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -311,4 +311,20 @@ module Helper
       Redis::Distributed.new(NODES, _format_options(options).merge(driver: ENV["conn"]))
     end
   end
+
+  # Like Helper::Distributed, but the single ring node is the module-capable server
+  # (MODULES_PORT): the standalone instance on Redis >= 8, or the dedicated Redis Stack
+  # instance on 7.2/7.4. Used by the distributed JSON test so it routes to a node that
+  # actually has the module loaded — the plain `standalone` is core-only on Redis < 8.
+  module DistributedModules
+    include Distributed
+
+    NODES = ["redis://127.0.0.1:#{MODULES_PORT}/#{DB}"].freeze
+
+    private
+
+    def _new_client(options = {})
+      Redis::Distributed.new(NODES, _format_options(options).merge(driver: ENV["conn"]))
+    end
+  end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -171,14 +171,20 @@ module Helper
       skip("Requires Redis > #{min_ver}") if version < min_ver
     end
 
-    # Skip unless the named Redis module is loaded (e.g. "ReJSON" for RedisJSON). Module
-    # presence depends on the server image, not the Redis version number — on Redis >= 8 the
-    # module ships in core, on earlier versions it requires Redis Stack — so check MODULE LIST
-    # rather than the version. Redis::Distributed doesn't expose #call, so probe one node.
-    def omit_unless_module(name)
+    # Assert the named Redis module is loaded (e.g. "ReJSON" for RedisJSON), raising if it is
+    # not. The module test suite always runs against a server that is expected to have the
+    # module — the standalone instance on Redis >= 8 (modules in core) or the dedicated Redis
+    # Stack instance on 7.2/7.4 — so a missing module is an infrastructure error we want to
+    # surface loudly rather than silently skip. Redis::Distributed doesn't expose #call, so
+    # probe one node.
+    def require_module(name)
       client = redis.respond_to?(:call) ? redis : redis.nodes.first
       loaded = client.call("MODULE", "LIST").map { |mod| Hash[*mod]["name"] }
-      skip("Requires the #{name} module") unless loaded.include?(name)
+      return if loaded.include?(name)
+
+      raise "Redis module #{name.inspect} is not loaded but the module test suite requires it. " \
+            "Bring up a module-capable server (Redis >= 8, or `make start_modules` for a Redis " \
+            "Stack instance). Modules loaded: #{loaded.inspect}."
     end
 
     def version

--- a/test/lint/json.rb
+++ b/test/lint/json.rb
@@ -4,7 +4,15 @@ module Lint
   module Json
     def setup
       super
-      omit_unless_module("ReJSON")
+      require_module("ReJSON")
+    end
+
+    def test_set_returns_ok
+      assert_equal "OK", r.json_set("doc", "$", { "a" => 1 })
+    end
+
+    def test_set_with_raw_returns_ok
+      assert_equal "OK", r.json_set("doc", "$", '{"a":1}', raw: true)
     end
 
     def test_set_and_get_whole_document
@@ -66,6 +74,10 @@ module Lint
 
       assert_equal false, r.json_set("doc", "$.b", 2, xx: true)
       assert_nil r.json_get("doc", "$.b").first
+    end
+
+    def test_set_with_both_nx_and_xx_raises
+      assert_raises(ArgumentError) { r.json_set("doc", "$", { "a" => 1 }, nx: true, xx: true) }
     end
 
     def test_set_with_raw_passes_encoded_json_through

--- a/test/lint/json.rb
+++ b/test/lint/json.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Lint
+  module Json
+    def setup
+      super
+      omit_unless_module("ReJSON")
+    end
+
+    def test_set_and_get_whole_document
+      doc = { "a" => 1, "nested" => { "b" => 2 } }
+
+      r.json_set("doc", "$", doc)
+
+      assert_equal doc, r.json_get("doc")
+    end
+
+    def test_set_and_get_with_array_value
+      value = [1, 2, ["a", "b"]]
+
+      r.json_set("doc", "$", value)
+
+      assert_equal value, r.json_get("doc")
+    end
+
+    def test_set_at_nested_path
+      r.json_set("doc", "$", { "a" => 1, "nested" => { "b" => 2 } })
+
+      r.json_set("doc", "$.nested.b", 99)
+
+      assert_equal [99], r.json_get("doc", "$.nested.b")
+    end
+
+    def test_get_single_path_returns_array_of_matches
+      r.json_set("doc", "$", { "a" => 1 })
+
+      assert_equal [1], r.json_get("doc", "$.a")
+    end
+
+    def test_get_multiple_paths_returns_hash_keyed_by_path
+      r.json_set("doc", "$", { "a" => 1, "nested" => { "b" => 2 } })
+
+      assert_equal({ "$.a" => [1], "$.nested.b" => [2] }, r.json_get("doc", "$.a", "$.nested.b"))
+    end
+
+    def test_get_missing_key_returns_nil
+      assert_nil r.json_get("missing")
+    end
+
+    def test_set_with_nx_on_existing_path_returns_false
+      r.json_set("doc", "$", { "a" => 1 })
+
+      assert_equal false, r.json_set("doc", "$.a", 2, nx: true)
+      assert_equal [1], r.json_get("doc", "$.a")
+    end
+
+    def test_set_with_nx_on_missing_path_returns_true
+      r.json_set("doc", "$", { "a" => 1 })
+
+      assert_equal true, r.json_set("doc", "$.b", 2, nx: true)
+      assert_equal [2], r.json_get("doc", "$.b")
+    end
+
+    def test_set_with_xx_on_missing_path_returns_false
+      r.json_set("doc", "$", { "a" => 1 })
+
+      assert_equal false, r.json_set("doc", "$.b", 2, xx: true)
+      assert_nil r.json_get("doc", "$.b").first
+    end
+  end
+end

--- a/test/lint/json.rb
+++ b/test/lint/json.rb
@@ -67,5 +67,28 @@ module Lint
       assert_equal false, r.json_set("doc", "$.b", 2, xx: true)
       assert_nil r.json_get("doc", "$.b").first
     end
+
+    def test_set_with_raw_passes_encoded_json_through
+      r.json_set("doc", "$", '{"a":1,"b":[2,3]}', raw: true)
+
+      assert_equal({ "a" => 1, "b" => [2, 3] }, r.json_get("doc"))
+    end
+
+    def test_set_without_raw_does_not_double_encode_a_string
+      # A plain Ruby string is a JSON value: it must be stored as a JSON string, not as raw JSON.
+      r.json_set("doc", "$", "hello")
+
+      assert_equal "hello", r.json_get("doc")
+    end
+
+    def test_get_with_raw_returns_unparsed_json_string
+      r.json_set("doc", "$", { "a" => 1 })
+
+      assert_equal '[{"a":1}]', r.json_get("doc", "$", raw: true)
+    end
+
+    def test_get_with_raw_on_missing_key_returns_nil
+      assert_nil r.json_get("missing", raw: true)
+    end
   end
 end

--- a/test/modules/commands_on_json_test.rb
+++ b/test/modules/commands_on_json_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestCommandsOnJson < Minitest::Test
+  include Helper::Modules
+  include Lint::Json
+
+  def test_get_in_pipeline_returns_parsed_object
+    r.json_set("doc", "$", { "a" => 1 })
+
+    result = r.pipelined do |pipe|
+      pipe.json_get("doc")
+    end
+
+    assert_equal({ "a" => 1 }, result.first)
+  end
+
+  def test_set_with_nx_in_pipeline_resolves_to_boolean
+    result = r.pipelined do |pipe|
+      pipe.json_set("doc", "$", { "a" => 1 }, nx: true)
+    end
+
+    assert_equal true, result.first
+  end
+end


### PR DESCRIPTION
This PR introduces support for Redis modules, starting with RedisJSON. Beyond the two commands themselves, the goal is to lay down the reusable pattern every future module command will follow: where module command code lives, how it's namespaced, how replies are kept protocol-safe, and how the module test suite is wired into CI.

  **Test infrastructure**
  - New decoupled test:modules group (test/modules/, shared test/lint/json.rb), folded into the default rake test aggregate after the standalone/distributed/sentinel suites.
  - New Helper::Modules client + omit_unless_module("ReJSON") helper (checks MODULE LIST, not the version number).
  - Module tests run on a configurable port (REDIS_MODULES_PORT, default 6381).
  
   **Docker / CI — version-aware module testing**
  - Module tests run inside the existing test matrix (Ruby × Redis version × driver), not a separate job.
  - On Redis ≥ 8.0, modules are in core → tests run against the regular standalone instance; no extra infrastructure.
  - On Redis 7.2.x / 7.4.x, a dedicated Redis Stack service (compose modules profile, port 6383) is booted with the version-matched image — 7.2 → rs-7.2.0-v20, 7.4 → rs-7.4.0-v8 — and the module client points
  at it.
  - makefile gains start_modules / stop_modules shims.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New optional API surface and test/docker wiring; no changes to core Redis command paths or auth.
> 
> **Overview**
> Adds **RedisJSON** client support via `json_set` and `json_get` under `Redis::Commands::Modules::Json`, wired into `Redis` and `Redis::Distributed`. Values are encoded with `JSON.generate` on write and parsed on read, with `raw:`, `nx:`, and `xx:` options; conditional sets use the existing `BoolifySet` reply shaping.
> 
> Introduces a **`test:modules`** suite (`test/modules/`, shared `Lint::Json`), `Helper::Modules` / `Helper::DistributedModules`, and `require_module("ReJSON")` so missing module support fails loudly. CI runs module tests in the existing matrix: Redis **≥ 8** hits standalone on **6381**; **7.2/7.4** boot a Redis Stack service on **6383** (`docker compose` `modules` profile, version-matched `REDIS_STACK_VERSION`). Rake default `test` and GitHub Actions now include `test:modules`; the makefile adds `start_modules` / `stop_modules`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cf316ea1ac5a2aeed5126116933dd15b4dd4414. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->