### PR TITLE
Pin downstream redis-client and redis-cluster-client dependencies to latest minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   (Redis < 6.0, or anything replying `NOPROTO`) transparently fall back to RESP2. See
   [specs/migration-resp3.md](specs/migration-resp3.md).
 - Maintainership change: `redis-rb` is now maintained by the Redis Ltd company.
-- Bump `redis-client` to `>= 0.26.4` to fix reply desynchronization (e.g. `mget` returning `"OK"`) after a Sentinel failover/reconnect.
+- Pin `redis-client` to `~> 0.30.0` (patch-only). redis-rb couples tightly to redis-client internals and redis-client is pre-1.0 (minors may break), so this lets bug/security patches flow automatically while gating minor/major upgrades behind a deliberate release. Includes the reply-desynchronization fix (e.g. `mget` returning `"OK"` after a Sentinel failover/reconnect) that landed in 0.26.4.
 
 # 5.4.1
 

--- a/cluster/CHANGELOG.md
+++ b/cluster/CHANGELOG.md
@@ -5,3 +5,5 @@
   with `WITHCOORD` now return coordinates as `Float` instead of `String`. Nodes without RESP3
   (Redis < 6.0, or anything replying `NOPROTO`) transparently fall back to RESP2. See
   [the RESP3 migration guide](../specs/migration-resp3.md).
+- Pin `redis-cluster-client` to `~> 0.16.0` (patch-only), so bug/security patches flow automatically
+  while minor/major upgrades are gated behind a deliberate release.

--- a/cluster/redis-clustering.gemspec
+++ b/cluster/redis-clustering.gemspec
@@ -47,5 +47,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.7.0'
 
   s.add_runtime_dependency('redis', s.version)
-  s.add_runtime_dependency('redis-cluster-client', '>= 0.10.0')
+  # Patch-only within the current redis-cluster-client minor (pre-1.0, so minors may break and we
+  # rely on its internals — e.g. InitialSetupError). Bug/security patches flow; minors are gated.
+  s.add_runtime_dependency('redis-cluster-client', '~> 0.16.0')
 end

--- a/redis.gemspec
+++ b/redis.gemspec
@@ -44,5 +44,9 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.6.0'
 
-  s.add_runtime_dependency('redis-client', '>= 0.26.4')
+  # Pinned to a single redis-client minor: redis-rb couples tightly to redis-client internals
+  # (subclassing, ensure_connected/call_v overrides, config access, RESP3/HELLO behavior), and
+  # redis-client is pre-1.0 where minors may break. `~> 0.30.0` allows only patch upgrades
+  # (0.30.x) so bug/security fixes flow automatically; new minors require a deliberate redis-rb bump.
+  s.add_runtime_dependency('redis-client', '~> 0.30.0')
 end


### PR DESCRIPTION
Currently, the downstream dependency isn't pinned to a specific version (or range of versions), which can break existing users. Since, downstream `redis-client` and `redis-cluster-client` is still in development (0.x version), according to SemVer even minor version may contains breaking change.

For user safety, this PR pins downstream dependency to pull only patch releases for bug/security fixes. Minor and major releases requires manual bump and testing through separate PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change to gemspecs and changelogs; no application code paths are modified.
> 
> **Overview**
> Tightens **runtime dependency constraints** so installs no longer float to arbitrary newer `redis-client` / `redis-cluster-client` minors.
> 
> The main `redis` gem now requires **`redis-client` `~> 0.30.0`** (replacing `>= 0.26.4`), and **`redis-clustering`** requires **`redis-cluster-client` `~> 0.16.0`** (replacing `>= 0.10.0`). Gemspec comments document that redis-rb depends on redis-client internals and that 0.x minors may break, so only patch releases are allowed automatically.
> 
> **CHANGELOG** entries for both gems describe the policy and note that deliberate redis-rb releases are needed to adopt new downstream minors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41a4e56ddee0863edd16103af360fc5e60fdc99f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->