### PR TITLE
Added support for LMOVEM/BLMOVEM list commands

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         ruby_distribution: [MRI, TruffleRuby]
         ruby_version: ["3.3", "3.4", "4.0"]
-        redis_version: ["7.2.14", "7.4.9", "8.2.6", "8.8.0", "unstable-29454887387-debian"]
+        redis_version: ["7.2.14", "7.4.9", "8.2.6", "8.8.0", "8.10-rc2"]
         driver: [default, hiredis]
         exclude:
           # TruffleRuby's C extension support (Sulong) cannot build hiredis cleanly.

--- a/cluster/test/commands_on_lists_test.rb
+++ b/cluster/test/commands_on_lists_test.rb
@@ -17,4 +17,28 @@ class TestClusterCommandsOnLists < Minitest::Test
   def test_rpoplpush
     assert_raises(Redis::CommandError) { super }
   end
+
+  def test_lmovem
+    target_version "8.9" do
+      assert_raises(Redis::CommandError) { super }
+    end
+  end
+
+  def test_lmovem_count_obo
+    target_version "8.9" do
+      assert_raises(Redis::CommandError) { super }
+    end
+  end
+
+  def test_lmovem_count_bulk
+    target_version "8.9" do
+      assert_raises(Redis::CommandError) { super }
+    end
+  end
+
+  def test_lmovem_exactly
+    target_version "8.9" do
+      assert_raises(Redis::CommandError) { super }
+    end
+  end
 end

--- a/lib/redis/commands/lists.rb
+++ b/lib/redis/commands/lists.rb
@@ -30,6 +30,53 @@ class Redis
         send_command([:lmove, source, destination, where_source, where_destination])
       end
 
+      # Remove multiple elements from the head/tail of a list, append/prepend
+      # them to another list and return them.
+      #
+      # @example Move a single element (still an array reply)
+      #   redis.lmovem("foo", "bar", "LEFT", "LEFT")
+      #     # => ["s1"]
+      # @example Move up to 3 elements, pushed one-by-one (block order reversed)
+      #   redis.lmovem("foo", "bar", "LEFT", "LEFT", count: 3, order: "OBO")
+      #     # => ["s3", "s2", "s1"]
+      # @example Move exactly 2 elements, preserving their relative order
+      #   redis.lmovem("foo", "bar", "LEFT", "RIGHT", exactly: 2, order: "BULK")
+      #     # => ["s1", "s2"]
+      #
+      # @param [String] source source key
+      # @param [String] destination destination key
+      # @param [String, Symbol] where_source from where to remove elements from the source list
+      #     e.g. 'LEFT' - from head, 'RIGHT' - from tail
+      # @param [String, Symbol] where_destination where to push elements to the destination list
+      #     e.g. 'LEFT' - to head, 'RIGHT' - to tail
+      # @param [Integer] count move up to `count` elements, fewer when the source holds fewer
+      # @param [Integer] exactly move exactly `exactly` elements; when the source holds fewer,
+      #     nothing is moved
+      # @param [String, Symbol] order ordering at the destination, required together with
+      #     `count` or `exactly`:
+      #  - when `'OBO'` - push each element as popped, so the moved block order is reversed
+      #  - when `'BULK'` - preserve the original relative order of the moved elements
+      #
+      # @return [nil, Array<String>] the moved elements in destination order, or nil when
+      #     nothing was moved
+      def lmovem(source, destination, where_source, where_destination, count: nil, exactly: nil, order: nil)
+        where_source, where_destination = _normalize_move_wheres(where_source, where_destination)
+
+        raise ArgumentError, "Pick either count or exactly, not both" if count && exactly
+
+        args = [:lmovem, source, destination, where_source, where_destination]
+        if count || exactly
+          order = order.to_s.upcase
+          raise ArgumentError, "order must be 'OBO' or 'BULK'" if order != "OBO" && order != "BULK"
+
+          args << (count ? "COUNT" : "EXACTLY") << Integer(count || exactly) << order
+        elsif order
+          raise ArgumentError, "order requires count or exactly"
+        end
+
+        send_command(args)
+      end
+
       # Remove the first/last element in a list and append/prepend it
       # to another list and return it, or block until one is available.
       #

--- a/lib/redis/commands/lists.rb
+++ b/lib/redis/commands/lists.rb
@@ -62,19 +62,50 @@ class Redis
       def lmovem(source, destination, where_source, where_destination, count: nil, exactly: nil, order: nil)
         where_source, where_destination = _normalize_move_wheres(where_source, where_destination)
 
