### PR TITLE
Added support for HIMPORT commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Unreleased
 
+- Add support for the `HIMPORT` command family (Redis 8.10, hinted hash templates): `himport_prepare`,
+  `himport_set`, `himport_discard`, `himport_discard_all`, available on standalone clients,
+  pipelines/transactions and `Redis::Distributed` (fan-out prepare/discard). Fieldsets are
+  server-side per-connection session state; the client remembers each prepared schema and, when a
+  `himport_set` reports the fieldset was lost (reconnect, failover, `RESET`), re-prepares it and
+  retries once. Disable with `himport_auto_prepare: false`. See the README "Bulk hash ingestion
+  (HIMPORT)" section.
 - Add support for the Redis Query Engine (RediSearch, `FT.*`): index management
   (`ft_create`/`create_index`, `ft_alter`, `ft_dropindex`, `ft_info`), querying (`ft_search` with a
   `Search::Query` builder, `ft_aggregate` with `Search::AggregateRequest`), vector and hybrid search,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
   pre-1.0 driver family delivers behavior changes in patch releases, so a floating patch
   constraint can change client semantics under a stable `redis` release. Driver bumps are now
   deliberate, suite-verified events.
-- Add support for the `HIMPORT` command family (Redis 8.10, hinted hash templates): `himport_prepare`,
+- **Experimental**: add support for the `HIMPORT` command family (Redis 8.10, hinted hash
+  templates) — the client API may change in a future minor release without a major version
+  bump: `himport_prepare`,
   `himport_set`, `himport_discard`, `himport_discard_all`, available on standalone clients,
   pipelines/transactions and `Redis::Distributed` (fan-out prepare/discard). Fieldsets are
   server-side per-connection session state; the client remembers each prepared schema and, when a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+- Pin the `redis-client` dependency to the exact version `0.30.1` (previously `~> 0.30.0`): the
+  pre-1.0 driver family delivers behavior changes in patch releases, so a floating patch
+  constraint can change client semantics under a stable `redis` release. Driver bumps are now
+  deliberate, suite-verified events.
 - Add support for the `HIMPORT` command family (Redis 8.10, hinted hash templates): `himport_prepare`,
   `himport_set`, `himport_discard`, `himport_discard_all`, available on standalone clients,
   pipelines/transactions and `Redis::Distributed` (fan-out prepare/discard). Fieldsets are

