### PR TITLE
Added explicit testing for FT.SEARCH timeout policies

### DIFF
--- a/lib/redis/commands/modules/search/result.rb
+++ b/lib/redis/commands/modules/search/result.rb
@@ -74,13 +74,18 @@ class Redis
         # @return [Integer] the total number of matching documents (may exceed +documents.size+
         #   because of paging)
         # @return [Array<Document>] the documents on this page
-        attr_reader :total, :documents
+        # @return [Array<String>] any warnings returned by the server (e.g. a query timeout under
+        #   the +return+ policy); only the RESP3 wire carries warnings on FT.SEARCH, so this is
+        #   always empty on RESP2 connections
+        attr_reader :total, :documents, :warnings
 
         # @param total [Integer] the total number of matching documents
         # @param documents [Array<Document>] the documents on this page
-        def initialize(total, documents)
+        # @param warnings [Array<String>] any warnings returned by the server
+        def initialize(total, documents, warnings: [])
           @total = total
           @documents = documents
+          @warnings = warnings
         end
 
         # Iterate over the documents on this page.
@@ -290,7 +295,7 @@ class Redis
                                     payload: row["payload"])
           end
 
-          SearchResult.new(reply["total_results"], documents)
+          SearchResult.new(reply["total_results"], documents, warnings: reply["warning"] || [])
         end
 
         # FT.AGGREGATE / FT.CURSOR READ -> AggregateResult

--- a/test/lint/search.rb
+++ b/test/lint/search.rb
@@ -720,6 +720,109 @@ module Lint
       assert_equal 2, result.total
     end
 
+    # ---- Server-side query timeout policies (search-on-timeout) ------------------------------
+
+    SEARCH_TIMEOUT_DIM = 8192
+    SEARCH_TIMEOUT_DOCS = 1500
+
+    # Build a large FLAT vector index and bulk-load enough documents that a full KNN scan with
+    # TIMEOUT 1 (1 ms) reliably exceeds the limit on the server.
+    def create_search_timeout_index
+      schema = Schema.build do
+        text_field :description
+        vector_field :embedding, :flat, type: :float32, dim: SEARCH_TIMEOUT_DIM,
+                                        distance_metric: :l2
+      end
+      # The prefix: keyword appends ":" on the wire, so documents live at "search-timeout-item:<i>".
+      r.create_index(@index_name, schema, prefix: "search-timeout-item")
+      wait_for_index(@index_name)
+    end
+
+    def add_data_for_search_timeout
+      vectors = [0.1, 0.2, 0.3, 0.4, 0.5].map { |v| ([v] * SEARCH_TIMEOUT_DIM).pack("f*") }
+      SEARCH_TIMEOUT_DOCS.times.each_slice(250) do |batch|
+        r.pipelined do |pipe|
+          batch.each do |i|
+            pipe.hset("search-timeout-item:#{i}",
+                      "description" => "red shoes",
+                      "embedding" => vectors[i % vectors.size])
+          end
+        end
+      end
+      wait_for_index(@index_name, 30.0)
+    end
+
+    def search_timeout_query(**options)
+      query_vector = ([0.25] * SEARCH_TIMEOUT_DIM).pack("f*")
+      r.ft_search(@index_name, "*=>[KNN #{SEARCH_TIMEOUT_DOCS} @embedding $vec]",
+                  params: { vec: query_vector }, dialect: 2, timeout: 1, **options)
+    end
+
+    def test_ft_search_query_with_timeout
+      create_search_timeout_index
+      add_data_for_search_timeout
+
+      result = search_timeout_query
+
+      # A timed-out search under the default `return` policy still yields a well-formed
+      # (partial) result.
+      assert_kind_of Integer, result.total
+      assert_operator result.total, :>=, 0
+
+      if PROTOCOL == 3
+        # Only the RESP3 wire carries the server timeout warning.
+        assert(result.warnings.any? { |warning| warning.include?("Timeout limit was reached") },
+               "expected a timeout warning, got: #{result.warnings.inspect}")
+      else
+        # The RESP2 wire does not carry the warning field on FT.SEARCH.
+        assert_equal [], result.warnings
+      end
+    end
+
+    def test_ft_search_query_with_timeout_fail_policy
+      target_version("8.9") do
+        create_search_timeout_index
+        add_data_for_search_timeout
+
+        original = nil
+        begin
+          original = r.config(:get, "search-on-timeout")["search-on-timeout"]
+          r.config(:set, "search-on-timeout", "fail")
+
+          # With the `fail` policy the server aborts the timed-out search instead of
+          # returning partial results.
+          assert_raises(Redis::CommandError) { search_timeout_query }
+        ensure
+          r.config(:set, "search-on-timeout", original) if original
+        end
+      end
+    end
+
+    def test_ft_search_query_with_timeout_return_strict_policy
+      target_version("8.9") do
+        create_search_timeout_index
+        add_data_for_search_timeout
+
+        original = nil
+        begin
+          original = r.config(:get, "search-on-timeout")["search-on-timeout"]
+          r.config(:set, "search-on-timeout", "return-strict")
+
+          # `return-strict` still returns a well-formed (partial) reply for a plain
+          # timed-out search, carrying the same timeout warning as `return`.
+          result = search_timeout_query
+
+          assert_kind_of Integer, result.total
+          if PROTOCOL == 3
+            assert(result.warnings.any? { |warning| warning.include?("Timeout limit was reached") },
+                   "expected a timeout warning, got: #{result.warnings.inspect}")
+          end
+        ensure
+          r.config(:set, "search-on-timeout", original) if original
+        end
+      end
+    end
+
     # ---- Suggestions / dictionaries / synonyms / aliases -------------------------------------
 
     def test_ft_sugadd_and_sugget

