### PR TITLE
Added new arguments MAXCOUNT and MAXSIZE to XREAD/XREADROUP

### DIFF
--- a/lib/redis/commands/streams.rb
+++ b/lib/redis/commands/streams.rb
@@ -183,18 +183,28 @@ class Redis
       #   redis.xread(%w[mystream1 mystream2], %w[0-0 0-0])
       # @example With count option
       #   redis.xread('mystream', '0-0', count: 2)
+      # @example With max_count option
+      #   redis.xread(%w[mystream1 mystream2], %w[0-0 0-0], max_count: 10)
       # @example With block option
       #   redis.xread('mystream', '$', block: 1000)
       #
-      # @param keys  [Array<String>] one or multiple stream keys
-      # @param ids   [Array<String>] one or multiple entry ids
-      # @param count [Integer]       the number of entries as limit per stream
-      # @param block [Integer]       the number of milliseconds as blocking timeout
+      # @param keys      [Array<String>] one or multiple stream keys
+      # @param ids       [Array<String>] one or multiple entry ids
+      # @param count     [Integer]       the number of entries as limit per stream
+      # @param max_count [Integer]       the total number of entries as limit across all streams
+      #   combined, must be greater than or equal to `count` when both are given (Redis 8.10+).
+      #   Defaults to unlimited.
+      # @param max_size  [Integer]       soft cap on the total reply size in bytes across all
+      #   streams combined, measured on the serialized server reply including protocol overhead;
+      #   a single oversized first entry can still be returned (Redis 8.10+). Defaults to unlimited.
+      # @param block     [Integer]       the number of milliseconds as blocking timeout
       #
       # @return [Hash{String => Hash{String => Hash}}] the entries
-      def xread(keys, ids, count: nil, block: nil)
+      def xread(keys, ids, count: nil, max_count: nil, max_size: nil, block: nil)
         args = [:xread]
         args << 'COUNT' << count if count
+        args << 'MAXCOUNT' << Integer(max_count) if max_count
+        args << 'MAXSIZE' << Integer(max_size) if max_size
         args << 'BLOCK' << block.to_i if block
         _xread(args, keys, ids, block)
       end
@@ -245,14 +255,22 @@ class Redis
       # @param ids      [Array<String>] one or multiple entry ids
       # @param opts     [Hash]          several options for `XREADGROUP` command
       #
-      # @option opts [Integer] :count the number of entries as limit
+      # @option opts [Integer] :count the number of entries as limit per stream
+      # @option opts [Integer] :max_count the total number of entries as limit across all streams
+      #   combined, must be greater than or equal to `count` when both are given (Redis 8.10+).
+      #   Defaults to unlimited.
+      # @option opts [Integer] :max_size soft cap on the total reply size in bytes across all
+      #   streams combined, measured on the serialized server reply including protocol overhead;
+      #   a single oversized first entry can still be returned (Redis 8.10+). Defaults to unlimited.
       # @option opts [Integer] :block the number of milliseconds as blocking timeout
       # @option opts [Boolean] :noack whether message loss is acceptable or not
       #
       # @return [Hash{String => Hash{String => Hash}}] the entries
-      def xreadgroup(group, consumer, keys, ids, count: nil, block: nil, noack: nil)
+      def xreadgroup(group, consumer, keys, ids, count: nil, max_count: nil, max_size: nil, block: nil, noack: nil)
         args = [:xreadgroup, 'GROUP', group, consumer]
         args << 'COUNT' << count if count
+        args << 'MAXCOUNT' << Integer(max_count) if max_count
+        args << 'MAXSIZE' << Integer(max_size) if max_size
         args << 'BLOCK' << block.to_i if block
         args << 'NOACK' if noack
         _xread(args, keys, ids, block)

--- a/test/lint/streams.rb
+++ b/test/lint/streams.rb
@@ -469,6 +469,82 @@ module Lint
       assert_equal 1, actual['s1'].size
     end
 