--- a/README.md
+++ b/README.md
@@ -280,6 +280,66 @@ incr.value
 # => 1
 ```
 
+## Bulk hash ingestion (HIMPORT)
+
+Redis 8.10 adds the `HIMPORT` command family for loading many hashes that share
+the same set of field names: register the field names once with
+`himport_prepare`, then create each hash by sending only its values. Keys
+written this way are regular hashes — every hash command works on them.
+
+```ruby
+redis.himport_prepare("users", ["name", "email", "age"])
+redis.himport_set("user:1", "users", ["alice", "alice@example.com", "25"])
+redis.himport_set("user:2", "users", ["bob", "bob@example.com", "30"])
+redis.himport_discard("users") # => 1
+```
+
+Values pair positionally with the prepared fields. Note that hash enumeration
+order (`HGETALL`, `HKEYS`) is not guaranteed to match the prepare order.
+
+### Fieldsets are connection state
+
+A prepared fieldset lives in the server-side session of the physical connection
+that prepared it: it is invisible to other connections and destroyed by a
+disconnect or `RESET`. A `himport_set` on a connection without the fieldset
+fails with `ERR no such fieldset`.
+
+Because a `Redis` instance transparently replaces a dead connection (see
+[Reconnections](#reconnections)), the client keeps the last schema prepared for
+each fieldset name and, when a `himport_set` reports the fieldset is gone,
+re-prepares it and retries the command once. Explicitly discarded fieldsets are
+never restored. To keep the fieldset lifecycle fully explicit instead, disable
+the recovery:
+
+```ruby
+redis = Redis.new(himport_auto_prepare: false)
+```
+
+For the highest ingestion throughput, send the `PREPARE` and its `SET`s as one
+pipeline — a single batch always executes on a single connection:
+
+```ruby
+redis.pipelined do |pipeline|
+  pipeline.himport_prepare("users", ["name", "email", "age"])
+  rows.each { |id, row| pipeline.himport_set("user:#{id}", "users", row) }
+end
+```
+
+If the `PREPARE` in a batch fails, every `SET` in it fails with
+`no such fieldset` — the `PREPARE` error is the root cause. Note that the
+automatic re-prepare applies to direct calls only, not to commands inside
+`pipelined`/`multi` blocks.
+
+When using the `connection_pool` gem, each checkout may hand you a different
+underlying connection: run `himport_prepare` and its `himport_set` calls within
+one checkout (`pool.with { |redis| ... }`), ideally as one pipelined block.
+
+With `Redis::Distributed`, `himport_prepare`, `himport_discard` and
+`himport_discard_all` fan out to every ring node and return an array with one
+reply per node; `himport_set` routes by key. With `Redis::Cluster`, the same
+commands fan out to every master node and return a single aggregated reply,
+matching the standalone API.
+
 ## Error Handling
 
 In general, if something goes wrong you'll get an exception. For example, if

--- a/README.md
+++ b/README.md
@@ -282,6 +282,10 @@ incr.value
 
 ## Bulk hash ingestion (HIMPORT)
 
+> **Experimental:** HIMPORT support is experimental. The client API (method
+> signatures, reply aggregation on cluster, and the automatic re-prepare
+> behavior) may change in a future minor release without a major version bump.
+
 Redis 8.10 adds the `HIMPORT` command family for loading many hashes that share
 the same set of field names: register the field names once with
 `himport_prepare`, then create each hash by sending only its values. Keys

--- a/cluster/CHANGELOG.md
+++ b/cluster/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Unreleased
 
+- Add first-class support for the `HIMPORT` command family (Redis 8.10): `himport_prepare`,
+  `himport_discard` and `himport_discard_all` execute on all master nodes (per the commands'
+  `request_policy:all_shards` tip) and return a single aggregated reply; `himport_set` routes by its
+  key's hash slot with MOVED/ASK handling preserved. Fieldset loss (node failover, topology reload,
+  redirection to a fresh connection) is repaired automatically by re-fanning out the last prepared
+  schema and retrying the SET once; disable with `himport_auto_prepare: false`. Partial fan-out
+  failures raise `Redis::Cluster::CommandErrorCollection`.
 - **Breaking**: the client now negotiates RESP3 (`HELLO 3`) by default; pass `protocol: 2` to keep
   RESP2. The only command whose return value changes is GEO — `GEOPOS` and `GEOSEARCH`/`GEORADIUS`
   with `WITHCOORD` now return coordinates as `Float` instead of `String`. Nodes without RESP3

--- a/cluster/CHANGELOG.md
+++ b/cluster/CHANGELOG.md
@@ -1,16 +1,31 @@
 # Unreleased
 
-- Add first-class support for the `HIMPORT` command family (Redis 8.10): `himport_prepare`,
+- **Experimental**: add first-class support for the `HIMPORT` command family (Redis 8.10) — the
+  client API may change in a future minor release without a major version bump: `himport_prepare`,
   `himport_discard` and `himport_discard_all` execute on all master nodes (per the commands'
   `request_policy:all_shards` tip) and return a single aggregated reply; `himport_set` routes by its
   key's hash slot with MOVED/ASK handling preserved. Routing is performed natively by
-  redis-cluster-client, which since 0.16.6 parses command tips and per-subcommand key specs; the
-  dependency is now pinned to the exact version `0.16.7`, since the driver ships behavior changes
-  in patch releases. Fieldset loss (node failover, topology reload, redirection to a
+  redis-cluster-client, which since 0.16.6 parses command tips and per-subcommand key specs (see
+  the pin entry below). Fieldset loss (node failover, topology reload, redirection to a
   fresh connection) is repaired automatically by re-fanning out the last prepared schema and
   retrying the SET once; disable with `himport_auto_prepare: false`. Partial fan-out failures raise
   `Redis::Cluster::CommandErrorCollection`. Inside `multi`, an `himport_set` pins the transaction to
   its key's slot and an accompanying `himport_prepare` executes on that same pinned connection.
+- **Breaking**: redis-cluster-client 0.16.6+ routes commands by their server-declared command tips
+  (`request_policy`/`response_policy`), which changes the behavior of a few commands that were
+  previously sent to one arbitrary node:
+  - `SLOWLOG GET` now returns an **array with one entry list per master** (previously a single
+    node's entry list) — the only reply-*shape* change.
+  - `SLOWLOG LEN` and `LATENCY RESET` still return an `Integer`, but now the **sum across all
+    masters** instead of one node's value.
+  - `FUNCTION LOAD`/`DELETE`/`FLUSH`/`RESTORE` now execute on **all masters** (reply unchanged).
+    This corrects a bug where functions were loaded onto a single arbitrary node and `FCALL`
+    failed for keys owned by the other masters.
+  - Container commands with keys in subcommands (e.g. `XINFO STREAM`) now route directly to the
+    key's slot owner and can pin a `multi` transaction (previously they raised
+    `Redis::Cluster::TransactionConsistencyError`).
+  Everything covered by the driver's legacy routing table (`PING`, `DBSIZE`, `KEYS`, `FLUSHALL`,
+  `SCRIPT`, `CONFIG`, `CLIENT`, `ACL`, `MEMORY`, `INFO`, multi-key commands, …) is unchanged.
 - **Breaking**: the client now negotiates RESP3 (`HELLO 3`) by default; pass `protocol: 2` to keep
   RESP2. The only command whose return value changes is GEO — `GEOPOS` and `GEOSEARCH`/`GEORADIUS`
   with `WITHCOORD` now return coordinates as `Float` instead of `String`. Nodes without RESP3
@@ -18,5 +33,6 @@
   [the RESP3 migration guide](../specs/migration-resp3.md).
 - **Breaking**: now requires Ruby 3.3 or newer, tracking the Ruby versions still under official
   maintenance. See https://www.ruby-lang.org/en/downloads/branches/.
-- Pin `redis-cluster-client` to `~> 0.16.0` (patch-only), so bug/security patches flow automatically
-  while minor/major upgrades are gated behind a deliberate release.
+- Pin `redis-cluster-client` to the exact version `0.16.7`: the driver ships behavior changes in
+  patch releases (see the command-tips entry above), so upgrades — including patches — are gated
+  behind a deliberate, suite-verified release.

--- a/cluster/CHANGELOG.md
+++ b/cluster/CHANGELOG.md
@@ -3,10 +3,14 @@
 - Add first-class support for the `HIMPORT` command family (Redis 8.10): `himport_prepare`,
   `himport_discard` and `himport_discard_all` execute on all master nodes (per the commands'
   `request_policy:all_shards` tip) and return a single aggregated reply; `himport_set` routes by its
-  key's hash slot with MOVED/ASK handling preserved. Fieldset loss (node failover, topology reload,
-  redirection to a fresh connection) is repaired automatically by re-fanning out the last prepared
-  schema and retrying the SET once; disable with `himport_auto_prepare: false`. Partial fan-out
-  failures raise `Redis::Cluster::CommandErrorCollection`.
+  key's hash slot with MOVED/ASK handling preserved. Routing is performed natively by
+  redis-cluster-client, which since 0.16.6 parses command tips and per-subcommand key specs; the
+  dependency is now pinned to the exact version `0.16.7`, since the driver ships behavior changes
+  in patch releases. Fieldset loss (node failover, topology reload, redirection to a
+  fresh connection) is repaired automatically by re-fanning out the last prepared schema and
+  retrying the SET once; disable with `himport_auto_prepare: false`. Partial fan-out failures raise
+  `Redis::Cluster::CommandErrorCollection`. Inside `multi`, an `himport_set` pins the transaction to
+  its key's slot and an accompanying `himport_prepare` executes on that same pinned connection.
 - **Breaking**: the client now negotiates RESP3 (`HELLO 3`) by default; pass `protocol: 2` to keep
   RESP2. The only command whose return value changes is GEO — `GEOPOS` and `GEOSEARCH`/`GEORADIUS`
   with `WITHCOORD` now return coordinates as `Float` instead of `String`. Nodes without RESP3

--- a/cluster/lib/redis/cluster.rb
+++ b/cluster/lib/redis/cluster.rb
@@ -139,13 +139,20 @@ class Redis
     # schema is re-fanned out and the SET retried once. Opt out with
     # `Redis::Cluster.new(himport_auto_prepare: false)`.
 
+    # As in the standalone overrides, @monitor is held across the server command AND the registry
+    # mutation so another thread's recovery path can't observe (and act on) a schema whose
+    # fieldset was just discarded on the servers. @monitor is reentrant; the nested synchronize
+    # and himport_prepare calls re-enter it safely.
+
     def himport_prepare(fieldset_name, *fields)
       fields.flatten!(1)
       raise ArgumentError, "fields must not be empty" if fields.empty?
 
-      reply = synchronize { |c| c.himport_fan_out([:himport, "PREPARE", fieldset_name].concat(fields)) }.first
-      @himport_fieldsets[fieldset_name.to_s] = fields.dup.freeze
-      reply
+      @monitor.synchronize do
+        reply = synchronize { |c| c.himport_fan_out([:himport, "PREPARE", fieldset_name].concat(fields)) }.first
+        @himport_fieldsets[fieldset_name.to_s] = fields.dup.freeze
+        reply
+      end
     end
 
     def himport_set(key, fieldset_name, *values)
@@ -153,7 +160,7 @@ class Redis
       raise ArgumentError, "values must not be empty" if values.empty?
 
       command = [:himport, "SET", key, fieldset_name].concat(values)
-      begin
+      @monitor.synchronize do
         synchronize { |c| c.himport_call_by_key(key, command) }
       rescue CommandError => error
         fields = @himport_fieldsets[fieldset_name.to_s]
@@ -165,15 +172,19 @@ class Redis
     end
 
     def himport_discard(fieldset_name)
-      reply = synchronize { |c| c.himport_fan_out([:himport, "DISCARD", fieldset_name]) }.max
-      @himport_fieldsets.delete(fieldset_name.to_s)
-      reply
+      @monitor.synchronize do
+        reply = synchronize { |c| c.himport_fan_out([:himport, "DISCARD", fieldset_name]) }.max
+        @himport_fieldsets.delete(fieldset_name.to_s)
+        reply
+      end
     end
 
     def himport_discard_all
-      reply = synchronize { |c| c.himport_fan_out([:himport, "DISCARDALL"]) }.max
-      @himport_fieldsets.clear
-      reply
+      @monitor.synchronize do
+        reply = synchronize { |c| c.himport_fan_out([:himport, "DISCARDALL"]) }.max
+        @himport_fieldsets.clear
+        reply
+      end
     end
 
     private

--- a/cluster/lib/redis/cluster.rb
+++ b/cluster/lib/redis/cluster.rb
@@ -125,6 +125,57 @@ class Redis
       synchronize { |c| c.watch(*keys, &block) }
     end
 
+    # HIMPORT on cluster: PREPARE/DISCARD/DISCARDALL carry request_policy:all_shards, so they
+    # fan out to every primary (fieldsets are per-connection session state and HIMPORT SET is a
+    # write that can be routed to any primary). SET routes by its key's slot like any other
+    # keyed write. Fan-out replies are aggregated to keep standalone/cluster API parity (like
+    # FLUSHALL): PREPARE returns the first "OK" (all-or-raise), the discards return the max
+    # across primaries — per-node integers can legitimately diverge when a node joined after
+    # the PREPARE. Partial fan-out failures raise Redis::Cluster::CommandErrorCollection whose
+    # #errors hash tells you which nodes failed; nodes that replied OK keep their fieldsets.
+    #
+    # Fieldset loss (node failover, topology reload, MOVED/ASK onto a connection that never saw
+    # the PREPARE) is repaired like in standalone: on "no such fieldset" the last prepared
+    # schema is re-fanned out and the SET retried once. Opt out with
+    # `Redis::Cluster.new(himport_auto_prepare: false)`.
+
+    def himport_prepare(fieldset_name, *fields)
+      fields.flatten!(1)
+      raise ArgumentError, "fields must not be empty" if fields.empty?
+
+      reply = synchronize { |c| c.himport_fan_out([:himport, "PREPARE", fieldset_name].concat(fields)) }.first
+      @himport_fieldsets[fieldset_name.to_s] = fields.dup.freeze
+      reply
+    end
+
+    def himport_set(key, fieldset_name, *values)
+      values.flatten!(1)
+      raise ArgumentError, "values must not be empty" if values.empty?
+
+      command = [:himport, "SET", key, fieldset_name].concat(values)
+      begin
+        synchronize { |c| c.himport_call_by_key(key, command) }
+      rescue CommandError => error
+        fields = @himport_fieldsets[fieldset_name.to_s]
+        raise unless @himport_auto_prepare && fields && error.message.include?("no such fieldset")
+
+        himport_prepare(fieldset_name, fields)
+        synchronize { |c| c.himport_call_by_key(key, command) }
+      end
+    end
+
+    def himport_discard(fieldset_name)
+      reply = synchronize { |c| c.himport_fan_out([:himport, "DISCARD", fieldset_name]) }.max
+      @himport_fieldsets.delete(fieldset_name.to_s)
+      reply
+    end
+
+    def himport_discard_all
+      reply = synchronize { |c| c.himport_fan_out([:himport, "DISCARDALL"]) }.max
+      @himport_fieldsets.clear
+      reply
+    end
+
     private
 
     def initialize_client(options)

--- a/cluster/lib/redis/cluster.rb
+++ b/cluster/lib/redis/cluster.rb
@@ -125,66 +125,37 @@ class Redis
       synchronize { |c| c.watch(*keys, &block) }
     end
 
-    # HIMPORT on cluster: PREPARE/DISCARD/DISCARDALL carry request_policy:all_shards, so they
-    # fan out to every primary (fieldsets are per-connection session state and HIMPORT SET is a
-    # write that can be routed to any primary). SET routes by its key's slot like any other
-    # keyed write. Fan-out replies are aggregated to keep standalone/cluster API parity (like
-    # FLUSHALL): PREPARE returns the first "OK" (all-or-raise), the discards return the max
+    # HIMPORT on cluster: redis-cluster-client (>= 0.16.6) routes the whole family natively from
+    # the server's command metadata — PREPARE/DISCARD/DISCARDALL fan out to all primaries per
+    # their request_policy:all_shards tip (fieldsets are per-connection session state, so every
+    # primary's connection needs its own copy), and SET routes by its key's slot via the
+    # per-subcommand key spec. HIMPORT defines no response_policy today, so fan-out replies
+    # arrive as one-per-primary arrays; these overrides aggregate them for standalone/cluster
+    # API parity: PREPARE returns the first "OK" (all-or-raise), the discards return the max
     # across primaries — per-node integers can legitimately diverge when a node joined after
-    # the PREPARE. Partial fan-out failures raise Redis::Cluster::CommandErrorCollection whose
-    # #errors hash tells you which nodes failed; nodes that replied OK keep their fieldsets.
+    # the PREPARE. The Array guard keeps the user-facing contract ("OK" / Integer) stable if a
+    # future server release adds a response_policy: the driver then aggregates the fan-out
+    # itself and hands us a scalar, which we pass through instead of crashing on String#first.
+    # Partial fan-out failures raise Redis::Cluster::CommandErrorCollection whose #errors hash
+    # tells you which nodes failed; nodes that replied OK keep their fieldsets.
     #
-    # Fieldset loss (node failover, topology reload, MOVED/ASK onto a connection that never saw
-    # the PREPARE) is repaired like in standalone: on "no such fieldset" the last prepared
-    # schema is re-fanned out and the SET retried once. Opt out with
-    # `Redis::Cluster.new(himport_auto_prepare: false)`.
-
-    # As in the standalone overrides, @monitor is held across the server command AND the registry
-    # mutation so another thread's recovery path can't observe (and act on) a schema whose
-    # fieldset was just discarded on the servers. @monitor is reentrant; the nested synchronize
-    # and himport_prepare calls re-enter it safely.
+    # The fieldset registry, monitor atomicity and loss-recovery (on "no such fieldset" the
+    # last prepared schema is re-fanned out — through these overrides — and the SET retried
+    # once) are inherited from the Redis superclass unchanged; `himport_set` needs no override.
 
     def himport_prepare(fieldset_name, *fields)
-      fields.flatten!(1)
-      raise ArgumentError, "fields must not be empty" if fields.empty?
-
-      @monitor.synchronize do
-        reply = synchronize { |c| c.himport_fan_out([:himport, "PREPARE", fieldset_name].concat(fields)) }.first
-        @himport_fieldsets[fieldset_name.to_s] = fields.dup.freeze
-        reply
-      end
-    end
-
-    def himport_set(key, fieldset_name, *values)
-      values.flatten!(1)
-      raise ArgumentError, "values must not be empty" if values.empty?
-
-      command = [:himport, "SET", key, fieldset_name].concat(values)
-      @monitor.synchronize do
-        synchronize { |c| c.himport_call_by_key(key, command) }
-      rescue CommandError => error
-        fields = @himport_fieldsets[fieldset_name.to_s]
-        raise unless @himport_auto_prepare && fields && error.message.include?("no such fieldset")
-
-        himport_prepare(fieldset_name, fields)
-        synchronize { |c| c.himport_call_by_key(key, command) }
-      end
+      reply = super
+      reply.is_a?(Array) ? reply.first : reply
     end
 
     def himport_discard(fieldset_name)
-      @monitor.synchronize do
-        reply = synchronize { |c| c.himport_fan_out([:himport, "DISCARD", fieldset_name]) }.max
-        @himport_fieldsets.delete(fieldset_name.to_s)
-        reply
-      end
+      reply = super
+      reply.is_a?(Array) ? reply.max : reply
     end
 
     def himport_discard_all
-      @monitor.synchronize do
-        reply = synchronize { |c| c.himport_fan_out([:himport, "DISCARDALL"]) }.max
-        @himport_fieldsets.clear
-        reply
-      end
+      reply = super
+      reply.is_a?(Array) ? reply.max : reply
     end
 
     private

--- a/cluster/lib/redis/cluster/client.rb
+++ b/cluster/lib/redis/cluster/client.rb
@@ -99,6 +99,40 @@ class Redis
         handle_errors { super(watch: watch, &block) }
       end
 
+      # Run a HIMPORT subcommand with request_policy:all_shards semantics: execute on every
+      # primary node (fieldsets are per-connection session state, so each primary's connection
+      # needs its own copy). Returns the array of per-node replies; any node failure raises
+      # Redis::Cluster::CommandErrorCollection via handle_errors.
+      #
+      # redis-cluster-client doesn't parse command tips and its primaries fan-out is private, so
+      # this reaches one private router method. TODO: drop this once command-tips routing
+      # (request_policy:all_shards) is upstreamed into redis-cluster-client.
+      def himport_fan_out(command)
+        command = @command_builder.generate(command)
+        handle_errors do
+          router.send(:send_command_to_primaries, :call_v, command, [])
+        rescue ::RedisClient::Cluster::ErrorCollection => error
+          # Router#send_command does this for its own fan-out actions (e.g. FLUSHALL); keep
+          # failover recovery on par since we bypass it.
+          if error.errors.values.any? { |e| e.is_a?(::RedisClient::ConnectionError) || e.message.start_with?('CLUSTERDOWN') }
+            router.renew_cluster_state
+          end
+          raise
+        end
+      end
+
+      # Route a keyed HIMPORT subcommand (SET) by the key's slot. The generic router can't
+      # extract the key (the COMMAND catalog stores the container command's spec, whose first
+      # key position is 0), so resolve the node from the key directly; send_command_to_node
+      # preserves the router's MOVED/ASK/CLUSTERDOWN redirection handling.
+      def himport_call_by_key(key, command, &block)
+        command = @command_builder.generate(command)
+        handle_errors do
+          node = router.find_node(router.find_node_key_by_key(key.to_s, primary: true))
+          router.send_command_to_node(node, :call_v, command, [], &block)
+        end
+      end
+
       def watch(*keys, &block)
         unless block_given?
           raise(

--- a/cluster/lib/redis/cluster/client.rb
+++ b/cluster/lib/redis/cluster/client.rb
@@ -99,40 +99,6 @@ class Redis
         handle_errors { super(watch: watch, &block) }
       end
 
-      # Run a HIMPORT subcommand with request_policy:all_shards semantics: execute on every
-      # primary node (fieldsets are per-connection session state, so each primary's connection
-      # needs its own copy). Returns the array of per-node replies; any node failure raises
-      # Redis::Cluster::CommandErrorCollection via handle_errors.
-      #
-      # redis-cluster-client doesn't parse command tips and its primaries fan-out is private, so
-      # this reaches one private router method. TODO: drop this once command-tips routing
-      # (request_policy:all_shards) is upstreamed into redis-cluster-client.
-      def himport_fan_out(command)
-        command = @command_builder.generate(command)
-        handle_errors do
-          router.send(:send_command_to_primaries, :call_v, command, [])
-        rescue ::RedisClient::Cluster::ErrorCollection => error
-          # Router#send_command does this for its own fan-out actions (e.g. FLUSHALL); keep
-          # failover recovery on par since we bypass it.
-          if error.errors.values.any? { |e| e.is_a?(::RedisClient::ConnectionError) || e.message.start_with?('CLUSTERDOWN') }
-            router.renew_cluster_state
-          end
-          raise
-        end
-      end
-
-      # Route a keyed HIMPORT subcommand (SET) by the key's slot. The generic router can't
-      # extract the key (the COMMAND catalog stores the container command's spec, whose first
-      # key position is 0), so resolve the node from the key directly; send_command_to_node
-      # preserves the router's MOVED/ASK/CLUSTERDOWN redirection handling.
-      def himport_call_by_key(key, command, &block)
-        command = @command_builder.generate(command)
-        handle_errors do
-          node = router.find_node(router.find_node_key_by_key(key.to_s, primary: true))
-          router.send_command_to_node(node, :call_v, command, [], &block)
-        end
-      end
-
       def watch(*keys, &block)
         unless block_given?
           raise(

--- a/cluster/redis-clustering.gemspec
+++ b/cluster/redis-clustering.gemspec
@@ -49,5 +49,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('redis', s.version)
   # Patch-only within the current redis-cluster-client minor (pre-1.0, so minors may break and we
   # rely on its internals — e.g. InitialSetupError). Bug/security patches flow; minors are gated.
-  s.add_runtime_dependency('redis-cluster-client', '~> 0.16.0')
+  # Pinned to an exact version: redis-cluster-client ships behavior changes in patch releases
+  # (0.16.6 added command-tips routing and per-subcommand key extraction, which HIMPORT relies
+  # on), so a floating constraint can change routing semantics under a stable redis-clustering
+  # release. Bump deliberately and re-run the cluster suite.
+  s.add_runtime_dependency('redis-cluster-client', '0.16.7')
 end

--- a/cluster/test/commands_on_himport_test.rb
+++ b/cluster/test/commands_on_himport_test.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestClusterCommandsOnHimport < Minitest::Test
+  include Helper::Cluster
+  include Lint::Himport
+
+  # PREPARE fails identically on every primary during the fan-out, so cluster
+  # surfaces a per-node error collection instead of a single CommandError.
+  def test_himport_duplicate_field_error
+    target_version "8.9" do
+      error = assert_raises(Redis::Cluster::CommandErrorCollection) do
+        r.himport_prepare("fs", %w[f1 f1])
+      end
+      refute_empty error.errors
+      error.errors.each_value do |node_error|
+        assert_kind_of Redis::CommandError, node_error
+        assert_match(/duplicate field/, node_error.message)
+      end
+    end
+  end
+
+  def test_himport_prepare_fans_out_to_all_primaries
+    target_version "8.9" do
+      owners = keys_on_distinct_masters(3)
+      assert_equal 3, owners.size, "test cluster should have 3 masters"
+
+      assert_equal "OK", r.himport_prepare("fs", %w[f1 f2])
+
+      # a SET can only succeed on a master whose connection saw the PREPARE, so
+      # success for keys owned by all three masters proves the 3-way fan-out
+      owners.values.each_with_index do |key, i|
+        assert_equal "OK", r.himport_set(key, "fs", ["v#{i}", "w#{i}"])
+        assert_equal({ "f1" => "v#{i}", "f2" => "w#{i}" }, r.hgetall(key))
+      end
+    end
+  end
+
+  def test_himport_set_routes_by_slot_with_hash_tags
+    target_version "8.9" do
+      assert_equal r.cluster(:keyslot, "{tag}a"), r.cluster(:keyslot, "{tag}b")
+
+      r.himport_prepare("fs", %w[f1])
+      assert_equal "OK", r.himport_set("{tag}a", "fs", %w[1])
+      assert_equal "OK", r.himport_set("{tag}b", "fs", %w[2])
+      assert_equal({ "f1" => "1" }, r.hgetall("{tag}a"))
+      assert_equal({ "f1" => "2" }, r.hgetall("{tag}b"))
+    end
+  end
+
+  def test_himport_set_recovers_after_connection_kill
+    target_version "8.9" do
+      owners = keys_on_distinct_masters(3)
+      victim_node, victim_key = owners.first
+
+      r.himport_prepare("fs", %w[f1 f2])
+      host, port = victim_node.split(":")
+
+      admin = Redis.new(host: host, port: Integer(port))
+      begin
+        admin.client(:kill, "TYPE", "normal")
+      ensure
+        admin.close
+      end
+
+      # the rebuilt connection has no fieldsets; the client re-fans-out the
+      # PREPARE from its registry and retries the SET once
+      assert_equal "OK", r.himport_set(victim_key, "fs", %w[1 2])
+      assert_equal({ "f1" => "1", "f2" => "2" }, r.hgetall(victim_key))
+    end
+  end
+
+  def test_himport_only_multi_raises_consistency_error
+    target_version "8.9" do
+      assert_raises(Redis::Cluster::TransactionConsistencyError) do
+        r.multi { |tx| tx.himport_prepare("fs", %w[f1]) }
+      end
+    end
+  end
+
+  # PREPARE + SET is still himport-only: the router cannot extract HIMPORT
+  # SET's key (container-command spec), so neither command can pin the
+  # transaction's node and EXEC fails loudly.
+  def test_himport_prepare_and_set_multi_raises_consistency_error
+    target_version "8.9" do
+      assert_raises(Redis::Cluster::TransactionConsistencyError) do
+        r.multi do |tx|
+          tx.himport_prepare("fs", %w[f1])
+          tx.himport_set("{tag}h", "fs", %w[v])
+        end
+      end
+    end
+  end
+
+  # A normal keyed command pins the transaction to its slot's master; an
+  # himport_set for a key in the same slot then executes on that node's
+  # connection, which holds the fieldset thanks to the fan-out prepare.
+  def test_himport_set_works_in_multi_pinned_by_keyed_command
+    target_version "8.9" do
+      r.himport_prepare("fs", %w[f1 f2])
+
+      results = r.multi do |tx|
+        tx.set("{tag}pin", "x")
+        tx.himport_set("{tag}h", "fs", %w[1 2])
+      end
+      assert_equal %w[OK OK], results
+      assert_equal({ "f1" => "1", "f2" => "2" }, r.hgetall("{tag}h"))
+
+      # order doesn't matter: an himport_set queued before the pinning command
+      # is deferred and replayed once the node is known
+      results = r.multi do |tx|
+        tx.himport_set("{tag}h2", "fs", %w[3 4])
+        tx.set("{tag}pin2", "y")
+      end
+      assert_equal %w[OK OK], results
+      assert_equal({ "f1" => "3", "f2" => "4" }, r.hgetall("{tag}h2"))
+    end
+  end
+
+  private
+
+  # Pick one key owned by each of `count` distinct masters, resolved through
+  # the server's own slot map (CLUSTER SLOTS + CLUSTER KEYSLOT).
+  def keys_on_distinct_masters(count)
+    ranges = r.cluster(:slots).map do |s|
+      [(s["start_slot"]..s["end_slot"]), "#{s['master']['ip']}:#{s['master']['port']}"]
+    end
+
+    owners = {}
+    (0..2000).each do |i|
+      key = "himport:#{i}"
+      slot = r.cluster(:keyslot, key)
+      node = ranges.find { |range, _| range.cover?(slot) }&.last
+      owners[node] ||= key
+      break if owners.size >= count
+    end
+    owners
+  end
+end

--- a/cluster/test/commands_on_himport_test.rb
+++ b/cluster/test/commands_on_himport_test.rb
@@ -79,17 +79,20 @@ class TestClusterCommandsOnHimport < Minitest::Test
     end
   end
 
-  # PREPARE + SET is still himport-only: the router cannot extract HIMPORT
-  # SET's key (container-command spec), so neither command can pin the
-  # transaction's node and EXEC fails loudly.
-  def test_himport_prepare_and_set_multi_raises_consistency_error
+  # Since redis-cluster-client 0.16.6 the driver extracts HIMPORT SET's key from the
+  # per-subcommand spec, so the SET pins the transaction to its slot's master and the
+  # PREPARE executes on that same pinned connection — single-connection semantics,
+  # like standalone. (The prepare travels inside the transaction, so no fan-out is
+  # needed; the fieldset only exists on the pinned connection afterwards.)
+  def test_himport_prepare_and_set_multi_pins_to_set_key_slot
     target_version "8.9" do
-      assert_raises(Redis::Cluster::TransactionConsistencyError) do
-        r.multi do |tx|
-          tx.himport_prepare("fs", %w[f1])
-          tx.himport_set("{tag}h", "fs", %w[v])
-        end
+      results = r.multi do |tx|
+        tx.himport_prepare("txfs", %w[f1])
+        tx.himport_set("{tag}h", "txfs", %w[v])
       end
+
+      assert_equal %w[OK OK], results
+      assert_equal({ "f1" => "v" }, r.hgetall("{tag}h"))
     end
   end
 

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -133,7 +133,10 @@ class Redis
   end
 
   def dup
-    self.class.new(@options)
+    # inherit_socket and himport_auto_prepare are stripped from @options before the client config
+    # is built (RedisClient::Config doesn't know them); merge the live values back so the
+    # duplicate keeps the caller's settings instead of silently reverting to defaults.
+    self.class.new(@options.merge(inherit_socket: @inherit_socket, himport_auto_prepare: @himport_auto_prepare))
   end
 
   def connection
@@ -155,34 +158,48 @@ class Redis
   # fieldset is removed from the registry and is never resurrected. Disable the recovery with
   # `Redis.new(himport_auto_prepare: false)`; the registry is still recorded for manual use.
 
+  # Each method holds @monitor across the server command AND its registry mutation: the two must
+  # be atomic with respect to other threads, otherwise a himport_set failing between another
+  # thread's DISCARD reply and its registry delete would still see the schema and re-prepare,
+  # resurrecting the fieldset the discard just removed. @monitor is reentrant, so the nested
+  # send_command/himport_prepare calls re-enter it safely.
+
   def himport_prepare(fieldset_name, *fields)
     fields.flatten!(1)
-    reply = super(fieldset_name, fields)
-    @himport_fieldsets[fieldset_name.to_s] = fields.dup.freeze
-    reply
+    @monitor.synchronize do
+      reply = super(fieldset_name, fields)
+      @himport_fieldsets[fieldset_name.to_s] = fields.dup.freeze
+      reply
+    end
   end
 
   def himport_set(key, fieldset_name, *values)
-    super
-  rescue CommandError => error
-    fields = @himport_fieldsets[fieldset_name.to_s]
-    raise unless @himport_auto_prepare && fields && error.message.include?("no such fieldset")
+    @monitor.synchronize do
+      super
+    rescue CommandError => error
+      fields = @himport_fieldsets[fieldset_name.to_s]
+      raise unless @himport_auto_prepare && fields && error.message.include?("no such fieldset")
 
-    himport_prepare(fieldset_name, fields)
-    # `super` (not himport_set) so a second failure propagates instead of recovering again.
-    super
+      himport_prepare(fieldset_name, fields)
+      # `super` (not himport_set) so a second failure propagates instead of recovering again.
+      super
+    end
   end
 
   def himport_discard(fieldset_name)
-    reply = super
-    @himport_fieldsets.delete(fieldset_name.to_s)
-    reply
+    @monitor.synchronize do
+      reply = super
+      @himport_fieldsets.delete(fieldset_name.to_s)
+      reply
+    end
   end
 
   def himport_discard_all
-    reply = super
-    @himport_fieldsets.clear
-    reply
+    @monitor.synchronize do
+      reply = super
+      @himport_fieldsets.clear
+      reply
+    end
   end
 
   private

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -74,6 +74,11 @@ class Redis
     # Kept as state, not just a local: the RESP3->RESP2 fallback rebuilds @client and must re-apply
     # socket inheritance, otherwise fork safety would be silently lost after a downgrade.
     @inherit_socket = @options.delete(:inherit_socket)
+    # HIMPORT fieldsets are server session state that dies with the physical connection; the
+    # registry remembers each prepared schema so a lost session can be repaired (see the
+    # himport_* overrides below). Deleted from @options so it never reaches RedisClient::Config.
+    @himport_auto_prepare = @options.delete(:himport_auto_prepare) != false
+    @himport_fieldsets = {}
     @subscription_client = nil
 
     @client = build_client
@@ -139,6 +144,45 @@ class Redis
       id: id,
       location: "#{@client.host}:#{@client.port}"
     }
+  end
+
+  # HIMPORT overrides adding fieldset-loss recovery on top of the transport-pure methods in
+  # Commands::Hashes. The connection can be transparently replaced under the caller (reconnect
+  # after a network error, failover, RESET by a proxy), destroying every prepared fieldset. The
+  # server then answers HIMPORT SET with "no such fieldset" — the authoritative signal that the
+  # session was lost. These overrides remember the last schema prepared per fieldset name and,
+  # on that error, re-prepare it and retry the SET exactly once. An explicitly discarded
+  # fieldset is removed from the registry and is never resurrected. Disable the recovery with
+  # `Redis.new(himport_auto_prepare: false)`; the registry is still recorded for manual use.
+
+  def himport_prepare(fieldset_name, *fields)
+    fields.flatten!(1)
+    reply = super(fieldset_name, fields)
+    @himport_fieldsets[fieldset_name.to_s] = fields.dup.freeze
+    reply
+  end
+
+  def himport_set(key, fieldset_name, *values)
+    super
+  rescue CommandError => error
+    fields = @himport_fieldsets[fieldset_name.to_s]
+    raise unless @himport_auto_prepare && fields && error.message.include?("no such fieldset")
+
+    himport_prepare(fieldset_name, fields)
+    # `super` (not himport_set) so a second failure propagates instead of recovering again.
+    super
+  end
+
+  def himport_discard(fieldset_name)
+    reply = super
+    @himport_fieldsets.delete(fieldset_name.to_s)
+    reply
+  end
+
+  def himport_discard_all
+    reply = super
+    @himport_fieldsets.clear
+    reply
   end
 
   private

--- a/lib/redis/commands/hashes.rb
+++ b/lib/redis/commands/hashes.rb
@@ -338,6 +338,69 @@ class Redis
       def hpttl(key, *fields)
         send_command([:hpttl, key, 'FIELDS', fields.length, *fields])
       end
+
+      # Register an ordered list of hash field names under +fieldset_name+ for
+      # use by subsequent #himport_set calls on the same connection.
+      #
+      # Fieldsets are server-side session state scoped to the current physical
+      # connection: they vanish on disconnect or RESET and are invisible to
+      # other connections. See the README "Bulk hash ingestion (HIMPORT)"
+      # section for connection-scoping guidance. Re-preparing an existing
+      # +fieldset_name+ silently replaces it. Field order is preserved as
+      # given; it defines the positional pairing used by #himport_set.
+      #
+      # @example
+      #   redis.himport_prepare("shared", ["name", "email", "age"])
+      #     # => "OK"
+      #
+      # @param [String] fieldset_name name used by later SET and DISCARD calls
+      # @param [String, Array<String>] fields one or more field names
+      # @return [String] `"OK"`
+      def himport_prepare(fieldset_name, *fields)
+        fields.flatten!(1)
+        raise ArgumentError, "fields must not be empty" if fields.empty?
+
+        send_command([:himport, "PREPARE", fieldset_name].concat(fields))
+      end
+
+      # Create or fully replace the hash at +key+ using the field list
+      # registered under +fieldset_name+ on this connection. Values pair
+      # positionally with the fields given to #himport_prepare; the value
+      # count must equal the field count.
+      #
+      # The fieldset must exist on the executing connection, otherwise the
+      # server replies with a "no such fieldset" error.
+      #
+      # @example
+      #   redis.himport_set("shared:1", "shared", ["alice", "alice@example.com", "25"])
+      #     # => "OK"
+      #
+      # @param [String] key hash key to create or overwrite
+      # @param [String] fieldset_name fieldset previously prepared on this connection
+      # @param [String, Array<String>] values one or more values, order preserved
+      # @return [String] `"OK"`
+      def himport_set(key, fieldset_name, *values)
+        values.flatten!(1)
+        raise ArgumentError, "values must not be empty" if values.empty?
+
+        send_command([:himport, "SET", key, fieldset_name].concat(values))
+      end
+
+      # Remove +fieldset_name+ from this connection's session. Keys already
+      # written through the fieldset are not affected.
+      #
+      # @param [String] fieldset_name
+      # @return [Integer] `1` if the fieldset was removed, `0` if it did not exist
+      def himport_discard(fieldset_name)
+        send_command([:himport, "DISCARD", fieldset_name])
+      end
+
+      # Remove all fieldsets from this connection's session.
+      #
+      # @return [Integer] number of fieldsets removed
+      def himport_discard_all
+        send_command([:himport, "DISCARDALL"])
+      end
     end
   end
 end

--- a/lib/redis/commands/hashes.rb
+++ b/lib/redis/commands/hashes.rb
@@ -349,6 +349,9 @@ class Redis
       # +fieldset_name+ silently replaces it. Field order is preserved as
       # given; it defines the positional pairing used by #himport_set.
       #
+      # @note HIMPORT support is experimental: the client API may change in a
+      #   future minor release without a major version bump.
+      #
       # @example
       #   redis.himport_prepare("shared", ["name", "email", "age"])
       #     # => "OK"
@@ -356,6 +359,7 @@ class Redis
       # @param [String] fieldset_name name used by later SET and DISCARD calls
       # @param [String, Array<String>] fields one or more field names
       # @return [String] `"OK"`
+      # @api experimental
       def himport_prepare(fieldset_name, *fields)
         fields.flatten!(1)
         raise ArgumentError, "fields must not be empty" if fields.empty?
@@ -371,6 +375,9 @@ class Redis
       # The fieldset must exist on the executing connection, otherwise the
       # server replies with a "no such fieldset" error.
       #
+      # @note HIMPORT support is experimental: the client API may change in a
+      #   future minor release without a major version bump.
+      #
       # @example
       #   redis.himport_set("shared:1", "shared", ["alice", "alice@example.com", "25"])
       #     # => "OK"
@@ -379,6 +386,7 @@ class Redis
       # @param [String] fieldset_name fieldset previously prepared on this connection
       # @param [String, Array<String>] values one or more values, order preserved
       # @return [String] `"OK"`
+      # @api experimental
       def himport_set(key, fieldset_name, *values)
         values.flatten!(1)
         raise ArgumentError, "values must not be empty" if values.empty?
@@ -389,15 +397,23 @@ class Redis
       # Remove +fieldset_name+ from this connection's session. Keys already
       # written through the fieldset are not affected.
       #
+      # @note HIMPORT support is experimental: the client API may change in a
+      #   future minor release without a major version bump.
+      #
       # @param [String] fieldset_name
       # @return [Integer] `1` if the fieldset was removed, `0` if it did not exist
+      # @api experimental
       def himport_discard(fieldset_name)
         send_command([:himport, "DISCARD", fieldset_name])
       end
 
       # Remove all fieldsets from this connection's session.
       #
+      # @note HIMPORT support is experimental: the client API may change in a
+      #   future minor release without a major version bump.
+      #
       # @return [Integer] number of fieldsets removed
+      # @api experimental
       def himport_discard_all
         send_command([:himport, "DISCARDALL"])
       end

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -1104,6 +1104,30 @@ class Redis
       node_for(key).hpttl(key, *fields)
     end
 
+    # Register a fieldset on every ring node. Fieldsets are scoped to a physical
+    # connection, so every node that may receive an `himport_set` for a key it
+    # owns needs the fieldset on its own connection.
+    def himport_prepare(fieldset_name, *fields)
+      fields.flatten!(1)
+      on_each_node(:himport_prepare, fieldset_name, fields)
+    end
+
+    # Create or fully replace a hash from a fieldset prepared on the key's node.
+    def himport_set(key, fieldset_name, *values)
+      values.flatten!(1)
+      node_for(key).himport_set(key, fieldset_name, values)
+    end
+
+    # Remove a fieldset from every ring node.
+    def himport_discard(fieldset_name)
+      on_each_node(:himport_discard, fieldset_name)
+    end
+
+    # Remove all fieldsets from every ring node.
+    def himport_discard_all
+      on_each_node(:himport_discard_all)
+    end
+
     # Add one or more geospatial items to a sorted set.
     def geoadd(key, *member, **options)
       node_for(key).geoadd(key, *member, **options)

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -22,6 +22,10 @@ class Redis
       @ring = options[:ring] || HashRing.new
       @node_configs = node_configs.map(&:dup)
       @default_options = options.dup
+      # Schemas registered via himport_prepare, replayed to nodes that join the ring later (see
+      # #add_node) so ring membership changes don't leave nodes without the fieldsets that
+      # key-routed himport_set calls expect. Initialized before the add_node loop below.
+      @himport_fieldsets = {}
       node_configs.each { |node_config| add_node(node_config) }
       @subscribed_node = nil
       @watch_key = nil
@@ -43,7 +47,12 @@ class Redis
       options = @default_options.merge(options)
       options.delete(:tag)
       options.delete(:ring)
-      @ring.add_node Redis.new(options)
+      node = Redis.new(options)
+      # Replay registered fieldsets before the node can receive key-routed himport_set calls:
+      # a node joining after a himport_prepare fan-out has neither the server-side fieldset nor
+      # a populated registry to self-recover from "no such fieldset".
+      @himport_fieldsets.each { |name, fields| node.himport_prepare(name, fields) }
+      @ring.add_node node
     end
 
     # Change the selected database for the current connection.
@@ -1109,7 +1118,9 @@ class Redis
     # owns needs the fieldset on its own connection.
     def himport_prepare(fieldset_name, *fields)
       fields.flatten!(1)
-      on_each_node(:himport_prepare, fieldset_name, fields)
+      results = on_each_node(:himport_prepare, fieldset_name, fields)
+      @himport_fieldsets[fieldset_name.to_s] = fields.dup.freeze
+      results
     end
 
     # Create or fully replace a hash from a fieldset prepared on the key's node.
@@ -1120,12 +1131,16 @@ class Redis
 
     # Remove a fieldset from every ring node.
     def himport_discard(fieldset_name)
-      on_each_node(:himport_discard, fieldset_name)
+      results = on_each_node(:himport_discard, fieldset_name)
+      @himport_fieldsets.delete(fieldset_name.to_s)
+      results
     end
 
     # Remove all fieldsets from every ring node.
     def himport_discard_all
-      on_each_node(:himport_discard_all)
+      results = on_each_node(:himport_discard_all)
+      @himport_fieldsets.clear
+      results
     end
 
     # Add one or more geospatial items to a sorted set.

--- a/redis.gemspec
+++ b/redis.gemspec
@@ -44,9 +44,10 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 3.3.0'
 
-  # Pinned to a single redis-client minor: redis-rb couples tightly to redis-client internals
+  # Pinned to an exact redis-client version: redis-rb couples tightly to redis-client internals
   # (subclassing, ensure_connected/call_v overrides, config access, RESP3/HELLO behavior), and
-  # redis-client is pre-1.0 where minors may break. `~> 0.30.0` allows only patch upgrades
-  # (0.30.x) so bug/security fixes flow automatically; new minors require a deliberate redis-rb bump.
-  s.add_runtime_dependency('redis-client', '~> 0.30.0')
+  # the pre-1.0 driver family ships behavior changes in patch releases, so even a `~> x.y.0`
+  # constraint can change semantics under a stable redis release. Bump deliberately and re-run
+  # the full suite. Note hiredis-client versions in lockstep (it requires redis-client `= x.y.z`).
+  s.add_runtime_dependency('redis-client', '0.30.1')
 end

--- a/test/distributed/himport_test.rb
+++ b/test/distributed/himport_test.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestDistributedHimport < Minitest::Test
+  include Helper::Distributed
+  include Lint::Himport
+
+  # Fan-out commands return one reply per ring node (the Redis::Distributed
+  # convention, cf. flushdb/script); the default test ring has a single node.
+
+  def test_himport_prepare_returns_ok
+    target_version "8.9" do
+      assert_equal ["OK"], r.himport_prepare("fs", %w[f1 f2])
+    end
+  end
+
+  def test_himport_discard_semantics
+    target_version "8.9" do
+      r.himport_prepare("fs", %w[f1])
+      r.himport_set("k1", "fs", %w[v])
+
+      assert_equal [1], r.himport_discard("fs")
+      assert_equal [0], r.himport_discard("fs")
+
+      error = assert_raises(Redis::CommandError) do
+        r.himport_set("k2", "fs", %w[v])
+      end
+      assert_match(/no such fieldset/, error.message)
+
+      assert_equal({ "f1" => "v" }, r.hgetall("k1"))
+    end
+  end
+
+  def test_himport_discard_all_counts
+    target_version "8.9" do
+      r.himport_prepare("fs1", %w[f1])
+      r.himport_prepare("fs2", %w[f1 f2])
+
+      assert_equal [2], r.himport_discard_all
+      assert_equal [0], r.himport_discard_all
+    end
+  end
+
+  # A second ring node on another DB of the same server is still a distinct
+  # physical connection — which is the scope fieldsets live in — so these
+  # tests genuinely exercise two independent sessions.
+
+  def test_prepare_fans_out_to_all_nodes
+    target_version "8.9" do
+      r.add_node("redis://127.0.0.1:#{PORT}/14")
+      r.flushdb
+
+      key_a, key_b = keys_on_distinct_nodes
+
+      assert_equal %w[OK OK], r.himport_prepare("fs", %w[f1])
+      assert_equal "OK", r.himport_set(key_a, "fs", %w[a])
+      assert_equal "OK", r.himport_set(key_b, "fs", %w[b])
+    end
+  end
+
+  def test_set_fails_when_prepare_missed_a_node
+    target_version "8.9" do
+      r.add_node("redis://127.0.0.1:#{PORT}/14")
+      r.flushdb
+
+      key_a, key_b = keys_on_distinct_nodes
+
+      # prepare on one node's connection only
+      r.nodes[0].himport_prepare("fs", %w[f1])
+
+      assert_equal "OK", r.himport_set(key_a, "fs", %w[v])
+      error = assert_raises(Redis::CommandError) do
+        r.himport_set(key_b, "fs", %w[v])
+      end
+      assert_match(/no such fieldset/, error.message)
+    end
+  end
+
+  def test_discard_fans_out
+    target_version "8.9" do
+      r.add_node("redis://127.0.0.1:#{PORT}/14")
+      r.flushdb
+
+      r.himport_prepare("fs", %w[f1])
+      assert_equal [1, 1], r.himport_discard("fs")
+
+      r.himport_prepare("fs1", %w[f1])
+      r.himport_prepare("fs2", %w[f1])
+      assert_equal [2, 2], r.himport_discard_all
+    end
+  end
+
+  def test_key_tags_route_himport_set
+    target_version "8.9" do
+      r.add_node("redis://127.0.0.1:#{PORT}/14")
+      r.flushdb
+
+      assert_equal r.node_for("{tag}k1").id, r.node_for("{tag}k2").id
+
+      r.himport_prepare("fs", %w[f1])
+      assert_equal "OK", r.himport_set("{tag}k1", "fs", %w[v1])
+      assert_equal "OK", r.himport_set("{tag}k2", "fs", %w[v2])
+    end
+  end
+
+  def test_himport_set_recovers_per_node
+    target_version "8.9" do
+      r.add_node("redis://127.0.0.1:#{PORT}/14")
+      r.flushdb
+
+      key_a, = keys_on_distinct_nodes
+      r.himport_prepare("fs", %w[f1])
+
+      r.node_for(key_a).disconnect!
+
+      # the routed node's own registry repairs its session
+      assert_equal "OK", r.himport_set(key_a, "fs", %w[v])
+    end
+  end
+
+  private
+
+  def keys_on_distinct_nodes
+    key_a = (0..100).map { |i| "himport:#{i}" }.find { |k| r.node_for(k).id == r.nodes[0].id }
+    key_b = (0..100).map { |i| "himport:#{i}" }.find { |k| r.node_for(k).id == r.nodes[1].id }
+    refute_nil key_a
+    refute_nil key_b
+    [key_a, key_b]
+  end
+end

--- a/test/distributed/himport_test.rb
+++ b/test/distributed/himport_test.rb
@@ -59,14 +59,16 @@ class TestDistributedHimport < Minitest::Test
     end
   end
 
-  def test_set_fails_when_prepare_missed_a_node
+  def test_prepare_called_directly_on_a_node_does_not_cover_the_ring
     target_version "8.9" do
       r.add_node("redis://127.0.0.1:#{PORT}/14")
       r.flushdb
 
       key_a, key_b = keys_on_distinct_nodes
 
-      # prepare on one node's connection only
+      # bypassing the Distributed fan-out prepares one node's connection only:
+      # keys routed to any other node fail, and the ring-level registry knows
+      # nothing about the fieldset, so there is no recovery either
       r.nodes[0].himport_prepare("fs", %w[f1])
 
       assert_equal "OK", r.himport_set(key_a, "fs", %w[v])
@@ -101,6 +103,38 @@ class TestDistributedHimport < Minitest::Test
       r.himport_prepare("fs", %w[f1])
       assert_equal "OK", r.himport_set("{tag}k1", "fs", %w[v1])
       assert_equal "OK", r.himport_set("{tag}k2", "fs", %w[v2])
+    end
+  end
+
+  def test_add_node_receives_registered_fieldsets
+    target_version "8.9" do
+      # prepare BEFORE the second node joins the ring
+      r.himport_prepare("fs", %w[f1])
+      r.add_node("redis://127.0.0.1:#{PORT}/14")
+      r.flushdb
+
+      key_a, key_b = keys_on_distinct_nodes
+      assert_equal "OK", r.himport_set(key_a, "fs", %w[a])
+      assert_equal "OK", r.himport_set(key_b, "fs", %w[b])
+
+      # the replay also populated the new node's own registry, so it self-recovers
+      r.node_for(key_b).disconnect!
+      assert_equal "OK", r.himport_set(key_b, "fs", %w[b2])
+    end
+  end
+
+  def test_add_node_does_not_receive_discarded_fieldsets
+    target_version "8.9" do
+      r.himport_prepare("fs", %w[f1])
+      r.himport_discard("fs")
+      r.add_node("redis://127.0.0.1:#{PORT}/14")
+      r.flushdb
+
+      _, key_b = keys_on_distinct_nodes
+      error = assert_raises(Redis::CommandError) do
+        r.himport_set(key_b, "fs", %w[v])
+      end
+      assert_match(/no such fieldset/, error.message)
     end
   end
 

--- a/test/lint/himport.rb
+++ b/test/lint/himport.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+module Lint
+  module Himport
+    def test_himport_prepare_returns_ok
+      target_version "8.9" do
+        assert_equal "OK", r.himport_prepare("fs", %w[f1 f2])
+      end
+    end
+
+    def test_himport_basic_ingestion
+      target_version "8.9" do
+        r.himport_prepare("shared", %w[name email age])
+
+        assert_equal "OK", r.himport_set("shared:1", "shared", %w[alice alice@example.com 25])
+        assert_equal "OK", r.himport_set("shared:2", "shared", %w[bob bob@example.com 30])
+
+        assert_equal({ "name" => "alice", "email" => "alice@example.com", "age" => "25" }, r.hgetall("shared:1"))
+        assert_equal "bob", r.hget("shared:2", "name")
+      end
+    end
+
+    def test_himport_set_accepts_splat_and_array
+      target_version "8.9" do
+        r.himport_prepare("fs", "f1", "f2")
+
+        assert_equal "OK", r.himport_set("k1", "fs", "v1", "v2")
+        assert_equal "OK", r.himport_set("k2", "fs", %w[v1 v2])
+        assert_equal r.hgetall("k1"), r.hgetall("k2")
+      end
+    end
+
+    def test_himport_multiple_fieldsets_are_independent
+      target_version "8.9" do
+        r.himport_prepare("users", %w[name age])
+        r.himport_prepare("events", %w[type payload ts])
+
+        r.himport_set("u:1", "users", %w[alice 25])
+        r.himport_set("e:1", "events", %w[click body 123])
+
+        assert_equal({ "name" => "alice", "age" => "25" }, r.hgetall("u:1"))
+        assert_equal({ "type" => "click", "payload" => "body", "ts" => "123" }, r.hgetall("e:1"))
+      end
+    end
+
+    def test_himport_prepare_replaces_existing_fieldset
+      target_version "8.9" do
+        r.himport_prepare("fs", %w[f1 f2])
+        assert_equal "OK", r.himport_set("k1", "fs", %w[v1 v2])
+
+        # last PREPARE wins, silently
+        r.himport_prepare("fs", %w[other])
+        assert_equal "OK", r.himport_set("k2", "fs", %w[v])
+        assert_equal({ "other" => "v" }, r.hgetall("k2"))
+
+        error = assert_raises(Redis::CommandError) do
+          r.himport_set("k3", "fs", %w[v1 v2])
+        end
+        assert_match(/value count/, error.message)
+      end
+    end
+
+    def test_himport_positional_pairing
+      target_version "8.9" do
+        r.himport_prepare("order1", %w[a b c])
+        r.himport_prepare("order2", %w[c b a])
+
+        r.himport_set("order:key1", "order1", %w[va1 vb1 vc1])
+        r.himport_set("order:key2", "order2", %w[vc2 vb2 va2])
+
+        assert_equal "va1", r.hget("order:key1", "a")
+        assert_equal "va2", r.hget("order:key2", "a")
+        assert_equal "vc1", r.hget("order:key1", "c")
+        assert_equal "vc2", r.hget("order:key2", "c")
+      end
+    end
+
+    def test_himport_empty_strings_are_valid
+      target_version "8.9" do
+        r.himport_prepare("", ["", "f"])
+
+        assert_equal "OK", r.himport_set("empty:1", "", ["", "v"])
+        assert_equal({ "" => "", "f" => "v" }, r.hgetall("empty:1"))
+      end
+    end
+
+    def test_himport_set_is_full_replace
+      target_version "8.9" do
+        r.hset("k1", "stale", "field")
+        r.himport_prepare("fs", %w[f1])
+
+        assert_equal "OK", r.himport_set("k1", "fs", %w[v])
+        assert_equal({ "f1" => "v" }, r.hgetall("k1"))
+      end
+    end
+
+    def test_himport_discard_semantics
+      target_version "8.9" do
+        r.himport_prepare("fs", %w[f1])
+        r.himport_set("k1", "fs", %w[v])
+
+        assert_equal 1, r.himport_discard("fs")
+        assert_equal 0, r.himport_discard("fs")
+
+        error = assert_raises(Redis::CommandError) do
+          r.himport_set("k2", "fs", %w[v])
+        end
+        assert_match(/no such fieldset/, error.message)
+
+        # keys written through the fieldset survive its discard
+        assert_equal({ "f1" => "v" }, r.hgetall("k1"))
+      end
+    end
+
+    def test_himport_discard_all_counts
+      target_version "8.9" do
+        r.himport_prepare("fs1", %w[f1])
+        r.himport_prepare("fs2", %w[f1 f2])
+
+        assert_equal 2, r.himport_discard_all
+        assert_equal 0, r.himport_discard_all
+      end
+    end
+
+    def test_himport_set_unknown_fieldset_error
+      target_version "8.9" do
+        error = assert_raises(Redis::CommandError) do
+          r.himport_set("k1", "never-prepared", %w[v])
+        end
+        assert_match(/no such fieldset/, error.message)
+      end
+    end
+
+    def test_himport_value_count_mismatch_error
+      target_version "8.9" do
+        r.himport_prepare("fs", %w[f1 f2])
+
+        error = assert_raises(Redis::CommandError) do
+          r.himport_set("k1", "fs", %w[only-one])
+        end
+        assert_match(/value count/, error.message)
+      end
+    end
+
+    def test_himport_duplicate_field_error
+      target_version "8.9" do
+        error = assert_raises(Redis::CommandError) do
+          r.himport_prepare("fs", %w[f1 f1])
+        end
+        assert_match(/duplicate field/, error.message)
+      end
+    end
+
+    def test_himport_set_wrongtype_error
+      target_version "8.9" do
+        r.set("string-key", "value")
+        r.himport_prepare("fs", %w[f1])
+
+        error = assert_raises(Redis::CommandError) do
+          r.himport_set("string-key", "fs", %w[v])
+        end
+        assert_match(/WRONGTYPE/, error.message)
+        assert_equal "value", r.get("string-key")
+      end
+    end
+
+    def test_himport_prepare_with_empty_fields_raises_argument_error
+      assert_raises(ArgumentError) { r.himport_prepare("fs") }
+      assert_raises(ArgumentError) { r.himport_prepare("fs", []) }
+    end
+
+    def test_himport_set_with_empty_values_raises_argument_error
+      assert_raises(ArgumentError) { r.himport_set("k1", "fs") }
+      assert_raises(ArgumentError) { r.himport_set("k1", "fs", []) }
+    end
+  end
+end

--- a/test/redis/himport_test.rb
+++ b/test/redis/himport_test.rb
@@ -129,6 +129,24 @@ class TestHimport < Minitest::Test
     assert_equal %w[PREPARE SET PREPARE SET], calls
   end
 
+  def test_dup_preserves_himport_auto_prepare_opt_out
+    target_version "8.9" do
+      redis = _new_client(himport_auto_prepare: false)
+      copy = redis.dup
+
+      copy.himport_prepare("fs", %w[f1])
+      copy.disconnect!
+
+      error = assert_raises(Redis::CommandError) do
+        copy.himport_set("k1", "fs", %w[v])
+      end
+      assert_match(/no such fieldset/, error.message)
+    ensure
+      redis&.close
+      copy&.close
+    end
+  end
+
   def test_himport_set_on_dup_client
     target_version "8.9" do
       r.himport_prepare("fs", %w[f1])

--- a/test/redis/himport_test.rb
+++ b/test/redis/himport_test.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestHimport < Minitest::Test
+  include Helper::Client
+  include Lint::Himport
+
+  def test_himport_wire_shape
+    calls = []
+    handler = lambda do |*args|
+      calls << args
+      %w[DISCARD DISCARDALL].include?(args.first) ? ":1" : "+OK"
+    end
+
+    redis_mock(himport: handler) do |redis|
+      assert_equal "OK", redis.himport_prepare("fs", "f1", "f2")
+      assert_equal "OK", redis.himport_prepare("fs2", %w[f1 f2])
+      assert_equal "OK", redis.himport_set("k", "fs", "v1", "v2")
+      assert_equal 1, redis.himport_discard("fs")
+      assert_equal 1, redis.himport_discard_all
+    end
+
+    assert_equal ["PREPARE", "fs", "f1", "f2"], calls[0]
+    assert_equal ["PREPARE", "fs2", "f1", "f2"], calls[1]
+    assert_equal ["SET", "k", "fs", "v1", "v2"], calls[2]
+    assert_equal ["DISCARD", "fs"], calls[3]
+    assert_equal ["DISCARDALL"], calls[4]
+  end
+
+  def test_fieldsets_are_connection_scoped
+    target_version "8.9" do
+      r.himport_prepare("fs", %w[f1])
+
+      other = _new_client
+      error = assert_raises(Redis::CommandError) do
+        other.himport_set("k1", "fs", %w[v])
+      end
+      assert_match(/no such fieldset/, error.message)
+
+      assert_equal "OK", r.himport_set("k1", "fs", %w[v])
+    ensure
+      other&.close
+    end
+  end
+
+  def test_himport_set_recovers_after_reconnect
+    target_version "8.9" do
+      r.himport_prepare("fs", %w[f1 f2])
+      r.himport_set("k1", "fs", %w[1 2])
+
+      r.disconnect!
+
+      # the reconnected session has no fieldsets; the client re-prepares from
+      # its registry and retries transparently
+      assert_equal "OK", r.himport_set("k2", "fs", %w[3 4])
+      assert_equal({ "f1" => "3", "f2" => "4" }, r.hgetall("k2"))
+    end
+  end
+
+  def test_himport_set_recovers_after_server_side_kill
+    target_version "8.9" do
+      r.himport_prepare("fs", %w[f1])
+      r.himport_set("k1", "fs", %w[v])
+
+      admin = _new_client
+      admin.client(:kill, "TYPE", "normal")
+
+      assert_equal "OK", r.himport_set("k2", "fs", %w[v])
+    ensure
+      admin&.close
+    end
+  end
+
+  def test_himport_set_does_not_recover_when_disabled
+    target_version "8.9" do
+      redis = _new_client(himport_auto_prepare: false)
+      redis.himport_prepare("fs", %w[f1])
+      redis.disconnect!
+
+      error = assert_raises(Redis::CommandError) do
+        redis.himport_set("k1", "fs", %w[v])
+      end
+      assert_match(/no such fieldset/, error.message)
+    ensure
+      redis&.close
+    end
+  end
+
+  def test_himport_set_after_discard_does_not_auto_prepare
+    target_version "8.9" do
+      r.himport_prepare("fs", %w[f1])
+      r.himport_discard("fs")
+
+      error = assert_raises(Redis::CommandError) do
+        r.himport_set("k1", "fs", %w[v])
+      end
+      assert_match(/no such fieldset/, error.message)
+    end
+  end
+
+  def test_recovery_uses_latest_schema
+    target_version "8.9" do
+      r.himport_prepare("fs", %w[f1 f2])
+      r.himport_prepare("fs", %w[f1 f2 f3])
+
+      r.disconnect!
+
+      assert_equal "OK", r.himport_set("k1", "fs", %w[1 2 3])
+      assert_equal({ "f1" => "1", "f2" => "2", "f3" => "3" }, r.hgetall("k1"))
+    end
+  end
+
+  def test_recovery_retries_exactly_once
+    calls = []
+    handler = lambda do |*args|
+      calls << args.first
+      args.first == "PREPARE" ? "+OK" : "-ERR no such fieldset"
+    end
+
+    redis_mock(himport: handler) do |redis|
+      redis.himport_prepare("fs", %w[f1])
+      error = assert_raises(Redis::CommandError) do
+        redis.himport_set("k", "fs", %w[v])
+      end
+      assert_match(/no such fieldset/, error.message)
+    end
+
+    assert_equal %w[PREPARE SET PREPARE SET], calls
+  end
+
+  def test_himport_set_on_dup_client
+    target_version "8.9" do
+      r.himport_prepare("fs", %w[f1])
+
+      copy = r.dup
+      error = assert_raises(Redis::CommandError) do
+        copy.himport_set("k1", "fs", %w[v])
+      end
+      assert_match(/no such fieldset/, error.message)
+    ensure
+      copy&.close
+    end
+  end
+
+  def test_pipelined_prepare_and_set_single_batch
+    target_version "8.9" do
+      results = r.pipelined do |pipeline|
+        pipeline.himport_prepare("pipe", %w[f1 f2])
+        pipeline.himport_set("pipe:1", "pipe", %w[1 2])
+        pipeline.himport_set("pipe:2", "pipe", %w[3 4])
+      end
+
+      assert_equal %w[OK OK OK], results
+      assert_equal({ "f1" => "1", "f2" => "2" }, r.hgetall("pipe:1"))
+      assert_equal({ "f1" => "3", "f2" => "4" }, r.hgetall("pipe:2"))
+    end
+  end
+
+  def test_multi_prepare_and_set
+    target_version "8.9" do
+      results = r.multi do |tx|
+        tx.himport_prepare("txfs", %w[f1])
+        tx.himport_set("tx:1", "txfs", %w[v])
+      end
+
+      assert_equal %w[OK OK], results
+      assert_equal({ "f1" => "v" }, r.hgetall("tx:1"))
+    end
+  end
+
+  def test_pipelined_failed_prepare_fails_dependent_sets
+    target_version "8.9" do
+      results = r.pipelined(exception: false) do |pipeline|
+        pipeline.himport_prepare("dupfs", %w[f1 f1])
+        pipeline.himport_set("k1", "dupfs", %w[v v])
+      end
+
+      # in-array errors from `exception: false` are raw RedisClient errors, per
+      # the gem's established behavior (cf. pipelining_commands_test.rb)
+      assert_kind_of RedisClient::CommandError, results[0]
+      assert_match(/duplicate field/, results[0].message)
+      assert_kind_of RedisClient::CommandError, results[1]
+      assert_match(/no such fieldset/, results[1].message)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements client support for `HIMPORT PREPARE / SET / DISCARD / DISCARDALL` across all three client types, including first-class cluster fan-out and automatic recovery from connection-scoped fieldset loss.

### What HIMPORT is

`HIMPORT` is a fast-ingestion mechanism for hashes sharing one field schema: the client registers field names once (`HIMPORT PREPARE fieldset field ...`) and then creates hashes sending only values (`HIMPORT SET key fieldset value ...`). The hard part for a client is that fieldsets are server-side session state scoped to one physical connection: they are destroyed by `disconnect/RESET`, are invisible to other connections, and a `SET` on a connection that didn't `PREPARE` fails with `ERR no such fieldset`.

### API

```
redis.himport_prepare("users", ["name", "email", "age"])          # => "OK"
redis.himport_set("user:1", "users", ["alice", "a@x.com", "25"])  # => "OK"
redis.himport_discard("users")                                    # => 1
redis.himport_discard_all
```

- `lib/redis/commands/hashes.rb` — four transport-pure methods (available on standalone clients and inside pipelined/multi automatically). Client-side validation is limited to non-empty fields/values; fields/values are never deduplicated or reordered; empty strings are valid names; server errors propagate unmodified as `Redis::CommandError`.
- `Redis::Distributed` — `himport_prepare/himport_discard/himport_discard_all` fan out via `on_each_node` (per-node array replies, the existing Distributed convention); `himport_set routes` via `node_for(key)`.
- `Redis::Cluster` — see below.

### Fieldset-loss recovery (himport_auto_prepare, default on)

A `Redis` instance transparently replaces a dead connection (default reconnect_attempts: 1), silently destroying prepared fieldsets. The client therefore keeps a registry of the last schema prepared per fieldset name and, when a `himport_set` fails with no such fieldset and the registry has the schema, re-issues the `PREPARE` (cluster: re-fans it out to all masters) and retries the `SET` exactly once. Explicitly discarded fieldsets are removed from the registry and never resurrected. One mechanism covers reconnects, idle-timeout reconnects, sentinel failover, `RESET` by connection sanitizers, cluster failover/topology rebuilds and `MOVED/ASK` onto fresh connections.

Opt out with `Redis.new(himport_auto_prepare: false)` for a fully explicit fieldset lifecycle; the registry is still recorded to support manual recovery. Recovery applies to direct calls only — commands inside pipelined/multi blocks are untouched (the recommended high-throughput pattern is a single pipeline carrying the PREPARE and its SETs, which always executes as one batch on one socket).

### Cluster support and its risks

~The server advertises `request_policy:all_shards` for `PREPARE/DISCARD/DISCARDALL` and a key at position 2 for `SET`. `redis-cluster-client (0.16.x)` parses neither command tips nor per-subcommand key specs — a container command gets the parent spec (first key = 0), so without intervention `HIMPORT SET` would route to an arbitrary node and `PREPARE` would reach one node only. This PR adds explicit routing in the cluster gem:~

- ~`Redis::Cluster::Client#himport_fan_out` — executes on all primaries; partial failures raise `Redis::Cluster::CommandErrorCollection` (per-node #errors), with the same `renew_cluster_state` handling `FLUSHALL's` fan-out gets.~
- ~`Redis::Cluster::Client#himport_call_by_key` — slot-routes `SET` via the router's public `find_node_key_by_key/send_command_to_node`, preserving `MOVED/ASK/CLUSTERDOWN` handling.~
- ~`Redis::Cluster#himport_*` overrides aggregate fan-out replies for standalone/cluster API parity (FLUSHALL-style): "OK" for prepare, max across masters for the discard counters.~

