### PR TITLE
Added support for new SUNIONCARD and SDIFFCARD

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         ruby_distribution: [MRI, TruffleRuby]
         ruby_version: ["3.3", "3.4", "4.0"]
-        redis_version: ["7.2.14", "7.4.9", "8.2.6", "8.8.0", "unstable-27987813126-debian"]
+        redis_version: ["7.2.14", "7.4.9", "8.2.6", "8.8.0", "unstable-29454887387-debian"]
         driver: [default, hiredis]
         exclude:
           # TruffleRuby's C extension support (Sulong) cannot build hiredis cleanly.

--- a/lib/redis/commands/sets.rb
+++ b/lib/redis/commands/sets.rb
@@ -135,6 +135,26 @@ class Redis
         send_command([:sdiffstore, destination].concat(keys))
       end
 
+      # Get the number of members in the difference between the first set and
+      # all successive sets.
+      #
+      # @example
+      #   redis.sadd("foo", ["s1", "s2", "s3"])
+      #   redis.sadd("bar", "s3")
+      #   redis.sdiffcard("foo", "bar")
+      #     # => 2
+      #
+      # @param [String, Array<String>] keys keys pointing to sets to subtract
+      # @param [Integer] limit stop counting once the difference reaches `limit`
+      #   members (`0` means unlimited)
+      # @return [Integer] number of members in the difference
+      def sdiffcard(*keys, limit: nil)
+        keys.flatten!(1)
+        args = [:sdiffcard, keys.size].concat(keys)
+        args << "LIMIT" << Integer(limit) if limit
+        send_command(args)
+      end
+
       # Intersect multiple sets.
       #
       # @param [String, Array<String>] keys keys pointing to sets to intersect
@@ -171,6 +191,27 @@ class Redis
       def sunionstore(destination, *keys)
         keys.flatten!(1)
         send_command([:sunionstore, destination].concat(keys))
+      end
+
+      # Get the number of distinct members in the union of multiple sets.
+      #
+      # @example
+      #   redis.sadd("foo", ["s1", "s2", "s3"])
+      #   redis.sadd("bar", ["s3", "s4"])
+      #   redis.sunioncard("foo", "bar")
+      #     # => 4
+      #
+      # @param [String, Array<String>] keys keys pointing to sets to unify
+      # @param [Boolean] approx return an approximate cardinality computed with HyperLogLog
+      # @param [Integer] limit stop counting once the union reaches `limit`
+      #   members (`0` means unlimited)
+      # @return [Integer] number of distinct members in the union
+      def sunioncard(*keys, approx: false, limit: nil)
+        keys.flatten!(1)
+        args = [:sunioncard, keys.size].concat(keys)
+        args << "APPROX" if approx
+        args << "LIMIT" << Integer(limit) if limit
+        send_command(args)
       end
 
       # Scan a set

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -767,6 +767,15 @@ class Redis
       end
     end
 
+    # Get the number of members in the difference between the first set and
+    # all successive sets.
+    def sdiffcard(*keys, limit: nil)
+      keys.flatten!(1)
+      ensure_same_node(:sdiffcard, keys) do |node|
+        node.sdiffcard(keys, limit: limit)
+      end
+    end
+
     # Intersect multiple sets.
     def sinter(*keys)
       keys.flatten!(1)
@@ -796,6 +805,14 @@ class Redis
       keys.flatten!(1)
       ensure_same_node(:sunionstore, [destination].concat(keys)) do |node|
         node.sunionstore(destination, keys)
+      end
+    end
+
+    # Get the number of distinct members in the union of multiple sets.
+    def sunioncard(*keys, approx: false, limit: nil)
+      keys.flatten!(1)
+      ensure_same_node(:sunioncard, keys) do |node|
+        node.sunioncard(keys, approx: approx, limit: limit)
       end
     end
 

--- a/test/distributed/commands_on_sets_test.rb
+++ b/test/distributed/commands_on_sets_test.rb
@@ -79,6 +79,18 @@ class TestDistributedCommandsOnSets < Minitest::Test
     end
   end
 
+  def test_sdiffcard_with_keys_on_different_nodes
+    assert_raises Redis::Distributed::CannotDistribute do
+      r.sdiffcard('foo', 'bar')
+    end
+  end
+
+  def test_sunioncard_with_keys_on_different_nodes
+    assert_raises Redis::Distributed::CannotDistribute do
+      r.sunioncard('foo', 'bar')
+    end
+  end
+
   def test_sscan
     r.sadd 'foo', 's1'
     r.sadd 'foo', 's2'

--- a/test/lint/sets.rb
+++ b/test/lint/sets.rb
@@ -318,6 +318,93 @@ module Lint
       assert_equal 2, r.sdiffstore('{1}baz', '{1}foo', '{1}bar')
     end
 
