### PR TITLE
Added support for remaining JSON commands

### DIFF
--- a/lib/redis/commands/modules/json.rb
+++ b/lib/redis/commands/modules/json.rb
@@ -14,6 +14,38 @@ class Redis
     # JSON.NUMINCRBY — DO return differently shaped replies under RESP3 and will need
     # protocol-aware reshaping once RESP3 is supported at this layer.
     module Json
+      # Normalize a JSON.NUMINCRBY reply to a protocol-independent value: an array of numbers for
+      # a JSONPath, a single number for a legacy path. Under RESP2 the result arrives as a
+      # JSON-encoded string ("[3,4]" / "3"); under RESP3 it arrives as native numbers (an array,
+      # even for a legacy path). Both shapes map to the same value.
+      NumincrbyNormalize = lambda do |reply, jsonpath|
+        return nil if reply.nil?
+
+        reply = ::JSON.parse(reply) if reply.is_a?(String) # RESP2 string form
+        if jsonpath
+          Array(reply)
+        elsif reply.is_a?(Array)
+          reply.first # RESP3 wraps even a legacy reply in an array
+        else
+          reply
+        end
+      end
+
+      # Normalize a JSON.TYPE reply to a protocol-independent value: an array of type strings for
+      # a JSONPath, a single type string for a legacy path. RESP2 returns ["integer"] / "integer";
+      # RESP3 nests one level further as [["integer"]] / ["integer"]. Both map to the same value.
+      TypeNormalize = lambda do |reply, jsonpath|
+        return nil if reply.nil?
+
+        if jsonpath
+          reply.flatten # RESP2 ["integer"] stays flat; RESP3 [["integer"]] collapses
+        elsif reply.is_a?(Array)
+          reply.first # RESP3 legacy ["integer"] -> "integer"
+        else
+          reply # RESP2 legacy "integer"
+        end
+      end
+
       # Set the JSON value at +path+ in the document stored under +key+.
       #
       # By default +value+ is a Ruby object that is serialized to JSON text with
@@ -339,6 +371,154 @@ class Redis
       # @return [Array<Integer>, Integer] the new array length(s)
       def json_arrtrim(key, path, start, stop)
         send_command([:"JSON.ARRTRIM", key, path, Integer(start), Integer(stop)])