### ⚠️ Risk: private upstream API usage

~The primaries fan-out reaches one private method of the underlying driver: `router.send(:send_command_to_primaries, ...)`. There is no public all-primaries primitive in `redis-cluster-client 0.16.x`. Mitigations:~

- ~the dependency is pinned to~ ~> 0.16.0, ~so the coupling can only break on a deliberate bump;~
- ~the cluster test suite exercises the call against a real cluster, so a future bump that removes or reshapes the method fails loudly in CI;~
- ~the call site carries a TODO. The durable fix is upstreaming command-tips (`request_policy:all_shards`) and subcommand key-spec parsing into `redis-cluster-client` (https://github.com/redis-rb/redis-cluster-client/issues/532); once that lands, both helper methods can be deleted without any public API change.~

~Everything else the cluster layer touches (`find_node_key_by_key, find_node, send_command_to_node, renew_cluster_state, router access from Redis::Cluster::Client`) is either public or has existing precedent in this repo (watch).~

~The issue has been addressed: https://github.com/redis-rb/redis-cluster-client/issues/534~

### ⚠️ Limitation: HIMPORT inside cluster transactions

~A cluster `MULTI` must pin to a single node, and the driver derives that node from the first command's key — which it cannot extract from any `HIMPORT` command (container-command spec). As a result:~

- ~A multi consisting only of `HIMPORT` commands raises `Redis::Cluster::TransactionConsistencyError` at `EXEC` — including the `himport_prepare + himport_set` combination. This is deliberate and covered by tests: even if the transaction could pin, a `PREPARE` inside it would reach one node's connection only, silently violating the all-shards contract; failing loudly is safer.~
- ~`himport_set` does work inside a multi pinned by a normal keyed command in the same hash slot (covered by tests, both orderings), because the fan-out `PREPARE` put the fieldset on every master's connection.~
- ~Inside a cluster pipelined block, `HIMPORT` commands route to the pipeline's arbitrary node — prepare does not fan out there. Documented as unsupported; use direct calls on cluster.~

~Standalone pipelined/multi have no such limitations and are fully supported (and tested).~

**All the risks about were solved in the downstream driver as a part of** https://github.com/redis-rb/redis-cluster-client/pull/535



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New experimental ingestion API and automatic re-prepare change behavior on reconnect; cluster users inherit breaking command-routing semantics from the pinned redis-cluster-client 0.16.7.
> 
> **Overview**
> Adds **experimental** client support for Redis 8.10’s `HIMPORT` family (`himport_prepare`, `himport_set`, `himport_discard`, `himport_discard_all`) for bulk hash ingestion with a shared field schema.
> 
> On standalone `Redis`, the client keeps a per-fieldset schema registry and, by default (`himport_auto_prepare`), re-issues `PREPARE` and retries `SET` once when the server reports `no such fieldset` after reconnect or connection loss; discarded fieldsets are not restored. **`Redis::Distributed`** fans prepare/discard to every ring node, routes `SET` by key, replays registered fieldsets when nodes are added, and returns per-node reply arrays for fan-out commands. **`Redis::Cluster`** relies on `redis-cluster-client` command-tip routing and aggregates multi-master fan-out replies to match the standalone API; loss recovery re-fans out through the same path.
> 
> Pins **`redis-client`** to `0.30.1` and **`redis-cluster-client`** to `0.16.7` (exact versions instead of patch ranges). The cluster gem changelog documents **breaking** routing changes from driver 0.16.6+ (`SLOWLOG`, `FUNCTION *`, `XINFO` subcommands, etc.). README adds a “Bulk hash ingestion (HIMPORT)” section; shared lint tests cover standalone, distributed, and cluster.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3036d854c339120d0f33731a01ef76be91b264e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->