-        raise ArgumentError, "Pick either count or exactly, not both" if count && exactly
-
         args = [:lmovem, source, destination, where_source, where_destination]
-        if count || exactly
-          order = order.to_s.upcase
-          raise ArgumentError, "order must be 'OBO' or 'BULK'" if order != "OBO" && order != "BULK"
-
-          args << (count ? "COUNT" : "EXACTLY") << Integer(count || exactly) << order
-        elsif order
-          raise ArgumentError, "order requires count or exactly"
-        end
+        args.concat(_movem_amount_args(count, exactly, order))
 
         send_command(args)
+      end
+
+      # Remove multiple elements from the head/tail of a list, append/prepend
+      # them to another list and return them; or block until the request can
+      # be satisfied or the timeout expires.
+      #
+      # @example Move up to 3 elements as soon as any are available
+      #   redis.blmovem("foo", "bar", "LEFT", "LEFT", timeout: 1, count: 3, order: "BULK")
+      #     # => ["s1", "s2", "s3"]
+      # @example Block until the source holds at least 2 elements
+      #   redis.blmovem("foo", "bar", "LEFT", "RIGHT", timeout: 1, exactly: 2, order: "OBO")
+      #     # => nil on timeout
+      #
+      # @param [String] source source key
+      # @param [String] destination destination key
+      # @param [String, Symbol] where_source from where to remove elements from the source list
+      #     e.g. 'LEFT' - from head, 'RIGHT' - from tail
+      # @param [String, Symbol] where_destination where to push elements to the destination list
+      #     e.g. 'LEFT' - to head, 'RIGHT' - to tail
+      # @param [Float, Integer] timeout seconds to block, 0 blocks indefinitely
+      # @param [Integer] count move up to `count` elements as soon as at least one is available
+      # @param [Integer] exactly move exactly `exactly` elements, blocking until the source
+      #     holds that many
+      # @param [String, Symbol] order ordering at the destination, required together with
+      #     `count` or `exactly`:
+      #  - when `'OBO'` - push each element as popped, so the moved block order is reversed
+      #  - when `'BULK'` - preserve the original relative order of the moved elements
+      #
+      # @return [nil, Array<String>] the moved elements in destination order, or nil when the
+      #     timeout expired and nothing was moved
+      #
+      # @see #lmovem
+      def blmovem(source, destination, where_source, where_destination, timeout: 0, count: nil, exactly: nil,
+                  order: nil)
+        where_source, where_destination = _normalize_move_wheres(where_source, where_destination)
+
+        command = [:blmovem, source, destination, where_source, where_destination, timeout]
+        command.concat(_movem_amount_args(count, exactly, order))
+
+        send_blocking_command(command, timeout)
       end
 
       # Remove the first/last element in a list and append/prepend it
@@ -365,6 +396,21 @@ class Redis
         command = [cmd].concat(args)
         command << timeout
         send_blocking_command(command, timeout, &blk)
+      end
+
+      def _movem_amount_args(count, exactly, order)
+        raise ArgumentError, "Pick either count or exactly, not both" if count && exactly
+
+        if count || exactly
+          order = order.to_s.upcase
+          raise ArgumentError, "order must be 'OBO' or 'BULK'" if order != "OBO" && order != "BULK"
+
+          [count ? "COUNT" : "EXACTLY", Integer(count || exactly), order]
+        elsif order
+          raise ArgumentError, "order requires count or exactly"
+        else
+          []
+        end
       end
 
       def _normalize_move_wheres(where_source, where_destination)

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -545,6 +545,15 @@ class Redis
       end
     end
 
+    # Remove multiple elements from the head/tail of a list, append/prepend
+    # them to another list and return them.
+    def lmovem(source, destination, where_source, where_destination, count: nil, exactly: nil, order: nil)
+      ensure_same_node(:lmovem, [source, destination]) do |node|
+        node.lmovem(source, destination, where_source, where_destination,
+                    count: count, exactly: exactly, order: order)
+      end
+    end
+
     # Remove the first/last element in a list and append/prepend it
     # to another list and return it, or block until one is available.
     def blmove(source, destination, where_source, where_destination, timeout: 0)

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -562,6 +562,17 @@ class Redis
       end
     end
 
+    # Remove multiple elements from the head/tail of a list, append/prepend
+    # them to another list and return them; or block until the request can
+    # be satisfied or the timeout expires.
+    def blmovem(source, destination, where_source, where_destination, timeout: 0, count: nil, exactly: nil,
+                order: nil)
+      ensure_same_node(:blmovem, [source, destination]) do |node|
+        node.blmovem(source, destination, where_source, where_destination,
+                     timeout: timeout, count: count, exactly: exactly, order: order)
+      end
+    end
+
     # Prepend one or more values to a list.
     def lpush(key, value)
       node_for(key).lpush(key, value)

