### PR TITLE
Add support for rest of JSON CRUD commands (MSET/GET, DEL, CLEAR, FORGET, MERGE))

### DIFF
--- a/lib/redis/commands/modules/json.rb
+++ b/lib/redis/commands/modules/json.rb
@@ -126,6 +126,7 @@ class Redis
       # @param [Boolean] raw return the unparsed JSON strings instead of parsed Ruby objects
       # @return [Array] one value per key (nil for a missing key/path)
       def json_mget(*keys, path, raw: false)
+        keys.flatten!(1)
         send_command([:"JSON.MGET", *keys, path]) do |reply|
           if reply.nil?
             reply

--- a/lib/redis/commands/modules/json.rb
+++ b/lib/redis/commands/modules/json.rb
@@ -85,6 +85,126 @@ class Redis
           end
         end
       end
+
+      # Set one or more JSON values atomically, one per +key+/+path+/+value+ triplet. Either all
+      # of the writes are applied or none are. For a key that does not yet exist the +path+ must
+      # be the root ("$").
+      #
+      # By default each value is a Ruby object serialized with JSON.generate; pass +raw: true+ to
+      # send already-encoded JSON strings through untouched.
+      #
+      # @example
+      #   redis.json_mset("doc1", "$", { "a" => 1 }, "doc2", "$", { "b" => 2 })
+      #     # => "OK"
+      #
+      # @param [Array] args a flat list of key, path, value triplets
+      # @param [Boolean] raw treat each value as an already-encoded JSON string
+      # @return [String] the raw "OK" reply
+      # @raise [ArgumentError] unless +args+ is a non-empty list of complete triplets
+      def json_mset(*args, raw: false)
+        raise ArgumentError, "wrong number of arguments (expected key/path/value triplets)" \
+          if args.empty? || !(args.size % 3).zero?
+
+        command = [:"JSON.MSET"]
+        args.each_slice(3) do |key, path, value|
+          command << key << path << (raw ? value : ::JSON.generate(value))
+        end
+        send_command(command)
+      end
+
+      # Get the values at a single +path+ from one or more +keys+.
+      #
+      # Returns one element per key, in order, parsed from JSON text into a Ruby object (or nil
+      # when the key or path does not exist). Pass +raw: true+ to get the unparsed JSON strings.
+      #
+      # @example
+      #   redis.json_mget("doc1", "doc2", "$.a")
+      #     # => [[1], [2]]
+      #
+      # @param [Array<String>] keys one or more keys to read
+      # @param [String] path a single JSONPath applied to every key
+      # @param [Boolean] raw return the unparsed JSON strings instead of parsed Ruby objects
+      # @return [Array] one value per key (nil for a missing key/path)
+      def json_mget(*keys, path, raw: false)
+        send_command([:"JSON.MGET", *keys, path]) do |reply|
+          if reply.nil?
+            reply
+          else
+            reply.map { |value| value.nil? || raw ? value : ::JSON.parse(value) }
+          end
+        end
+      end
+
+      # Delete the value(s) at +path+ in the document stored under +key+. When +path+ is omitted
+      # it defaults to the root, so deleting the root removes the whole key.
+      #
+      # @example
+      #   redis.json_del("doc", "$.a")
+      #     # => 1
+      #
+      # @param [String] key
+      # @param [String] path an optional JSONPath (defaults to the root "$")
+      # @return [Integer] the number of values deleted
+      def json_del(key, path = nil)
+        args = [:"JSON.DEL", key]
+        args << path if path
+        send_command(args)
+      end
+
+      # Delete the value(s) at +path+ in the document stored under +key+. Alias of {#json_del}.
+      #
+      # @example
+      #   redis.json_forget("doc", "$.a")
+      #     # => 1
+      #
+      # @param [String] key
+      # @param [String] path an optional JSONPath (defaults to the root "$")
+      # @return [Integer] the number of values deleted
+      def json_forget(key, path = nil)
+        args = [:"JSON.FORGET", key]
+        args << path if path
+        send_command(args)
+      end
+
+      # Clear the container and numeric value(s) at +path+: arrays and objects are emptied and
+      # numbers are set to 0. Strings, booleans and null are left unchanged. When +path+ is
+      # omitted it defaults to the root.
+      #
+      # @example
+      #   redis.json_clear("doc", "$.arr")
+      #     # => 1
+      #
+      # @param [String] key
+      # @param [String] path an optional JSONPath (defaults to the root "$")
+      # @return [Integer] the number of values cleared
+      def json_clear(key, path = nil)
+        args = [:"JSON.CLEAR", key]
+        args << path if path
+        send_command(args)
+      end
+
+      # Merge +value+ into the document stored under +key+ at +path+, following RFC 7396 (JSON
+      # Merge Patch): a null value deletes a key, a non-null value creates or updates it, and any
+      # value merged into an existing array replaces the whole array. For a key that does not yet
+      # exist the +path+ must be the root ("$").
+      #
+      # By default +value+ is a Ruby object serialized with JSON.generate; pass +raw: true+ to
+      # send an already-encoded JSON string through untouched.
+      #
+      # @example
+      #   redis.json_merge("doc", "$.b", 8)
+      #     # => "OK"
+      #
+      # @param [String] key
+      # @param [String] path a JSONPath (must be "$" when creating a new key)
+      # @param [Object] value a JSON-serializable Ruby object, or a pre-encoded JSON string when
+      #   +raw+ is true
+      # @param [Boolean] raw treat +value+ as an already-encoded JSON string and send it as-is
+      # @return [String] the raw "OK" reply
+      def json_merge(key, path, value, raw: false)
+        value = ::JSON.generate(value) unless raw
+        send_command([:"JSON.MERGE", key, path, value])
+      end
     end
   end
 end

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -350,6 +350,44 @@ class Redis
       node_for(key).json_get(key, *paths, **options)
     end
 
