### PR TITLE
Added support for JSON array commands

### DIFF
--- a/lib/redis/commands/modules/json.rb
+++ b/lib/redis/commands/modules/json.rb
@@ -206,6 +206,140 @@ class Redis
         value = ::JSON.generate(value) unless raw
         send_command([:"JSON.MERGE", key, path, value])
       end
+
+      # Append one or more values to the array at +path+ in the document stored under +key+.
+      #
+      # By default each value is a Ruby object serialized with JSON.generate; pass +raw: true+ to
+      # send already-encoded JSON strings through untouched.
+      #
+      # @example
+      #   redis.json_arrappend("doc", "$.colors", "blue")
+      #     # => [3]
+      #
+      # @param [String] key
+      # @param [String] path a JSONPath to the target array
+      # @param [Array<Object>] values one or more JSON values to append
+      # @param [Boolean] raw treat each value as an already-encoded JSON string
+      # @return [Array<Integer>, Integer] the new array length(s); an Array for a JSONPath,
+      #   a single Integer for a legacy path (nil for a match that is not an array)
+      def json_arrappend(key, path, *values, raw: false)
+        values = values.map { |value| ::JSON.generate(value) } unless raw
+        send_command([:"JSON.ARRAPPEND", key, path, *values])
+      end
+
+      # Return the index of the first occurrence of a scalar +value+ in the array at +path+. The
+      # optional +start+ (inclusive) and +stop+ (exclusive) bound the search.
+      #
+      # @example
+      #   redis.json_arrindex("doc", "$.colors", "silver")
+      #     # => [1]
+      #
+      # @param [String] key
+      # @param [String] path a JSONPath to the target array
+      # @param [Object] value the scalar JSON value to search for
+      # @param [Integer] start optional inclusive start index
+      # @param [Integer] stop optional exclusive stop index
+      # @param [Boolean] raw treat +value+ as an already-encoded JSON string
+      # @return [Array<Integer>, Integer] the index/indices of the first match (-1 if not found)
+      def json_arrindex(key, path, value, start: nil, stop: nil, raw: false)
+        value = ::JSON.generate(value) unless raw
+        args = [:"JSON.ARRINDEX", key, path, value]
+        unless start.nil? && stop.nil?
+          args << Integer(start || 0)
+          args << Integer(stop) unless stop.nil?
+        end
+        send_command(args)
+      end
+
+      # Insert one or more values into the array at +path+ before +index+ (existing elements at
+      # and after +index+ shift right; 0 prepends, negative counts from the end).
+      #
+      # By default each value is a Ruby object serialized with JSON.generate; pass +raw: true+ to
+      # send already-encoded JSON strings through untouched.
+      #
+      # @example
+      #   redis.json_arrinsert("doc", "$.colors", 1, "gold")
+      #     # => [4]
+      #
+      # @param [String] key
+      # @param [String] path a JSONPath to the target array
+      # @param [Integer] index the position to insert before
+      # @param [Array<Object>] values one or more JSON values to insert
+      # @param [Boolean] raw treat each value as an already-encoded JSON string
+      # @return [Array<Integer>, Integer] the new array length(s)
+      def json_arrinsert(key, path, index, *values, raw: false)
+        values = values.map { |value| ::JSON.generate(value) } unless raw
+        send_command([:"JSON.ARRINSERT", key, path, Integer(index), *values])
+      end
+
+      # Return the length of the array at +path+. When +path+ is omitted it defaults to the root.
+      #
+      # @example
+      #   redis.json_arrlen("doc", "$.colors")
+      #     # => [2]
+      #
+      # @param [String] key
+      # @param [String] path an optional JSONPath (defaults to the root "$")
+      # @return [Array<Integer>, Integer, nil] the array length(s); nil for a match that is not an
+      #   array, or when the key/path does not exist
+      def json_arrlen(key, path = nil)
+        args = [:"JSON.ARRLEN", key]
+        args << path if path
+        send_command(args)
+      end
+
+      # Remove and return an element from the array at +path+. When +path+ is omitted it defaults
+      # to the root; when +index+ is omitted it defaults to -1 (the last element).
+      #
+      # The popped element is returned as parsed JSON (a Ruby object), or as the unparsed JSON
+      # string when +raw: true+.
+      #
+      # @example
+      #   redis.json_arrpop("doc", "$.colors", 0)
+      #     # => ["black"]
+      #
+      # @param [String] key
+      # @param [String] path an optional JSONPath to the target array (defaults to the root "$")
+      # @param [Integer] index an optional position to pop from (defaults to -1, the last element)
+      # @param [Boolean] raw return the unparsed JSON string(s) instead of parsed Ruby objects
+      # @return [Array, Object, nil] the popped value(s); an Array for a JSONPath, a single value
+      #   for a legacy path, nil for an empty array or a non-array match
+      # @raise [ArgumentError] if +index+ is given without a +path+
+      def json_arrpop(key, path = nil, index = nil, raw: false)
+        raise ArgumentError, "index requires a path" if !index.nil? && path.nil?
+
+        args = [:"JSON.ARRPOP", key]
+        if path
+          args << path
+          args << Integer(index) unless index.nil?
+        end
+
+        send_command(args) do |reply|
+          if reply.nil? || raw
+            reply
+          elsif reply.is_a?(Array)
+            reply.map { |value| value.nil? ? nil : ::JSON.parse(value) }
+          else
+            ::JSON.parse(reply)
+          end
+        end
+      end
+
+      # Trim the array at +path+ so it keeps only the inclusive range of elements from +start+ to
+      # +stop+ (negative indices count from the end).
+      #
+      # @example
+      #   redis.json_arrtrim("doc", "$.colors", 0, 1)
+      #     # => [2]
+      #
+      # @param [String] key
+      # @param [String] path a JSONPath to the target array
+      # @param [Integer] start inclusive index of the first element to keep
+      # @param [Integer] stop inclusive index of the last element to keep
+      # @return [Array<Integer>, Integer] the new array length(s)
+      def json_arrtrim(key, path, start, stop)
+        send_command([:"JSON.ARRTRIM", key, path, Integer(start), Integer(stop)])
+      end
     end
   end
 end

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -388,6 +388,36 @@ class Redis
       node_for(key).json_merge(key, path, value, **options)
     end
 