--- a/test/distributed/commands_on_lists_test.rb
+++ b/test/distributed/commands_on_lists_test.rb
@@ -14,6 +14,55 @@ class TestDistributedCommandsOnLists < Minitest::Test
     end
   end
 
+  def test_lmovem
+    target_version "8.9" do
+      assert_raises Redis::Distributed::CannotDistribute do
+        r.lmovem('foo', 'bar', 'LEFT', 'RIGHT')
+      end
+    end
+  end
+
+  def test_lmovem_count_obo
+    target_version "8.9" do
+      assert_raises Redis::Distributed::CannotDistribute do
+        r.lmovem('foo', 'bar', 'LEFT', 'LEFT', count: 3, order: 'OBO')
+      end
+    end
+  end
+
+  def test_lmovem_count_bulk
+    target_version "8.9" do
+      assert_raises Redis::Distributed::CannotDistribute do
+        r.lmovem('foo', 'bar', 'LEFT', 'LEFT', count: 3, order: 'BULK')
+      end
+    end
+  end
+
+  def test_lmovem_exactly
+    target_version "8.9" do
+      assert_raises Redis::Distributed::CannotDistribute do
+        r.lmovem('foo', 'bar', 'LEFT', 'RIGHT', exactly: 2, order: 'BULK')
+      end
+    end
+  end
+
+  def test_lmovem_argument_errors
+    target_version "8.9" do
+      assert_raises Redis::Distributed::CannotDistribute do
+        r.lmovem('foo', 'bar', 'LEFT', 'RIGHT', count: 1, order: 'BULK')
+      end
+    end
+  end
+
+  def test_lmovem_with_key_tags
+    target_version "8.9" do
+      r.rpush('{tag}foo', %w[1 2 3])
+
+      assert_equal %w[1 2], r.lmovem('{tag}foo', '{tag}bar', 'LEFT', 'RIGHT', count: 2, order: 'BULK')
+      assert_equal %w[1 2], r.lrange('{tag}bar', 0, -1)
+    end
+  end
+
   def test_rpoplpush
     assert_raises Redis::Distributed::CannotDistribute do
       r.rpoplpush('foo', 'bar')

--- a/test/lint/blocking_commands.rb
+++ b/test/lint/blocking_commands.rb
@@ -36,6 +36,10 @@ module Lint
           sleep options[:delay] if options.key?(:delay)
           to_protocol(args.last)
         end,
+        blmovem: lambda do |*args|
+          sleep options[:delay] if options.key?(:delay)
+          to_protocol([args[4]])
+        end,
         blpop: lambda do |*args|
           sleep options[:delay] if options.key?(:delay)
           to_protocol([args.first, args.last])
@@ -72,6 +76,59 @@ module Lint
         mock do |r|
           assert_equal '0', r.blmove('{zap}foo', '{zap}bar', 'LEFT', 'RIGHT')
           assert_equal LOW_TIMEOUT.to_s, r.blmove('{zap}foo', '{zap}bar', 'LEFT', 'RIGHT', timeout: LOW_TIMEOUT)
