### PR TITLE
Bump ruby version to support non-EOL versions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,11 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.3
+
+# Ruby 3.1+ lets you omit hash values (`{ x: }`); allow both forms rather than forcing a rewrite.
+Style/HashSyntax:
+  EnforcedShorthandSyntax: either
 
 Layout/LineLength:
   Max: 120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
   with `WITHCOORD` now return coordinates as `Float` instead of `String`. Servers without RESP3
   (Redis < 6.0, or anything replying `NOPROTO`) transparently fall back to RESP2. See
   [specs/migration-resp3.md](specs/migration-resp3.md).
+- **Breaking**: now requires Ruby 3.3 or newer. redis-rb tracks the Ruby versions still under
+  official maintenance and drops them at end-of-life; see
+  https://www.ruby-lang.org/en/downloads/branches/.
 - Maintainership change: `redis-rb` is now maintained by the Redis Ltd company.
 - Bump `redis-client` to `>= 0.26.4` to fix reply desynchronization (e.g. `mget` returning `"OK"`) after a Sentinel failover/reconnect.
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,9 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'base64' # For older rubocop
 gem 'minitest'
 gem 'rake'
-gem 'rubocop', '~> 1.25.1'
+gem 'rubocop', '~> 1.88.0'
 gem 'mocha'
 
 gem 'hiredis-client'

--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ redis.get("mykey")
 All commands, their arguments, and return values are documented and
 available on [RubyDoc.info][rubydoc].
 
+## Language and server support
+
+redis-rb targets actively supported runtimes on both the language and the server side:
+
+- **Ruby:** the versions still under official maintenance (normal or security); a version is
+  dropped once it reaches end-of-life. See the [Ruby maintenance branches][ruby-branches] page for
+  each version's status and dates. The current minimum is **Ruby 3.3**.
+- **Redis server:** the versions designated for support (LTS) by Redis. See
+  [Supported Redis database versions][redis-versions]. The test suite runs against those versions
+  (currently the 7.2, 7.4, 8.2 and 8.8 lines).
+
 ## Protocol (RESP3)
 
 Starting in 6.0, the client negotiates the [RESP3 protocol][resp3] (`HELLO 3`)
