### PR TITLE
Bump redis-client to >= 0.26.4 to fix reply desynchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Maintainership change: `redis-rb` is now maintained by the Redis Ltd company.
+- Bump `redis-client` to `>= 0.26.4` to fix reply desynchronization (e.g. `mget` returning `"OK"`) after a Sentinel failover/reconnect.
 
 # 5.4.1
 

--- a/redis.gemspec
+++ b/redis.gemspec
@@ -44,5 +44,5 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.6.0'
 
-  s.add_runtime_dependency('redis-client', '>= 0.22.0')
+  s.add_runtime_dependency('redis-client', '>= 0.26.4')
 end


### PR DESCRIPTION
Closes #1294 

### Problem

Users on Redis Sentinel reported Redis#mget (and other commands) returning "OK" — a reply belonging to a different command. Downstream code that zips keys with the result then fails with TypeError: wrong argument type String (must respond to :each). This is reply desynchronization: after a Sentinel failover/reconnect, a connection-prelude OK (from SELECT/AUTH/CLIENT …) leaked into the next command's read, shifting every subsequent reply.
  
The regression appeared when upgrading redis from 5.0.6 → 5.0.8. That's consistent: 5.0.8 (#1212) removed redis-rb's own reconnection shim and delegated connection lifecycle entirely to redis-client (bumping the floor to >= 0.17.0), which exposed Sentinel reconnection bugs in older redis-client releases.

### Fix

Bump the redis-client floor to >= 0.26.4, which contains the relevant Sentinel fixes:

- redis-rb/redis-client#260 (released in 0.26.1) — "Hiredis+sentinel don't re-use connections after a failover." A connection to the old master was reused after failover instead of being discarded and reconnected, causing the stale-reply desync that surfaces as mget returning "OK". (Affects the hiredis-client driver.)
- redis-rb/redis-client#283 (released in 0.26.4) — "Fix sentinel resolution when used through redis-rb." SentinelConfig used call, which Redis::Client undefines, raising NoMethodError during Sentinel master resolution; switched to call_v.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core networking dependency and minimum version for all installs; low code churn but affects Sentinel reconnection behavior in production.
> 
> **Overview**
> Raises the **`redis-client` runtime dependency floor** from `>= 0.22.0` to **`>= 0.26.4`** in `redis.gemspec`, and documents it under **Unreleased** in `CHANGELOG.md`.
> 
> This is a **dependency-only** fix for Sentinel users who saw **reply desynchronization** after failover/reconnect (e.g. `mget` returning `"OK"` from connection prelude replies, then `TypeError` when pairing keys with results). The newer `redis-client` releases include Sentinel reconnection fixes (stale connection reuse after failover, and Sentinel resolution via `call_v` instead of undefined `call` on `Redis::Client`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d32677e3c065c7cb178a5cf3c15b2d419cca75be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->