+        end
+      end
+    end
+
+    def test_blmovem
+      target_version "8.9" do
+        # setup: {zap}foo = [s1, s2], {zap}bar = [s1, s2]
+        assert_equal ['s1'], r.blmovem('{zap}foo', '{zap}bar', 'LEFT', 'RIGHT')
+        assert_equal ['s2'], r.lrange('{zap}foo', 0, -1)
+        assert_equal ['s1', 's2', 's1'], r.lrange('{zap}bar', 0, -1)
+
+        assert_equal ['s2'], r.blmovem('{zap}foo', '{zap}bar', 'LEFT', 'LEFT', count: 5, order: 'BULK')
+        assert_equal ['s2', 's1', 's2', 's1'], r.lrange('{zap}bar', 0, -1)
+
+        assert_equal %w[s2 s1], r.blmovem('{zap}bar', '{zap}foo', 'RIGHT', 'LEFT', exactly: 2, order: 'OBO')
+        assert_equal %w[s2 s1], r.lrange('{zap}foo', 0, -1)
+      end
+    end
+
+    def test_blmovem_timeout
+      target_version "8.9" do
+        mock do |r|
+          assert_equal ['0'], r.blmovem('{zap}foo', '{zap}bar', 'LEFT', 'RIGHT')
+          assert_equal [LOW_TIMEOUT.to_s], r.blmovem('{zap}foo', '{zap}bar', 'LEFT', 'RIGHT', timeout: LOW_TIMEOUT)
+        end
+      end
+    end
+
+    def test_blmovem_blocks_until_timeout
+      target_version "8.9" do
+        # empty source: blocks, then nil
+        assert_nil r.blmovem('{zap}empty', '{zap}bar', 'LEFT', 'LEFT', timeout: LOW_TIMEOUT)
+
+        # EXACTLY more than available: blocks, then nil, lists unchanged
+        assert_nil r.blmovem('{zap}foo', '{zap}bar', 'LEFT', 'LEFT', timeout: LOW_TIMEOUT, exactly: 5, order: 'BULK')
+        assert_equal %w[s1 s2], r.lrange('{zap}foo', 0, -1)
+        assert_equal %w[s1 s2], r.lrange('{zap}bar', 0, -1)
+      end
+    end
+
+    def test_blmovem_argument_errors
+      target_version "8.9" do
+        assert_raises(ArgumentError) do
+          r.blmovem('{zap}foo', '{zap}bar', 'LEFT', 'MIDDLE')
+        end
+        assert_raises(ArgumentError) do
+          r.blmovem('{zap}foo', '{zap}bar', 'LEFT', 'RIGHT', count: 1, exactly: 1, order: 'BULK')
+        end
+        assert_raises(ArgumentError) do
+          r.blmovem('{zap}foo', '{zap}bar', 'LEFT', 'RIGHT', count: 1)
+        end
+        assert_raises(ArgumentError) do
+          r.blmovem('{zap}foo', '{zap}bar', 'LEFT', 'RIGHT', order: 'BULK')
         end
       end
     end

--- a/test/lint/lists.rb
+++ b/test/lint/lists.rb
@@ -29,6 +29,98 @@ module Lint
       end
     end
 
+    def test_lmovem
+      target_version "8.9" do
+        r.rpush("foo", ["s1", "s2", "s3"])
+        r.rpush("bar", ["s4", "s5"])
+
+        assert_nil r.lmovem("nonexistent", "foo", "LEFT", "LEFT")
+
+        # no count/exactly: single element, still an array reply
+        assert_equal ["s1"], r.lmovem("foo", "bar", "LEFT", "LEFT") # foo = [s2, s3], bar = [s1, s4, s5]
+        assert_equal ["s3"], r.lmovem("foo", "bar", "RIGHT", "RIGHT") # foo = [s2], bar = [s1, s4, s5, s3]
+        assert_equal ["s2"], r.lrange("foo", 0, -1)
+        assert_equal ["s1", "s4", "s5", "s3"], r.lrange("bar", 0, -1)
+      end
+    end
+
+    def test_lmovem_count_obo
+      target_version "8.9" do
+        r.rpush("foo", ["1", "2", "3", "4", "5"])
+        r.rpush("bar", ["6", "7", "8", "9", "10"])
+
+        # OBO pushes each element as popped, so the moved block order is reversed
+        assert_equal ["3", "2", "1"], r.lmovem("foo", "bar", "LEFT", "LEFT", count: 3, order: "OBO")
+        assert_equal ["3", "2", "1", "6", "7", "8", "9", "10"], r.lrange("bar", 0, -1)
+        assert_equal ["4", "5"], r.lrange("foo", 0, -1)
+
+        # COUNT moves up to count: fewer when the source holds fewer
+        assert_equal ["4", "5"], r.lmovem("foo", "bar", "LEFT", "RIGHT", count: 10, order: "OBO")
+        assert_equal ["4", "5"], r.lrange("bar", -2, -1)
+        assert_nil r.lmovem("foo", "bar", "LEFT", "LEFT", count: 2, order: "OBO")
+      end
+    end
+
+    def test_lmovem_count_bulk
+      target_version "8.9" do
+        r.rpush("foo", ["1", "2", "3", "4", "5"])
+        r.rpush("bar", ["6", "7", "8", "9", "10"])
+
+        # BULK preserves the original relative order of the moved elements
+        assert_equal ["1", "2", "3"], r.lmovem("foo", "bar", "LEFT", "LEFT", count: 3, order: "BULK")
+        assert_equal ["1", "2", "3", "6", "7", "8", "9", "10"], r.lrange("bar", 0, -1)
+        assert_equal ["4", "5"], r.lrange("foo", 0, -1)
+      end
+    end
+
+    def test_lmovem_exactly
+      target_version "8.9" do
+        r.rpush("foo", ["1", "2", "3"])
+
+        assert_equal ["1", "2"], r.lmovem("foo", "bar", "LEFT", "RIGHT", exactly: 2, order: "BULK")
+        assert_equal ["1", "2"], r.lrange("bar", 0, -1)
+
+        # EXACTLY with too few elements moves nothing; source is unchanged
+        assert_nil r.lmovem("foo", "bar", "LEFT", "RIGHT", exactly: 2, order: "BULK")
+        assert_equal ["3"], r.lrange("foo", 0, -1)
+        assert_equal ["1", "2"], r.lrange("bar", 0, -1)
+      end
+    end
+
+    def test_lmovem_argument_errors
+      target_version "8.9" do
+        error = assert_raises(ArgumentError) do
+          r.lmovem("foo", "bar", "LEFT", "MIDDLE")
+        end
+        assert_equal "where_destination must be 'LEFT' or 'RIGHT'", error.message
+
+        assert_raises(ArgumentError) do
+          r.lmovem("foo", "bar", "LEFT", "RIGHT", count: 1, exactly: 1, order: "BULK")
+        end
+
+        # count/exactly require an order, and an order requires count/exactly
+        assert_raises(ArgumentError) do
+          r.lmovem("foo", "bar", "LEFT", "RIGHT", count: 1)
+        end
+        assert_raises(ArgumentError) do
+          r.lmovem("foo", "bar", "LEFT", "RIGHT", order: "BULK")
+        end
+
+        # non-positive count is rejected by the server
+        r.rpush("foo", "s1")
+        assert_raises(Redis::CommandError) do
+          r.lmovem("foo", "bar", "LEFT", "RIGHT", count: 0, order: "BULK")
+        end
+
+        # WRONGTYPE when a key holds something else; nothing is moved
+        r.set("string", "value")
+        assert_raises(Redis::CommandError) do
+          r.lmovem("string", "bar", "LEFT", "RIGHT", count: 1, order: "BULK")
+        end
+        assert_equal ["s1"], r.lrange("foo", 0, -1)
+      end
+    end
+
     def test_lpush
       r.lpush "foo", "s1"
       r.lpush "foo", "s2"