+      end
+
+      # Increment the numeric value(s) at +path+ in the document stored under +key+ by +number+.
+      #
+      # @example
+      #   redis.json_numincrby("doc", "$.a", 2)
+      #     # => [3]
+      #
+      # @param [String] key
+      # @param [String] path a JSONPath to the numeric value(s)
+      # @param [Numeric] number the amount to add
+      # @return [Array<Numeric>, Numeric, nil] the new value(s): an Array for a JSONPath, a single
+      #   number for a legacy path; nil (or nil element) for a non-numeric match
+      def json_numincrby(key, path, number)
+        jsonpath = json_path?(path)
+        send_command([:"JSON.NUMINCRBY", key, path, number]) do |reply|
+          NumincrbyNormalize.call(reply, jsonpath)
+        end
+      end
+
+      # Return the type name of the value(s) at +path+ (e.g. "integer", "string", "object"). When
+      # +path+ is omitted it defaults to the root.
+      #
+      # @example
+      #   redis.json_type("doc", "$.a")
+      #     # => ["integer"]
+      #
+      # @param [String] key
+      # @param [String] path an optional JSONPath (defaults to the root)
+      # @return [Array<String>, String, nil] the type name(s): an Array for a JSONPath, a single
+      #   string for a legacy path
+      def json_type(key, path = nil)
+        jsonpath = json_path?(path)
+        args = [:"JSON.TYPE", key]
+        args << path if path
+        send_command(args) do |reply|
+          TypeNormalize.call(reply, jsonpath)
+        end
+      end
+
+      # Return the key names of the JSON object(s) at +path+. When +path+ is omitted it defaults
+      # to the root.
+      #
+      # @example
+      #   redis.json_objkeys("doc", "$.nested")
+      #     # => [["b", "c"]]
+      #
+      # @param [String] key
+      # @param [String] path an optional JSONPath (defaults to the root)
+      # @return [Array] an array of key-name arrays (JSONPath) or a single array of key names
+      #   (legacy path); nil for a non-object match
+      def json_objkeys(key, path = nil)
+        args = [:"JSON.OBJKEYS", key]
+        args << path if path
+        send_command(args)
+      end
+
+      # Return the number of keys in the JSON object(s) at +path+. When +path+ is omitted it
+      # defaults to the root.
+      #
+      # @example
+      #   redis.json_objlen("doc", "$.nested")
+      #     # => [2]
+      #
+      # @param [String] key
+      # @param [String] path an optional JSONPath (defaults to the root)
+      # @return [Array<Integer>, Integer, nil] the key count(s): an Array for a JSONPath, a single
+      #   integer for a legacy path; nil for a non-object match
+      def json_objlen(key, path = nil)
+        args = [:"JSON.OBJLEN", key]
+        args << path if path
+        send_command(args)
+      end
+
+      # Return the length of the JSON string(s) at +path+. When +path+ is omitted it defaults to
+      # the root.
+      #
+      # @example
+      #   redis.json_strlen("doc", "$.a")
+      #     # => [3]
+      #
+      # @param [String] key
+      # @param [String] path an optional JSONPath (defaults to the root)
+      # @return [Array<Integer>, Integer, nil] the string length(s): an Array for a JSONPath, a
+      #   single integer for a legacy path; nil for a non-string match
+      def json_strlen(key, path = nil)
+        args = [:"JSON.STRLEN", key]
+        args << path if path
+        send_command(args)
+      end
+
+      # Append +value+ to the JSON string(s) at +path+ in the document stored under +key+.
+      #
+      # By default +value+ is a Ruby string serialized with JSON.generate; pass +raw: true+ to
+      # send an already-encoded JSON string through untouched.
+      #
+      # @example
+      #   redis.json_strappend("doc", "$.a", "bar")
+      #     # => [6]
+      #
+      # @param [String] key
+      # @param [String] path a JSONPath to the target string(s)
+      # @param [String] value the string to append
+      # @param [Boolean] raw treat +value+ as an already-encoded JSON string and send it as-is
+      # @return [Array<Integer>, Integer, nil] the new string length(s): an Array for a JSONPath, a
+      #   single integer for a legacy path; nil for a non-string match
+      def json_strappend(key, path, value, raw: false)
+        value = ::JSON.generate(value) unless raw
+        send_command([:"JSON.STRAPPEND", key, path, value])
+      end
+
+      # Toggle the boolean value(s) at +path+ in the document stored under +key+.
+      #
+      # @example
+      #   redis.json_toggle("doc", "$.flag")
+      #     # => [0]
+      #
+      # @param [String] key
+      # @param [String] path a JSONPath to the target boolean(s)
+      # @return [Array, Object, nil] +1+/+0+ for the new true/false value(s): an Array for a
+      #   JSONPath, a single value for a legacy path; nil for a non-boolean match
+      def json_toggle(key, path)
+        send_command([:"JSON.TOGGLE", key, path])
+      end
+
+      # Report the size in bytes of the JSON value(s) at +path+ (the JSON.DEBUG MEMORY
+      # subcommand). When +path+ is omitted it defaults to the root.
+      #
+      # @example
+      #   redis.json_debug_memory("doc")
+      #     # => 264
+      #
+      # @param [String] key
+      # @param [String] path an optional JSONPath (defaults to the root)
+      # @return [Array<Integer>, Integer] the size(s) in bytes: an Array for a JSONPath, a single
+      #   integer for a legacy path or when no path is given (0 for a missing key)
+      def json_debug_memory(key, path = nil)
+        args = [:"JSON.DEBUG", "MEMORY", key]
+        args << path if path
+        send_command(args)
+      end
+
+      private
+
+      # RedisJSON distinguishes JSONPath expressions (which start with "$") from legacy paths.
+      # JSONPath queries return an array of matches; legacy paths return a single value.
+      def json_path?(path)
+        path.to_s.start_with?("$")
       end
     end
   end

--- a/lib/redis/commands/modules/json.rb
+++ b/lib/redis/commands/modules/json.rb
@@ -16,8 +16,13 @@ class Redis
     module Json
       # Normalize a JSON.NUMINCRBY reply to a protocol-independent value: an array of numbers for
       # a JSONPath, a single number for a legacy path. Under RESP2 the result arrives as a
