### PR TITLE
Fixed FloatifyPairs to not transform already transformed structure

### DIFF
--- a/lib/redis/commands.rb
+++ b/lib/redis/commands.rb
@@ -97,7 +97,10 @@ class Redis
       return value unless value.respond_to?(:each_slice)
 
       if value.first.is_a?(Array) # RESP3 already returns [[member, score], ...]
-        value.map(&FloatifyPair)
+        # Scores arrive as native doubles, so the pairs are already in the final shape and
+        # re-mapping would only re-allocate identical arrays. Floatify only transforms Strings, so
+        # unless a score came back as one (it shouldn't under RESP3) return the parser's array as-is.
+        value.first.last.is_a?(String) ? value.map(&FloatifyPair) : value
       else # RESP2 flat [member, score, member, score, ...]
         value.each_slice(2).map(&FloatifyPair)
       end


### PR DESCRIPTION
In RESP3 the doubles already parsed as floats, added check to not apply float conversion for RESP3 responses

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small reply-shaping optimization with unchanged RESP2 behavior and a fallback when scores are strings.
> 
> **Overview**
> **`FloatifyPairs`** no longer runs **`map(&FloatifyPair)`** on RESP3 sorted-set replies when scores are already numeric (non-`String`), returning the parser’s `[[member, score], ...]` array unchanged.
> 
> RESP2 flat `[member, score, ...]` handling is unchanged. If a RESP3 score is still a `String` (e.g. `inf`), conversion still runs via **`FloatifyPair`**.
> 
> This affects commands that reshape member/score pairs (e.g. **`zpopmax`**, **`zpopmin`**, blocking pop paths using **`FloatifyPairs`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f29a8eed21b869c242bbc46c508d85134da2c718. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->