--- a/test/lint/search.rb
+++ b/test/lint/search.rb
@@ -911,7 +911,7 @@ module Lint
     end
 
     def test_ft_aliaslist
-      target_version("8.10") do
+      target_version("8.9") do
         schema = Schema.build { text_field :title }
         r.create_index(@index_name, schema)
 

--- a/test/redis/blocking_commands_test.rb
+++ b/test/redis/blocking_commands_test.rb
@@ -27,6 +27,28 @@ class TestBlockingCommands < Minitest::Test
     end
   end
 
+  def test_blmovem_disable_client_timeout
+    target_version "8.9" do
+      assert_takes_longer_than_client_timeout do |r|
+        assert_equal ['0'], r.blmovem('foo', 'bar', 'LEFT', 'RIGHT')
+      end
+    end
+  end
+
+  def test_blmovem_unblocks_when_enough_elements_arrive
+    target_version "8.9" do
+      writer = Thread.new do
+        sleep 0.1
+        Redis.new(OPTIONS).rpush('foo', %w[a b])
+      end
+
+      assert_equal %w[a b], r.blmovem('foo', 'bar', 'LEFT', 'RIGHT', timeout: 2, exactly: 2, order: 'BULK')
+      assert_equal %w[a b], r.lrange('bar', 0, -1)
+    ensure
+      writer&.join
+    end
+  end
+
   def test_blpop_disable_client_timeout
     assert_takes_longer_than_client_timeout do |r|
       assert_equal %w[foo 0], r.blpop('foo')


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive list-command wrappers with argument validation and tests; no changes to auth, persistence, or existing command behavior.
> 
> **Overview**
> Adds Ruby client support for Redis **8.9+** list commands **`LMOVEM`** and **`BLMOVEM`**, mirroring the existing `lmove` / `blmove` API.
> 
> `lmovem` and `blmovem` move one or more elements between lists with optional **`count`** or **`exactly`**, plus required **`order`** (`OBO` vs `BULK`) when batching. A new **`_movem_amount_args`** helper validates mutually exclusive options and builds the wire args. **`Redis::Distributed`** delegates both commands through **`ensure_same_node`** like other two-key list ops.
> 
> Tests cover standalone, distributed (including hash-tagged keys), cluster error cases, blocking timeouts, and client-timeout behavior. CI now runs against **`8.10-rc2`** instead of an unstable Debian image, and **`ft_aliaslist`** lint is gated at **8.9** instead of **8.10**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ef5d400d2757447f41f8832672b3077dd692460. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->