### PR TITLE
Added support for FT.ALIASLIST command

### DIFF
--- a/lib/redis/commands/modules/search/miscellaneous.rb
+++ b/lib/redis/commands/modules/search/miscellaneous.rb
@@ -551,6 +551,15 @@ class Redis
         send_command(["FT.ALIASDEL", alias_name])
       end
 
+      # List all aliases associated with an index (Redis 8.10+).
+      #
+      # @param index_name [String] the index name
+      # @return [Array<String>] the aliases pointing to the index (empty when none)
+      # @raise [Redis::CommandError] if the index does not exist
+      def ft_aliaslist(index_name)
+        send_command(["FT.ALIASLIST", index_name])
+      end
+
       # Add terms to a custom dictionary.
       #
       # @param dict_name [String] the dictionary name

--- a/test/lint/search.rb
+++ b/test/lint/search.rb
@@ -910,6 +910,25 @@ module Lint
       r.ft_dropindex("new_index")
     end
 
+    def test_ft_aliaslist
+      target_version("8.10") do
+        schema = Schema.build { text_field :title }
+        r.create_index(@index_name, schema)
+
+        assert_equal [], r.ft_aliaslist(@index_name)
+
+        r.ft_aliasadd("alias1", @index_name)
+        r.ft_aliasadd("alias2", @index_name)
+
+        assert_equal %w[alias1 alias2], r.ft_aliaslist(@index_name).sort
+
+        r.ft_aliasdel("alias1")
+        assert_equal ["alias2"], r.ft_aliaslist(@index_name)
+
+        assert_raises(Redis::CommandError) { r.ft_aliaslist("nonexistent-index") }
+      end
+    end
+
     # ---- Filters (numeric + geo) -------------------------------------------------------------
 
     def test_ft_search_numeric_and_geo_filters


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Thin command wrapper and integration test only; no changes to parsing, connection, or existing alias APIs.
> 
> **Overview**
> Adds client support for the RediSearch **`FT.ALIASLIST`** command (Redis **8.10+**), alongside the existing alias add/update/delete helpers.
> 
> The new **`ft_aliaslist(index_name)`** issues `FT.ALIASLIST` and returns an array of alias names for that index (empty when none). Documentation notes that a missing index raises **`Redis::CommandError`**.
> 
> **`test_ft_aliaslist`** in the search lint suite (behind **`target_version("8.10")`**) checks empty lists, multiple aliases, updates after delete, and error on a nonexistent index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 741d1c578397e162bf4a515ba987f27ff59d7469. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->