+    # Append one or more values to the JSON array at a path in the document stored under a key.
+    def json_arrappend(key, path, *values, **options)
+      node_for(key).json_arrappend(key, path, *values, **options)
+    end
+
+    # Return the index of the first occurrence of a scalar in the JSON array at a path.
+    def json_arrindex(key, path, value, **options)
+      node_for(key).json_arrindex(key, path, value, **options)
+    end
+
+    # Insert one or more values into the JSON array at a path in the document stored under a key.
+    def json_arrinsert(key, path, index, *values, **options)
+      node_for(key).json_arrinsert(key, path, index, *values, **options)
+    end
+
+    # Return the length of the JSON array at a path in the document stored under a key.
+    def json_arrlen(key, path = nil)
+      node_for(key).json_arrlen(key, path)
+    end
+
+    # Remove and return an element from the JSON array at a path in the document stored under a key.
+    def json_arrpop(key, path = nil, index = nil, **options)
+      node_for(key).json_arrpop(key, path, index, **options)
+    end
+
+    # Trim the JSON array at a path in the document stored under a key to an inclusive range.
+    def json_arrtrim(key, path, start, stop)
+      node_for(key).json_arrtrim(key, path, start, stop)
+    end
+
     # Get the values of all the given keys as an Array.
     def mget(*keys)
       keys.flatten!(1)

--- a/test/lint/json.rb
+++ b/test/lint/json.rb
@@ -203,5 +203,143 @@ module Lint
       r.json_merge("doc", "$.b", "[1,2]", raw: true)
       assert_equal({ "a" => 1, "b" => [1, 2] }, r.json_get("doc"))
     end
