### PR TITLE
Testing with 8.10 custom image

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         ruby_distribution: [MRI, TruffleRuby]
         ruby_version: ["3.2", "3.3", "3.4", "4.0"]
-        redis_version: ["7.2.14", "7.4.9", "8.2.6", "8.8.0", "8.10-rc2"]
+        redis_version: ["7.2.14", "7.4.9", "8.2.6", "8.8.0", "custom-30445126297-debian"]
         driver: [default, hiredis]
         exclude:
           # TruffleRuby's C extension support (Sulong) cannot build hiredis cleanly.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only the GitHub Actions test matrix changes; no library or runtime code is affected.
> 
> **Overview**
> **CI** now exercises the full test matrix against a **custom Redis client-libs test image** (`custom-30445126297-debian`) instead of the prior **`8.10-rc2`** matrix entry.
> 
> That value is passed through as **`REDIS_VERSION`**, so Docker Compose pulls `redislabs/client-libs-test:custom-30445126297-debian` for standalone, replica, sentinel, and cluster profiles on that matrix row—intended to validate **Redis 8.10** before a stable published tag is available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ab8a6f1a759ad425840560dbe080e5c11ebf87d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->