+    # Set one or more JSON values. The keys may live on different nodes and the operation must be
+    # atomic, so it cannot be distributed.
+    def json_mset(*)
+      raise CannotDistribute, :json_mset
+    end
+
+    # Get the values at a path from several keys. Keys are grouped by node, queried per node, and
+    # reassembled in the original key order.
+    def json_mget(*keys, path, **options)
+      keys.flatten!(1)
+      values = keys.group_by { |key| node_for(key) }.each_with_object({}) do |(node, subkeys), acc|
+        node.json_mget(*subkeys, path, **options).each_with_index do |value, i|
+          acc[subkeys[i]] = value
+        end
+      end
+      keys.map { |key| values[key] }
+    end
+
+    # Delete the JSON value(s) at a path in the document stored under a key.
+    def json_del(key, path = nil)
+      node_for(key).json_del(key, path)
+    end
+
+    # Delete the JSON value(s) at a path in the document stored under a key (alias of json_del).
+    def json_forget(key, path = nil)
+      node_for(key).json_forget(key, path)
+    end
+
+    # Clear the container and numeric JSON value(s) at a path in the document stored under a key.
+    def json_clear(key, path = nil)
+      node_for(key).json_clear(key, path)
+    end
+
+    # Merge a JSON value into the document stored under a key at a path.
+    def json_merge(key, path, value, **options)
+      node_for(key).json_merge(key, path, value, **options)
+    end
+
     # Get the values of all the given keys as an Array.
     def mget(*keys)
       keys.flatten!(1)

--- a/test/distributed/commands_on_json_test.rb
+++ b/test/distributed/commands_on_json_test.rb
@@ -5,4 +5,11 @@ require "helper"
 class TestDistributedCommandsOnJson < Minitest::Test
   include Helper::DistributedModules
   include Lint::Json