--- a/test/modules/search_offline_test.rb
+++ b/test/modules/search_offline_test.rb
@@ -634,6 +634,27 @@ class TestSearchOffline < Minitest::Test
     assert_in_delta 2.0, result[0].score
   end
 
+  def test_search_resp3_exposes_server_warnings
+    # A timed-out search under the `return` policy carries a "warning" list on the RESP3 wire.
+    reply = {
+      "total_results" => 1,
+      "results" => [{ "id" => "doc1", "extra_attributes" => { "title" => "Hello" } }],
+      "warning" => ["Timeout limit was reached"]
+    }
+    result = RP.search(reply)
+    assert_equal ["Timeout limit was reached"], result.warnings
+  end
+
+  def test_search_warnings_default_to_empty
+    # RESP3 without a warning field, and RESP2 (whose wire never carries warnings), both
+    # expose an empty list rather than nil.
+    resp3 = RP.search({ "total_results" => 0, "results" => [] })
+    assert_equal [], resp3.warnings
+
+    resp2 = RP.search([1, "doc1", ["title", "Hello"]])
+    assert_equal [], resp2.warnings
+  end
+
   # ---- Aggregate reshaping -----------------------------------------------------------------
 
   def test_aggregate_resp2_rows


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive API on SearchResult with backward-compatible defaults; changes are limited to search result parsing and test coverage.
> 
> **Overview**
> **`SearchResult`** now includes a **`warnings`** array (default `[]`), populated from the RESP3 **`warning`** field when parsing **`FT.SEARCH`** replies. RESP2 paths still yield an empty list because that wire format does not carry warnings.
> 
> Integration tests exercise **`search-on-timeout`** with a heavy KNN query and **`TIMEOUT 1`**: default **`return`** (partial results plus timeout warning on RESP3), **`fail`** (command error on Redis ≥ 8.9), and **`return-strict`** (partial reply with the same warning). Offline tests cover RESP3 warning parsing and empty defaults for RESP2/RESP3 without warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 708c066f4c1770fb2d9c8e513cf0f9c1cfec5d3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->