### PR TITLE
Added support for Ruby 3.2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,13 +36,14 @@ jobs:
       fail-fast: false
       matrix:
         ruby_distribution: [MRI, TruffleRuby]
-        ruby_version: ["3.3", "3.4", "4.0"]
+        ruby_version: ["3.2", "3.3", "3.4", "4.0"]
         redis_version: ["7.2.14", "7.4.9", "8.2.6", "8.8.0", "8.10-rc2"]
         driver: [default, hiredis]
         exclude:
           # TruffleRuby's C extension support (Sulong) cannot build hiredis cleanly.
           - { ruby_distribution: TruffleRuby, driver: hiredis }
           # TruffleRuby tracks one Ruby compat level at a time; cover it on 3.4 only.
+          - { ruby_distribution: TruffleRuby, ruby_version: "3.2" }
           - { ruby_distribution: TruffleRuby, ruby_version: "3.3" }
           - { ruby_distribution: TruffleRuby, ruby_version: "4.0" }
     env:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 3.3
+  TargetRubyVersion: 3.2
 
 # Ruby 3.1+ lets you omit hash values (`{ x: }`); allow both forms rather than forcing a rewrite.
 Style/HashSyntax:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,7 @@
   with `WITHCOORD` now return coordinates as `Float` instead of `String`. Servers without RESP3
   (Redis < 6.0, or anything replying `NOPROTO`) transparently fall back to RESP2. See
   [specs/migration-resp3.md](specs/migration-resp3.md).
-- **Breaking**: now requires Ruby 3.3 or newer. redis-rb tracks the Ruby versions still under
-  official maintenance and drops them at end-of-life; see
-  https://www.ruby-lang.org/en/downloads/branches/.
+- **Breaking**: now requires Ruby 3.2 or newer.
 - Maintainership change: `redis-rb` is now maintained by the Redis Ltd company.
 - Pin `redis-client` to `~> 0.30.0` (patch-only). redis-rb couples tightly to redis-client internals and redis-client is pre-1.0 (minors may break), so this lets bug/security patches flow automatically while gating minor/major upgrades behind a deliberate release. Includes the reply-desynchronization fix (e.g. `mget` returning `"OK"` after a Sentinel failover/reconnect) that landed in 0.26.4.
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,8 @@ available on [RubyDoc.info][rubydoc].
 
 redis-rb targets actively supported runtimes on both the language and the server side:
 
-- **Ruby:** the versions still under official maintenance (normal or security); a version is
-  dropped once it reaches end-of-life. See the [Ruby maintenance branches][ruby-branches] page for
-  each version's status and dates. The current minimum is **Ruby 3.3**.
+- **Ruby:** Ruby 3.2 and newer. See the [Ruby maintenance branches][ruby-branches] page for
+  each version's status and dates.
 - **Redis server:** the versions designated for support by Redis. See 
 [Supported Redis database versions][redis-versions].
 

--- a/cluster/CHANGELOG.md
+++ b/cluster/CHANGELOG.md
@@ -31,8 +31,7 @@
   with `WITHCOORD` now return coordinates as `Float` instead of `String`. Nodes without RESP3
   (Redis < 6.0, or anything replying `NOPROTO`) transparently fall back to RESP2. See
   [the RESP3 migration guide](../specs/migration-resp3.md).
-- **Breaking**: now requires Ruby 3.3 or newer, tracking the Ruby versions still under official
-  maintenance. See https://www.ruby-lang.org/en/downloads/branches/.
+- **Breaking**: now requires Ruby 3.2 or newer.
 - Pin `redis-cluster-client` to the exact version `0.16.7`: the driver ships behavior changes in
   patch releases (see the command-tips entry above), so upgrades — including patches — are gated
   behind a deliberate, suite-verified release.

--- a/cluster/redis-clustering.gemspec
+++ b/cluster/redis-clustering.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.files         = Dir["CHANGELOG.md", "LICENSE", "README.md", "lib/**/*"]
   s.executables   = `git ls-files -- exe/*`.split("\n").map { |f| File.basename(f) }
 
-  s.required_ruby_version = '>= 3.3.0'
+  s.required_ruby_version = '>= 3.2.0'
 
   s.add_runtime_dependency('redis', s.version)
   # Patch-only within the current redis-cluster-client minor (pre-1.0, so minors may break and we

--- a/redis.gemspec
+++ b/redis.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["CHANGELOG.md", "LICENSE", "README.md", "lib/**/*"]
 
-  s.required_ruby_version = '>= 3.3.0'
+  s.required_ruby_version = '>= 3.2.0'
 
   # Pinned to an exact redis-client version: redis-rb couples tightly to redis-client internals
   # (subclassing, ensure_connected/call_v overrides, config access, RESP3/HELLO behavior), and


### PR DESCRIPTION
Following the ecosystem adoption we decided to keep Ruby 3.2+ support and move forward more tightened to the ecosystem standarts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Policy and tooling-only changes with no runtime code paths modified; CI gains an extra matrix row for Ruby 3.2.
> 
> **Overview**
> **Lowers the supported Ruby floor from 3.3 to 3.2** across packaging, CI, and docs so apps on Ruby 3.2 can install and run the gem again.
> 
> `redis` and `redis-clustering` now declare `required_ruby_version >= 3.2.0`. RuboCop’s `TargetRubyVersion` is **3.2**. The GitHub Actions matrix adds an MRI **3.2** job and excludes TruffleRuby on 3.2 (TruffleRuby stays on 3.4 only). README and both CHANGELOGs state **Ruby 3.2+** instead of 3.3+.
> 
> There are **no library or client behavior changes** in this diff—only version policy and test/lint configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb8ebc855d0b3bf089dff088c2e50c2da4f370ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->