+    def test_xread_with_max_count_option
+      target_version('8.10') do
+        redis.xadd('{s}1', { f: 'v01' }, id: '0-1')
+        redis.xadd('{s}1', { f: 'v02' }, id: '0-2')
+        redis.xadd('{s}2', { f: 'v11' }, id: '1-1')
+        redis.xadd('{s}2', { f: 'v12' }, id: '1-2')
+
+        actual = redis.xread(%w[{s}1 {s}2], %w[0 0], max_count: 3)
+
+        assert_equal 2, actual['{s}1'].size
+        assert_equal 1, actual['{s}2'].size
+        assert_equal 'v11', actual['{s}2'][0].last['f']
+      end
+    end
+
+    def test_xread_with_count_and_max_count_options
+      target_version('8.10') do
+        redis.xadd('{s}1', { f: 'v01' }, id: '0-1')
+        redis.xadd('{s}1', { f: 'v02' }, id: '0-2')
+        redis.xadd('{s}1', { f: 'v03' }, id: '0-3')
+        redis.xadd('{s}2', { f: 'v11' }, id: '1-1')
+        redis.xadd('{s}2', { f: 'v12' }, id: '1-2')
+
+        actual = redis.xread(%w[{s}1 {s}2], %w[0 0], count: 2, max_count: 3)
+
+        assert_equal 2, actual['{s}1'].size
+        assert_equal 1, actual['{s}2'].size
+      end
+    end
+
+    def test_xread_with_max_size_option
+      target_version('8.10') do
+        redis.xadd('{s}1', { f: 'v01' }, id: '0-1')
+        redis.xadd('{s}1', { f: 'v02' }, id: '0-2')
+        redis.xadd('{s}2', { f: 'v11' }, id: '1-1')
+
+        capped = redis.xread(%w[{s}1 {s}2], %w[0 0], max_size: 1)
+
+        assert_equal 1, capped['{s}1'].size
+        assert_equal 'v01', capped['{s}1'][0].last['f']
+        refute capped.key?('{s}2')
+
+        uncapped = redis.xread(%w[{s}1 {s}2], %w[0 0], max_size: 1_048_576)
+
+        assert_equal 2, uncapped['{s}1'].size
+        assert_equal 1, uncapped['{s}2'].size
+      end
+    end
+
+    def test_xread_with_max_count_and_block_options
+      target_version('8.10') do
+        redis.xadd('s1', { f: 'v1' }, id: '0-1')
+        redis.xadd('s1', { f: 'v2' }, id: '0-2')
+
+        actual = redis.xread('s1', 0, max_count: 1, block: LOW_TIMEOUT * 1000)
+
+        assert_equal 1, actual['s1'].size
+
+        empty = redis.xread('s1', '$', max_count: 1, block: LOW_TIMEOUT * 1000)
+
+        assert_equal({}, empty)
+      end
+    end
+
+    def test_xread_with_invalid_max_count_and_max_size
+      target_version('8.10') do
+        redis.xadd('s1', { f: 'v1' }, id: '0-1')
+
+        assert_raises(Redis::CommandError) { redis.xread('s1', 0, max_count: 0) }
+        assert_raises(Redis::CommandError) { redis.xread('s1', 0, max_size: 0) }
+        assert_raises(Redis::CommandError) { redis.xread('s1', 0, count: 2, max_count: 1) }
+        assert_raises(ArgumentError) { redis.xread('s1', 0, max_count: 'a') }
+        assert_raises(ArgumentError) { redis.xread('s1', 0, max_size: 'a') }
+      end
+    end
+
     def test_xread_with_block_option
       actual = redis.xread('s1', '$', block: LOW_TIMEOUT * 1000)
       assert_equal({}, actual)
@@ -599,6 +675,48 @@ module Lint
       actual = redis.xreadgroup('g1', 'c1', 's1', '>', block: LOW_TIMEOUT * 1000)
 
       assert_equal({}, actual)
+    end
+
+    def test_xreadgroup_with_max_count_option
+      target_version('8.10') do
+        redis.xadd('{s}1', { f: 'v01' }, id: '0-1')
+        redis.xadd('{s}1', { f: 'v02' }, id: '0-2')
+        redis.xadd('{s}2', { f: 'v11' }, id: '1-1')
+        redis.xadd('{s}2', { f: 'v12' }, id: '1-2')
+        redis.xgroup(:create, '{s}1', 'g1', '0')
+        redis.xgroup(:create, '{s}2', 'g1', '0')
+
+        actual = redis.xreadgroup('g1', 'c1', %w[{s}1 {s}2], %w[> >], max_count: 3)
+
+        assert_equal 2, actual['{s}1'].size
+        assert_equal 1, actual['{s}2'].size
+        assert_equal 'v11', actual['{s}2'][0].last['f']
+      end
+    end
+
+    def test_xreadgroup_with_max_size_option
+      target_version('8.10') do
+        redis.xadd('{s}1', { f: 'v01' }, id: '0-1')
+        redis.xadd('{s}1', { f: 'v02' }, id: '0-2')
+        redis.xgroup(:create, '{s}1', 'g1', '0')
+
+        actual = redis.xreadgroup('g1', 'c1', '{s}1', '>', max_size: 1)
+
+        assert_equal 1, actual['{s}1'].size
+        assert_equal 'v01', actual['{s}1'][0].last['f']
+      end
+    end
+
+    def test_xreadgroup_with_invalid_max_count_and_max_size
+      target_version('8.10') do
+        redis.xadd('s1', { f: 'v1' }, id: '0-1')
+        redis.xgroup(:create, 's1', 'g1', '0')
+
+        assert_raises(Redis::CommandError) { redis.xreadgroup('g1', 'c1', 's1', '>', max_count: 0) }
+        assert_raises(Redis::CommandError) { redis.xreadgroup('g1', 'c1', 's1', '>', max_size: 0) }
+        assert_raises(Redis::CommandError) { redis.xreadgroup('g1', 'c1', 's1', '>', count: 2, max_count: 1) }
+        assert_raises(ArgumentError) { redis.xreadgroup('g1', 'c1', 's1', '>', max_count: 'a') }
+      end
     end
 
     def test_xreadgroup_with_invalid_arguments


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Backward-compatible optional keyword arguments on existing stream read APIs; behavior only changes when callers opt in and requires Redis 8.10+ for the new server flags.
> 
> **Overview**
> Adds Redis **8.10+** stream read limits to the Ruby client: optional `max_count` and `max_size` on **`xread`** and **`xreadgroup`**, emitted as `MAXCOUNT` / `MAXSIZE` before `BLOCK` when set. Values are coerced with `Integer()` so non-numeric inputs raise **`ArgumentError`** on the client; server rules (e.g. `max_count` ≥ `count`, non-zero limits) still surface as **`Redis::CommandError`**.
> 
> Docs now distinguish per-stream **`count`** from cross-stream **`max_count`** and document **`max_size`** as a soft reply-byte cap. Lint coverage exercises multi-stream behavior, interaction with **`count`** / **`block`**, and the same options on **`xreadgroup`**, all behind **`target_version('8.10')`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 479f9fbd2101c0297f2a74be3b5164a0f5a31775. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->