-      # JSON-encoded string ("[3,4]" / "3"); under RESP3 it arrives as native numbers (an array,
+      # JSON-encoded string ("[3,4]" / "7"); under RESP3 it arrives as native numbers (an array,
       # even for a legacy path). Both shapes map to the same value.
+      #
+      # A legacy path can also match multiple values (e.g. "..a"). RESP2 collapses those to the
+      # last changed scalar ("7"), while RESP3 returns the full match array with nil for every
+      # non-numeric match ([nil, 4, 7, nil]). To stay RESP2-compatible we take the last non-nil
+      # element of that array, not its first.
       NumincrbyNormalize = lambda do |reply, jsonpath|
         return nil if reply.nil?
 
@@ -25,7 +30,7 @@ class Redis
         if jsonpath
           Array(reply)
         elsif reply.is_a?(Array)
-          reply.first # RESP3 wraps even a legacy reply in an array
+          reply.compact.last # RESP3 wraps even a legacy reply in an array; RESP2 keeps the last changed scalar
         else
           reply
         end

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -418,6 +418,46 @@ class Redis
       node_for(key).json_arrtrim(key, path, start, stop)
     end
 
+    # Increment the numeric JSON value(s) at a path in the document stored under a key.
+    def json_numincrby(key, path, number)
+      node_for(key).json_numincrby(key, path, number)
+    end
+
+    # Return the type name(s) of the JSON value(s) at a path in the document stored under a key.
+    def json_type(key, path = nil)
+      node_for(key).json_type(key, path)
+    end
+
+    # Return the key names of the JSON object(s) at a path in the document stored under a key.
+    def json_objkeys(key, path = nil)
+      node_for(key).json_objkeys(key, path)
+    end
+
+    # Return the number of keys in the JSON object(s) at a path in the document stored under a key.
+    def json_objlen(key, path = nil)
+      node_for(key).json_objlen(key, path)
+    end
+
+    # Return the length of the JSON string(s) at a path in the document stored under a key.
+    def json_strlen(key, path = nil)
+      node_for(key).json_strlen(key, path)
+    end
+
+    # Append a string to the JSON string(s) at a path in the document stored under a key.
+    def json_strappend(key, path, value, **options)
+      node_for(key).json_strappend(key, path, value, **options)
+    end
+
+    # Toggle the boolean JSON value(s) at a path in the document stored under a key.
+    def json_toggle(key, path)
+      node_for(key).json_toggle(key, path)
+    end
+
+    # Report the size in bytes of the JSON value(s) at a path in the document stored under a key.
+    def json_debug_memory(key, path = nil)
+      node_for(key).json_debug_memory(key, path)
+    end
+
     # Get the values of all the given keys as an Array.
     def mget(*keys)
       keys.flatten!(1)

--- a/test/lint/json.rb
+++ b/test/lint/json.rb
@@ -341,5 +341,152 @@ module Lint
 
       assert_equal 2, r.json_arrtrim("doc", ".c", 1, 2)
     end