+
+  # Multi-key atomic write cannot be guaranteed across nodes.
+  def test_mset_cannot_be_distributed
+    assert_raises(Redis::Distributed::CannotDistribute) do
+      r.json_mset("doc1", "$", { "a" => 1 }, "doc2", "$", { "b" => 2 })
+    end
+  end
 end

--- a/test/lint/json.rb
+++ b/test/lint/json.rb
@@ -110,6 +110,14 @@ module Lint
       assert_equal [[1], [2], nil], r.json_mget("doc1", "doc2", "missing", "$.a")
     end
 
+    def test_mget_accepts_an_array_of_keys
+      r.json_set("doc1", "$", { "a" => 1 })
+      r.json_set("doc2", "$", { "a" => 2 })
+
+      # A nested array of keys must behave the same as splatted keys (matches #mget).
+      assert_equal [[1], [2]], r.json_mget(["doc1", "doc2"], "$.a")
+    end
+
     def test_mget_returns_empty_match_for_missing_path
       r.json_set("doc1", "$", { "a" => 1 })
 

--- a/test/lint/json.rb
+++ b/test/lint/json.rb
@@ -102,5 +102,98 @@ module Lint
     def test_get_with_raw_on_missing_key_returns_nil
       assert_nil r.json_get("missing", raw: true)
     end
+
+    def test_mget_returns_one_value_per_key_in_order
+      r.json_set("doc1", "$", { "a" => 1 })
+      r.json_set("doc2", "$", { "a" => 2 })
+
+      assert_equal [[1], [2], nil], r.json_mget("doc1", "doc2", "missing", "$.a")
+    end
+
+    def test_mget_returns_empty_match_for_missing_path
+      r.json_set("doc1", "$", { "a" => 1 })
+
+      assert_equal [[]], r.json_mget("doc1", "$.nope")
+    end
+
+    def test_mget_with_raw_returns_unparsed_strings
+      r.json_set("doc1", "$", { "a" => 1 })
+
+      assert_equal ["[1]"], r.json_mget("doc1", "$.a", raw: true)
+    end
+
+    def test_del_with_path_deletes_matching_values
+      r.json_set("doc", "$", { "a" => 1, "nested" => { "a" => 2, "b" => 3 } })
+
+      assert_equal 2, r.json_del("doc", "$..a")
+      assert_equal({ "nested" => { "b" => 3 } }, r.json_get("doc"))
+    end
+
+    def test_del_without_path_removes_the_key
+      r.json_set("doc", "$", { "a" => 1 })
+
+      assert_equal 1, r.json_del("doc")
+      assert_nil r.json_get("doc")
+    end
+
+    def test_del_on_missing_path_returns_zero
+      r.json_set("doc", "$", { "a" => 1 })
+
+      assert_equal 0, r.json_del("doc", "$.nope")
+    end
+
+    def test_forget_deletes_like_del
+      r.json_set("doc", "$", { "a" => 1, "b" => 2 })
+
+      assert_equal 1, r.json_forget("doc", "$.a")
+      assert_equal({ "b" => 2 }, r.json_get("doc"))
+    end
+
+    def test_clear_empties_containers_and_zeroes_numbers
+      r.json_set("doc", "$", { "obj" => { "a" => 1 }, "arr" => [1, 2, 3], "int" => 42, "str" => "foo" })
+
+      assert_equal 3, r.json_clear("doc", "$.*")
+      assert_equal({ "obj" => {}, "arr" => [], "int" => 0, "str" => "foo" }, r.json_get("doc"))
+    end
+
+    def test_clear_on_already_cleared_value_returns_zero
+      r.json_set("doc", "$", { "arr" => [] })
+
+      assert_equal 0, r.json_clear("doc", "$.arr")
+    end
+
+    def test_merge_creates_key_at_root
+      assert_equal "OK", r.json_merge("doc", "$", { "a" => 1 })
+      assert_equal({ "a" => 1 }, r.json_get("doc"))
+    end
+
+    def test_merge_adds_and_updates_fields
+      r.json_set("doc", "$", { "a" => 2 })
+
+      assert_equal "OK", r.json_merge("doc", "$.b", 8)
+      r.json_merge("doc", "$.a", 3)
+      assert_equal({ "a" => 3, "b" => 8 }, r.json_get("doc"))
+    end
+
+    def test_merge_with_null_deletes_a_field
+      r.json_set("doc", "$", { "a" => 2, "b" => 3 })
+
+      r.json_merge("doc", "$", { "a" => nil })
+      assert_equal({ "b" => 3 }, r.json_get("doc"))
+    end
+
+    def test_merge_replaces_an_existing_array
+      r.json_set("doc", "$", { "a" => [2, 4, 6] })
+
+      r.json_merge("doc", "$.a", [10, 12])
+      assert_equal({ "a" => [10, 12] }, r.json_get("doc"))
+    end
+
+    def test_merge_with_raw_value
+      r.json_set("doc", "$", { "a" => 1 })
+
+      r.json_merge("doc", "$.b", "[1,2]", raw: true)
+      assert_equal({ "a" => 1, "b" => [1, 2] }, r.json_get("doc"))
+    end
   end
 end