@@ -440,11 +451,6 @@ the client object, specify hiredis:
 redis = Redis.new(driver: :hiredis)
 ```
 
-## Testing
-
-This library is tested against recent Ruby and Redis versions.
-Check [Github Actions][gh-actions-link] for the exact versions supported.
-
 ## See Also
 
 - [async-redis](https://github.com/socketry/async-redis) — An [async](https://github.com/socketry/async) compatible Redis client.
@@ -471,3 +477,5 @@ requests.
 [gh-actions-link]:   https://github.com/redis/redis-rb/actions
 [rubydoc]:           https://rubydoc.info/gems/redis
 [resp3]:             https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md
+[ruby-branches]:     https://www.ruby-lang.org/en/downloads/branches/
+[redis-versions]:    https://redis.io/docs/latest/operate/rc/databases/version-management/#supported-database-versions

--- a/README.md
+++ b/README.md
@@ -78,9 +78,8 @@ redis-rb targets actively supported runtimes on both the language and the server
 - **Ruby:** the versions still under official maintenance (normal or security); a version is
   dropped once it reaches end-of-life. See the [Ruby maintenance branches][ruby-branches] page for
   each version's status and dates. The current minimum is **Ruby 3.3**.
-- **Redis server:** the versions designated for support (LTS) by Redis. See
-  [Supported Redis database versions][redis-versions]. The test suite runs against those versions
-  (currently the 7.2, 7.4, 8.2 and 8.8 lines).
+- **Redis server:** the versions designated for support by Redis. See 
+[Supported Redis database versions][redis-versions].
 
 ## Protocol (RESP3)
 

--- a/cluster/CHANGELOG.md
+++ b/cluster/CHANGELOG.md
@@ -5,3 +5,5 @@
   with `WITHCOORD` now return coordinates as `Float` instead of `String`. Nodes without RESP3
   (Redis < 6.0, or anything replying `NOPROTO`) transparently fall back to RESP2. See
   [the RESP3 migration guide](../specs/migration-resp3.md).
+- **Breaking**: now requires Ruby 3.3 or newer, tracking the Ruby versions still under official
+  maintenance. See https://www.ruby-lang.org/en/downloads/branches/.

--- a/cluster/Gemfile
+++ b/cluster/Gemfile
@@ -7,7 +7,7 @@ gemspec
 gem 'redis', path: File.expand_path("..", __dir__)
 gem 'minitest'
 gem 'rake'
-gem 'rubocop', '~> 1.25.1'
+gem 'rubocop', '~> 1.88.0'
 gem 'mocha'
 
 group :test do

--- a/cluster/lib/redis/cluster.rb
+++ b/cluster/lib/redis/cluster.rb
@@ -65,7 +65,7 @@ class Redis
     # @option options [Class] :connector Class of custom connector
     #
     # @return [Redis::Cluster] a new client instance
-    def initialize(*) # rubocop:disable Lint/UselessMethodDefinition
+    def initialize(*)
       super
     end
     ruby2_keywords :initialize if respond_to?(:ruby2_keywords, true)

--- a/cluster/lib/redis/cluster/client.rb
+++ b/cluster/lib/redis/cluster/client.rb
@@ -27,7 +27,7 @@ class Redis
         def translate_error!(error, mapping: ERROR_MAPPING)
           case error
           when RedisClient::Cluster::ErrorCollection
-            error.errors.each do |_node, node_error|
+            error.errors.each_value do |node_error|
               if node_error.is_a?(RedisClient::AuthenticationError)
                 raise mapping.fetch(node_error.class), node_error.message, node_error.backtrace
               end

--- a/cluster/redis-clustering.gemspec
+++ b/cluster/redis-clustering.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.files         = Dir["CHANGELOG.md", "LICENSE", "README.md", "lib/**/*"]
   s.executables   = `git ls-files -- exe/*`.split("\n").map { |f| File.basename(f) }
 
-  s.required_ruby_version = '>= 2.7.0'
+  s.required_ruby_version = '>= 3.3.0'
 
   s.add_runtime_dependency('redis', s.version)
   s.add_runtime_dependency('redis-cluster-client', '>= 0.10.0')

--- a/cluster/test/helper.rb
+++ b/cluster/test/helper.rb
@@ -11,7 +11,7 @@ module Helper
     include Generic
 
     DEFAULT_HOST = '127.0.0.1'
-    DEFAULT_PORTS = (16_380..16_385).freeze
+    DEFAULT_PORTS = (16_380..16_385)
 
     ClusterSlotsRawReply = lambda { |host, port|
       # @see https://redis.io/topics/protocol

--- a/lib/redis/commands/sorted_sets.rb
+++ b/lib/redis/commands/sorted_sets.rb
@@ -366,7 +366,6 @@ class Redis
       #   - when `:with_scores` is specified, an array with `[member, score]` pairs
       def zrange(key, start, stop, byscore: false, by_score: byscore, bylex: false, by_lex: bylex,
                  rev: false, limit: nil, withscores: false, with_scores: withscores)
-
         if by_score && by_lex
           raise ArgumentError, "only one of :by_score or :by_lex can be specified"
         end

--- a/lib/redis/subscribe.rb
+++ b/lib/redis/subscribe.rb
@@ -80,7 +80,7 @@ class Redis
   end
 
   class Subscription
-    attr :callbacks
+    attr_reader :callbacks
 
     def initialize
       @callbacks = {}

--- a/redis.gemspec
+++ b/redis.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["CHANGELOG.md", "LICENSE", "README.md", "lib/**/*"]
 
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 3.3.0'
 
   s.add_runtime_dependency('redis-client', '>= 0.26.4')
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -68,7 +68,7 @@ module Helper
   class Version
     include Comparable
 
-    attr :parts
+    attr_reader :parts
 
     def initialize(version)
       @parts = case version

--- a/test/lint/streams.rb
+++ b/test/lint/streams.rb
@@ -3,7 +3,7 @@
 module Lint
   module Streams
     MIN_REDIS_VERSION = '4.9.0'
-    ENTRY_ID_FORMAT = /\d+-\d+/.freeze
+    ENTRY_ID_FORMAT = /\d+-\d+/
 
     def setup
       super


### PR DESCRIPTION
Raises the minimum Ruby to **3.3** for both `redis` and `redis-clustering`, and adds an explicit support policy to the README: `redis-rb` tracks the runtimes still under official maintenance on both sides and drops them at end-of-life.

The previous floors (`redis >= 2.6`, `redis-clustering >= 2.7`) were inherited from redis-client and pointed at Ruby versions that have been EOL for years `(2.6 since 2022, 2.7 since 2023)`. This aligns the declared minimum with what's actually maintained upstream and tested here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking for apps still on Ruby &lt; 3.3 at install time; runtime/client behavior changes in the diff are limited to small style refactors.
> 
> **Overview**
> **Breaking:** `redis` and `redis-clustering` now declare **`required_ruby_version >= 3.3.0`**, with matching **Unreleased** changelog entries. The README adds a **Language and server support** policy (maintained Ruby/Redis only, minimum Ruby 3.3) and drops the old standalone **Testing** section.
> 
> Tooling moves with the floor: **RuboCop** targets Ruby **3.3**, allows **either** hash shorthand via `Style/HashSyntax`, and **Gemfile**s bump **rubocop** to **~> 1.88.0** (and drop the legacy **base64** dev gem). A few small Ruby 3.3–friendly cleanups follow (e.g. `attr_reader`, `each_value`, dropping redundant `.freeze` on constants).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c3ec95c9af38754ed90a786b116733a5e836d7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->