+
+    def test_numincrby_with_jsonpath_returns_an_array
+      r.json_set("doc", "$", { "a" => 1 })
+
+      assert_equal [3], r.json_numincrby("doc", "$.a", 2)
+    end
+
+    def test_numincrby_with_legacy_path_returns_a_scalar
+      r.json_set("doc", "$", { "a" => 1 })
+
+      assert_equal 3, r.json_numincrby("doc", ".a", 2)
+    end
+
+    def test_numincrby_increments_a_float
+      r.json_set("doc", "$", { "a" => 2.5 })
+
+      assert_equal [3.0], r.json_numincrby("doc", "$.a", 0.5)
+    end
+
+    def test_numincrby_on_non_numeric_match_yields_nil
+      r.json_set("doc", "$", { "a" => "x" })
+
+      assert_equal [nil], r.json_numincrby("doc", "$.a", 1)
+    end
+
+    def test_type_with_jsonpath_returns_an_array_of_type_strings
+      r.json_set("doc", "$", { "a" => 1 })
+
+      assert_equal ["integer"], r.json_type("doc", "$.a")
+    end
+
+    def test_type_with_legacy_path_returns_a_single_type_string
+      r.json_set("doc", "$", { "s" => "x" })
+
+      assert_equal "string", r.json_type("doc", ".s")
+    end
+
+    def test_type_without_a_path_returns_the_root_type
+      r.json_set("doc", "$", { "a" => 1 })
+
+      assert_equal "object", r.json_type("doc")
+    end
+
+    def test_type_on_a_missing_path_returns_no_matches
+      r.json_set("doc", "$", { "a" => 1 })
+
+      assert_equal [], r.json_type("doc", "$.zzz")
+    end
+
+    def test_objkeys_with_jsonpath_returns_an_array_of_key_arrays
+      r.json_set("doc", "$", { "obj" => { "b" => 2, "c" => 1 } })
+
+      assert_equal [%w[b c]], r.json_objkeys("doc", "$.obj")
+    end
+
+    def test_objkeys_with_legacy_path_returns_a_key_array
+      r.json_set("doc", "$", { "obj" => { "b" => 2, "c" => 1 } })
+
+      assert_equal %w[b c], r.json_objkeys("doc", ".obj")
+    end
+
+    def test_objkeys_on_non_object_match_yields_nil
+      r.json_set("doc", "$", { "a" => 1 })
+
+      assert_equal [nil], r.json_objkeys("doc", "$.a")
+    end
+
+    def test_objlen_with_jsonpath_returns_an_array
+      r.json_set("doc", "$", { "obj" => { "b" => 2, "c" => 1 } })
+
+      assert_equal [2], r.json_objlen("doc", "$.obj")
+    end
+
+    def test_objlen_with_legacy_path_returns_an_integer
+      r.json_set("doc", "$", { "obj" => { "b" => 2, "c" => 1 } })
+
+      assert_equal 2, r.json_objlen("doc", ".obj")
+    end
+
+    def test_strlen_with_jsonpath_returns_an_array
+      r.json_set("doc", "$", { "s" => "foo" })
+
+      assert_equal [3], r.json_strlen("doc", "$.s")
+    end
+
+    def test_strlen_with_legacy_path_returns_an_integer
+      r.json_set("doc", "$", { "s" => "foo" })
+
+      assert_equal 3, r.json_strlen("doc", ".s")
+    end
+
+    def test_strappend_appends_and_returns_new_length
+      r.json_set("doc", "$", { "s" => "foo" })
+
+      assert_equal [6], r.json_strappend("doc", "$.s", "bar")
+      assert_equal ["foobar"], r.json_get("doc", "$.s")
+    end
+
+    def test_strappend_with_legacy_path_returns_an_integer
+      r.json_set("doc", "$", { "s" => "foo" })
+
+      assert_equal 6, r.json_strappend("doc", ".s", "bar")
+    end
+
+    def test_strappend_with_raw_value
+      r.json_set("doc", "$", { "s" => "foo" })
+
+      assert_equal [4], r.json_strappend("doc", "$.s", '"X"', raw: true)
+      assert_equal ["fooX"], r.json_get("doc", "$.s")
+    end
+
+    def test_toggle_flips_a_boolean
+      r.json_set("doc", "$", { "flag" => true })
+
+      assert_equal [0], r.json_toggle("doc", "$.flag")
+      assert_equal [1], r.json_toggle("doc", "$.flag")
+    end
+
+    def test_toggle_on_non_boolean_match_yields_nil
+      r.json_set("doc", "$", { "a" => 1 })
+
+      assert_equal [nil], r.json_toggle("doc", "$.a")
+    end
+
+    def test_debug_memory_without_a_path_returns_an_integer
+      r.json_set("doc", "$", { "a" => 1, "obj" => { "b" => 2 } })
+
+      assert_kind_of Integer, r.json_debug_memory("doc")
+    end
+
+    def test_debug_memory_with_jsonpath_returns_an_array
+      r.json_set("doc", "$", { "obj" => { "b" => 2 } })
+
+      result = r.json_debug_memory("doc", "$.obj")
+      assert_kind_of Array, result
+      assert_kind_of Integer, result.first
+    end
+
+    def test_debug_memory_with_legacy_path_returns_an_integer
+      r.json_set("doc", "$", { "obj" => { "b" => 2 } })
+
+      assert_kind_of Integer, r.json_debug_memory("doc", ".obj")
+    end
+
+    def test_debug_memory_on_missing_key_returns_zero
+      assert_equal 0, r.json_debug_memory("missing")
+    end
   end
 end