--- a/test/modules/commands_on_json_test.rb
+++ b/test/modules/commands_on_json_test.rb
@@ -23,4 +23,29 @@ class TestCommandsOnJson < Minitest::Test
 
     assert_equal true, result.first
   end
+
+  # JSON.MSET is multi-key and atomic, so it is only exercised against a single instance here;
+  # Redis::Distributed cannot support it (see test/distributed/commands_on_json_test.rb).
+  def test_mset_sets_multiple_documents
+    assert_equal "OK", r.json_mset("doc1", "$", { "a" => 1 }, "doc2", "$", { "b" => 2 })
+    assert_equal({ "a" => 1 }, r.json_get("doc1"))
+    assert_equal({ "b" => 2 }, r.json_get("doc2"))
+  end
+
+  def test_mset_updates_a_nested_path
+    r.json_set("doc", "$", { "f" => { "a" => 1 } })
+
+    assert_equal "OK", r.json_mset("doc", "$.f.a", 3)
+    assert_equal({ "f" => { "a" => 3 } }, r.json_get("doc"))
+  end
+
+  def test_mset_with_raw_values
+    assert_equal "OK", r.json_mset("doc1", "$", '{"a":1}', "doc2", "$", '{"b":2}', raw: true)
+    assert_equal({ "a" => 1 }, r.json_get("doc1"))
+    assert_equal({ "b" => 2 }, r.json_get("doc2"))
+  end
+
+  def test_mset_with_incomplete_triplet_raises
+    assert_raises(ArgumentError) { r.json_mset("doc1", "$") }
+  end
 end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive client wrappers and tests around RedisJSON; no auth or core connection changes, with explicit distributed limits for atomic MSET.
> 
> **Overview**
> Extends the RedisJSON client API beyond `json_set` / `json_get` with **MSET**, **MGET**, **DEL**, **FORGET**, **CLEAR**, and **MERGE**, using the same JSON encode/decode and optional `raw:` behavior as existing commands.
> 
> On a single `Redis` connection, callers get atomic multi-key writes via `json_mset`, ordered multi-key reads via `json_mget`, path-aware deletes (`json_del` / `json_forget`), container/numeric reset via `json_clear`, and RFC 7396-style updates via `json_merge`. `Redis::Distributed` routes per-key commands to the right node, implements `json_mget` by querying each node and preserving key order, and **rejects** `json_mset` with `CannotDistribute` because cross-node atomicity cannot be guaranteed.
> 
> Shared lint coverage exercises ordering, missing keys/paths, merge semantics (including `nil` deletes and array replacement), and distributed behavior for `json_mset`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ab23584d9c8e60a5d64dd00a0217ae4e9d0284c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->