+
+    def test_arrappend_appends_values_and_returns_new_length
+      r.json_set("doc", "$", { "colors" => ["black", "silver"] })
+
+      assert_equal [4], r.json_arrappend("doc", "$.colors", "blue", "red")
+      assert_equal [["black", "silver", "blue", "red"]], r.json_get("doc", "$.colors")
+    end
+
+    def test_arrappend_with_raw_values
+      r.json_set("doc", "$", { "a" => [1] })
+
+      assert_equal [3], r.json_arrappend("doc", "$.a", "2", "3", raw: true)
+      assert_equal [[1, 2, 3]], r.json_get("doc", "$.a")
+    end
+
+    def test_arrappend_on_non_array_match_returns_nil
+      r.json_set("doc", "$", { "a" => 1 })
+
+      assert_equal [nil], r.json_arrappend("doc", "$.a", "x")
+    end
+
+    def test_arrindex_finds_a_scalar
+      r.json_set("doc", "$", { "colors" => ["black", "silver", "blue"] })
+
+      assert_equal [1], r.json_arrindex("doc", "$.colors", "silver")
+    end
+
+    def test_arrindex_returns_minus_one_when_absent
+      r.json_set("doc", "$", { "colors" => ["black"] })
+
+      assert_equal [-1], r.json_arrindex("doc", "$.colors", "gold")
+    end
+
+    def test_arrindex_with_start_restricts_the_search
+      r.json_set("doc", "$", { "colors" => ["black", "silver", "black"] })
+
+      assert_equal [2], r.json_arrindex("doc", "$.colors", "black", start: 1)
+    end
+
+    def test_arrinsert_inserts_values_and_returns_new_length
+      r.json_set("doc", "$", { "colors" => ["black", "blue"] })
+
+      assert_equal [4], r.json_arrinsert("doc", "$.colors", 1, "silver", "gold")
+      assert_equal [["black", "silver", "gold", "blue"]], r.json_get("doc", "$.colors")
+    end
+
+    def test_arrinsert_with_a_negative_index
+      r.json_set("doc", "$", { "c" => [1, 2, 3] })
+
+      r.json_arrinsert("doc", "$.c", -1, 9)
+      assert_equal [[1, 2, 9, 3]], r.json_get("doc", "$.c")
+    end
+
+    def test_arrlen_returns_the_length
+      r.json_set("doc", "$", { "colors" => %w[a b c] })
+
+      assert_equal [3], r.json_arrlen("doc", "$.colors")
+    end
+
+    def test_arrlen_on_missing_path_returns_no_matches
+      r.json_set("doc", "$", { "a" => 1 })
+
+      assert_equal [], r.json_arrlen("doc", "$.nope")
+    end
+
+    def test_arrlen_on_non_array_match_returns_nil
+      r.json_set("doc", "$", { "a" => 1 })
+
+      assert_equal [nil], r.json_arrlen("doc", "$.a")
+    end
+
+    def test_arrpop_without_index_pops_the_last_element
+      r.json_set("doc", "$", { "c" => [1, 2, 3] })
+
+      assert_equal [3], r.json_arrpop("doc", "$.c")
+      assert_equal [[1, 2]], r.json_get("doc", "$.c")
+    end
+
+    def test_arrpop_with_an_index
+      r.json_set("doc", "$", { "c" => %w[x y z] })
+
+      assert_equal ["x"], r.json_arrpop("doc", "$.c", 0)
+    end
+
+    def test_arrpop_with_raw_returns_unparsed_strings
+      r.json_set("doc", "$", { "c" => %w[x y] })
+
+      assert_equal ['"y"'], r.json_arrpop("doc", "$.c", raw: true)
+    end
+
+    def test_arrpop_with_index_but_no_path_raises
+      assert_raises(ArgumentError) { r.json_arrpop("doc", nil, 0) }
+    end
+
+    def test_arrtrim_keeps_the_range_and_returns_new_length
+      r.json_set("doc", "$", { "c" => [1, 2, 3, 4, 5] })
+
+      assert_equal [3], r.json_arrtrim("doc", "$.c", 1, 3)
+      assert_equal [[2, 3, 4]], r.json_get("doc", "$.c")
+    end
+
+    # A legacy path (".foo") returns a single scalar reply rather than the JSONPath array form.
+
+    def test_arrappend_with_legacy_path_returns_an_integer
+      r.json_set("doc", "$", { "colors" => ["black"] })
+
+      assert_equal 2, r.json_arrappend("doc", ".colors", "silver")
+    end
+
+    def test_arrindex_with_legacy_path_returns_an_integer
+      r.json_set("doc", "$", { "colors" => ["black", "silver"] })
+
+      assert_equal 1, r.json_arrindex("doc", ".colors", "silver")
+    end
+
+    def test_arrinsert_with_legacy_path_returns_an_integer
+      r.json_set("doc", "$", { "colors" => ["black", "blue"] })
+
+      assert_equal 3, r.json_arrinsert("doc", ".colors", 1, "silver")
+    end
+
+    def test_arrlen_with_legacy_path_returns_an_integer
+      r.json_set("doc", "$", { "colors" => %w[a b c] })
+
+      assert_equal 3, r.json_arrlen("doc", ".colors")
+    end
+
+    def test_arrpop_with_legacy_path_returns_a_single_value
+      r.json_set("doc", "$", { "colors" => ["black", "silver"] })
+
+      assert_equal "silver", r.json_arrpop("doc", ".colors")
+    end
+
+    def test_arrtrim_with_legacy_path_returns_an_integer
+      r.json_set("doc", "$", { "c" => [1, 2, 3, 4] })
+
+      assert_equal 2, r.json_arrtrim("doc", ".c", 1, 2)
+    end
   end
 end

--- a/test/modules/commands_on_json_test.rb
+++ b/test/modules/commands_on_json_test.rb
@@ -48,4 +48,14 @@ class TestCommandsOnJson < Minitest::Test
   def test_mset_with_incomplete_triplet_raises
     assert_raises(ArgumentError) { r.json_mset("doc1", "$") }
   end
+
+  def test_arrpop_in_pipeline_returns_parsed_value
+    r.json_set("doc", "$", { "c" => [1, 2, 3] })
+
+    result = r.pipelined do |pipe|
+      pipe.json_arrpop("doc", "$.c")
+    end
+
+    assert_equal [3], result.first
+  end
 end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive client API following existing JSON command patterns; no auth or core protocol changes, with broad test coverage.
> 
> **Overview**
> Adds **RedisJSON array command** wrappers so clients can mutate and query arrays inside JSON documents at a path.
> 
> The `Json` module gains `json_arrappend`, `json_arrindex`, `json_arrinsert`, `json_arrlen`, `json_arrpop`, and `json_arrtrim`, mapping to `JSON.ARR*` with the same conventions as other JSON helpers: optional `raw:` for pre-encoded values, and `json_arrpop` parses popped elements via `JSON.parse` unless `raw: true`. `json_arrindex` supports optional `start`/`stop`; `json_arrpop` raises if an `index` is passed without a `path`.
> 
> `Redis::Distributed` forwards each new method to the node for the key. Coverage is added in the JSON lint suite (JSONPath vs legacy `.path` reply shapes) plus a pipelined `json_arrpop` integration test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ebe18b26e043fed5261a81a47870f55eda0d2cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->