+    def test_sdiffcard
+      target_version('8.10') do
+        r.sadd('{1}foo', %w[s1 s2 s3 s4 s5])
+        r.sadd('{1}bar', %w[s3 s4])
+        r.sadd('{1}baz', 's5')
+
+        assert_equal 2, r.sdiffcard('{1}foo', '{1}bar', '{1}baz')
+        assert_equal 0, r.sdiffcard('{1}bar', '{1}foo')
+      end
+    end
+
+    def test_sdiffcard_with_single_key
+      target_version('8.10') do
+        r.sadd('{1}foo', %w[s1 s2 s3])
+
+        assert_equal 3, r.sdiffcard('{1}foo')
+        assert_equal 0, r.sdiffcard('{1}nonexistent')
+      end
+    end
+
+    def test_variadic_sdiffcard_expand
+      target_version('8.10') do
+        r.sadd('{1}foo', %w[s1 s2 s3])
+        r.sadd('{1}bar', 's3')
+
+        assert_equal 2, r.sdiffcard(['{1}foo', '{1}bar'])
+      end
+    end
+
+    def test_sdiffcard_with_limit
+      target_version('8.10') do
+        r.sadd('{1}foo', %w[s1 s2 s3 s4])
+        r.sadd('{1}bar', 's4')
+
+        assert_equal 2, r.sdiffcard('{1}foo', '{1}bar', limit: 2)
+        assert_equal 3, r.sdiffcard('{1}foo', '{1}bar', limit: 0)
+      end
+    end
+
+    def test_sunioncard
+      target_version('8.10') do
+        r.sadd('{1}foo', %w[s1 s2 s3])
+        r.sadd('{1}bar', %w[s3 s4])
+
+        assert_equal 4, r.sunioncard('{1}foo', '{1}bar')
+      end
+    end
+
+    def test_sunioncard_with_single_key
+      target_version('8.10') do
+        r.sadd('{1}foo', %w[s1 s2 s3])
+
+        assert_equal 3, r.sunioncard('{1}foo')
+        assert_equal 0, r.sunioncard('{1}nonexistent')
+      end
+    end
+
+    def test_variadic_sunioncard_expand
+      target_version('8.10') do
+        r.sadd('{1}foo', %w[s1 s2])
+        r.sadd('{1}bar', %w[s2 s3])
+
+        assert_equal 3, r.sunioncard(['{1}foo', '{1}bar'])
+      end
+    end
+
+    def test_sunioncard_with_approx
+      target_version('8.10') do
+        r.sadd('{1}foo', %w[s1 s2 s3])
+        r.sadd('{1}bar', %w[s3 s4])
+
+        assert_equal r.sunioncard('{1}foo', '{1}bar'),
+                     r.sunioncard('{1}foo', '{1}bar', approx: true)
+      end
+    end
+
+    def test_sunioncard_with_limit
+      target_version('8.10') do
+        r.sadd('{1}foo', %w[s1 s2 s3])
+        r.sadd('{1}bar', %w[s3 s4])
+
+        assert_equal 2, r.sunioncard('{1}foo', '{1}bar', limit: 2)
+        assert_equal 4, r.sunioncard('{1}foo', '{1}bar', limit: 0)
+        assert_equal 2, r.sunioncard('{1}foo', '{1}bar', approx: true, limit: 2)
+      end
+    end
+
     def test_sscan
       r.sadd('foo', %w[1 2 3 foo foobar feelsgood])
       assert_equal %w[0 feelsgood foo foobar], r.sscan('foo', 0, match: 'f*').flatten.sort


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive API and tests for new Redis commands; distributed behavior follows existing multi-key set command patterns with no auth or data-model changes.
> 
> **Overview**
> Adds Ruby client bindings for Redis **8.10+** set cardinality commands **`SDIFFCARD`** and **`SUNIONCARD`**, mirroring existing multi-key set helpers like `sdiff` / `sunion`.
> 
> On the standalone client, **`sdiffcard`** sends the key count plus optional **`LIMIT`**, and **`sunioncard`** adds optional **`APPROX`** and **`LIMIT`**. **`Redis::Distributed`** routes both through **`ensure_same_node`** (same pattern as `sdiff` / `sunion`) and raises **`CannotDistribute`** when keys span nodes—covered by new distributed tests.
> 
> Lint tests in **`test/lint/sets.rb`** exercise multi-key, single-key, array expansion, limits, and approximate union counting behind **`target_version('8.10')`**. CI bumps the unstable Redis matrix image so those commands can run in the pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20ef3e9d8ce7b34d51145a0ac386738c20270040. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->