--- a/test/modules/commands_on_json_test.rb
+++ b/test/modules/commands_on_json_test.rb
@@ -58,4 +58,31 @@ class TestCommandsOnJson < Minitest::Test
 
     assert_equal [3], result.first
   end
+
+  # JSON.NUMINCRBY and JSON.TYPE reply differently under RESP2 and RESP3. The client is pinned to
+  # RESP2 today, so these unit-test the reshapes directly with both protocol shapes to prove they
+  # normalize to the same value (guarding the result when RESP3 is eventually enabled).
+
+  def test_numincrby_reshape_is_protocol_compatible
+    norm = Redis::Commands::Json::NumincrbyNormalize
+
+    assert_equal [3, 4], norm.call("[3,4]", true)  # RESP2 JSONPath (JSON string)
+    assert_equal [3, 4], norm.call([3, 4], true)   # RESP3 JSONPath (native array)
+    assert_equal 3, norm.call("3", false)          # RESP2 legacy (JSON string)
+    assert_equal 3, norm.call([3], false)          # RESP3 legacy (wrapped array)
+    assert_equal [nil, 4], norm.call("[null,4]", true)
+    assert_nil norm.call(nil, true)
+  end
+
+  def test_type_reshape_is_protocol_compatible
+    norm = Redis::Commands::Json::TypeNormalize
+
+    assert_equal ["integer"], norm.call(["integer"], true)             # RESP2 JSONPath
+    assert_equal ["integer"], norm.call([["integer"]], true)           # RESP3 JSONPath
+    assert_equal %w[integer boolean], norm.call(%w[integer boolean], true)          # RESP2 multi
+    assert_equal %w[integer boolean], norm.call([["integer"], ["boolean"]], true)   # RESP3 multi
+    assert_equal "string", norm.call("string", false)                  # RESP2 legacy
+    assert_equal "string", norm.call(["string"], false)                # RESP3 legacy
+    assert_nil norm.call(nil, true)
+  end
 end

--- a/test/modules/commands_on_json_test.rb
+++ b/test/modules/commands_on_json_test.rb
@@ -72,6 +72,12 @@ class TestCommandsOnJson < Minitest::Test
     assert_equal 3, norm.call([3], false)          # RESP3 legacy (wrapped array)
     assert_equal [nil, 4], norm.call("[null,4]", true)
     assert_nil norm.call(nil, true)
+
+    # A legacy path can match multiple values (e.g. "..a"): RESP2 returns the last changed
+    # scalar, RESP3 the full match array with nil for non-numeric matches. Both must normalize
+    # to the same RESP2-compatible last-changed value.
+    assert_equal 7, norm.call("7", false)                  # RESP2 legacy multi-match (last scalar)
+    assert_equal 7, norm.call([nil, 4, 7, nil], false)     # RESP3 legacy multi-match (full array)
   end
 
   def test_type_reshape_is_protocol_compatible


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive API and tests on the JSON command module; normalization logic is isolated and covered by lint and protocol unit tests.
> 
> **Overview**
> Adds the remaining **RedisJSON** client commands: `json_numincrby`, `json_type`, `json_objkeys`, `json_objlen`, `json_strlen`, `json_strappend`, `json_toggle`, and `json_debug_memory`, with the same JSONPath vs legacy path return shapes as existing array helpers.
> 
> **`json_numincrby`** and **`json_type`** apply reply normalizers (`NumincrbyNormalize`, `TypeNormalize`) so RESP2 (JSON strings / flat arrays) and future RESP3 (native numbers, extra nesting, multi-match legacy paths) yield the same Ruby values. A private **`json_path?`** helper drives that branching.
> 
> **`Redis::Distributed`** forwards each new method to the node for the key. Integration coverage lives in **`test/lint/json.rb`**; **`test/modules/commands_on_json_test.rb`** unit-tests the normalizers against both protocol shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bc80ee9ae96122cfd84de0fb10f2014933249d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->