### PR TITLE
Testing with 8.10 GA

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         ruby_distribution: [MRI, TruffleRuby]
         ruby_version: ["3.2", "3.3", "3.4", "4.0"]
-        redis_version: ["7.2.14", "7.4.9", "8.2.6", "8.8.0", "8.10-rc2"]
+        redis_version: ["7.2.14", "7.4.9", "8.2.6", "8.8.0", "8.10.0"]
         driver: [default, hiredis]
         exclude:
           # TruffleRuby's C extension support (Sulong) cannot build hiredis cleanly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,52 @@
-# Unreleased
+# 6.0.0
 
-- Pin the `redis-client` dependency to the exact version `0.30.1` (previously `~> 0.30.0`): the
-  pre-1.0 driver family delivers behavior changes in patch releases, so a floating patch
-  constraint can change client semantics under a stable `redis` release. Driver bumps are now
-  deliberate, suite-verified events.
-- **Experimental**: add support for the `HIMPORT` command family (Redis 8.10, hinted hash
-  templates) — the client API may change in a future minor release without a major version
-  bump: `himport_prepare`,
-  `himport_set`, `himport_discard`, `himport_discard_all`, available on standalone clients,
-  pipelines/transactions and `Redis::Distributed` (fan-out prepare/discard). Fieldsets are
-  server-side per-connection session state; the client remembers each prepared schema and, when a
-  `himport_set` reports the fieldset was lost (reconnect, failover, `RESET`), re-prepares it and
-  retries once. Disable with `himport_auto_prepare: false`. See the README "Bulk hash ingestion
-  (HIMPORT)" section.
-- Add support for the Redis Query Engine (RediSearch, `FT.*`): index management
-  (`ft_create`/`create_index`, `ft_alter`, `ft_dropindex`, `ft_info`), querying (`ft_search` with a
-  `Search::Query` builder, `ft_aggregate` with `Search::AggregateRequest`), vector and hybrid search,
-  suggestions, dictionaries, synonyms, aliases, and spellcheck. Replies are reshaped into
-  `Search::SearchResult`/`Search::Document` and `Search::AggregateResult` objects (RESP2- and
-  RESP3-compatible). Available on standalone and cluster clients; not supported by
-  `Redis::Distributed` (indexes are not key-shardable).
-- **Breaking**: the client now negotiates RESP3 (`HELLO 3`) by default; pass `protocol: 2` to keep
-  RESP2. The only command whose return value changes is GEO — `GEOPOS` and `GEOSEARCH`/`GEORADIUS`
-  with `WITHCOORD` now return coordinates as `Float` instead of `String`. Servers without RESP3
-  (Redis < 6.0, or anything replying `NOPROTO`) transparently fall back to RESP2. See
-  [specs/migration-resp3.md](specs/migration-resp3.md).
-- **Breaking**: now requires Ruby 3.2 or newer.
+## Breaking changes
+
+- Use RESP3 (`HELLO 3`) by default; pass `protocol: 2` to keep RESP2. `GEOPOS` and
+  `GEOSEARCH`/`GEORADIUS` with `WITHCOORD` now return coordinates as `Float` instead of `String`.
+  See [specs/migration-resp3.md](specs/migration-resp3.md). (#1351)
+- Require Ruby 3.2+. (#1353, #1365)
+
+## New features
+
+- Add support for the Redis Query Engine (RediSearch, `FT.*`): `ft_create`, `ft_alter`,
+  `ft_dropindex`, `ft_info`, `ft_search`, `ft_aggregate`, vector and hybrid search, suggestions,
+  dictionaries, synonyms, aliases, and spellcheck. Not supported by `Redis::Distributed`.
+  (#1356, #1359, #1360, #1361)
+- Add support for the JSON module: `json_set`, `json_get`, `json_mset`, `json_mget`, `json_del`,
+  `json_forget`, `json_clear`, `json_merge`, `json_arr*`, `json_obj*`, `json_str*`,
+  `json_numincrby`, `json_toggle`, `json_type`, `json_debug_memory`. (#1346, #1347, #1348, #1349)
+- Add `lmovem` and `blmovem` (Redis 8.10). (#1363)
+- Add `sunioncard` and `sdiffcard` (Redis 8.10). (#1357)
+- `xread` and `xreadgroup` now accept `max_count:` and `max_size:` (Redis 8.10). (#1358)
+- Add `hexpire`, `hpexpire`, `httl` and `hpttl` (Redis 7.4). (#1324, #1325, #1331)
+- `hscan` and `hscan_each` now accept `novalues: true` (Redis 7.4). (#1327)
+- Add `geosearch` and `geosearchstore` (Redis 6.2); geo commands are now available on
+  `Redis::Distributed`. (#1342)
+- `geoadd` now accepts `nx:`, `xx:` and `ch:`; geo radius searches accept `count_any:`; `xadd`
+  accepts `limit:` (Redis 6.2). (#1345)
+- `Redis::Distributed` now implements `hscan`, `hscan_each` and `hstrlen`. (#1319)
+
+## Experimental
+
+- Add `himport_prepare`, `himport_set`, `himport_discard` and `himport_discard_all`
+  (Redis 8.10 `HIMPORT`). Lost fieldsets are re-prepared and retried automatically; disable with
+  `himport_auto_prepare: false`. The API may change in a future minor release. See the README
+  "Bulk hash ingestion (HIMPORT)" section. (#1364)
+
+## Bug fixes
+
+- Fix `FloatifyPairs` to not re-transform already transformed replies. (#1354)
+- `unlink` now returns `0` for an empty keyset, consistent with `del`. (#1316)
+
+## Maintenance
+
+- Pin `redis-client` to the exact version `0.30.1` (previously `>= 0.22.0`); includes the
+  reply-desynchronization fix from 0.26.4. (#1350, #1352)
 - Maintainership change: `redis-rb` is now maintained by the Redis Ltd company.
-- Pin `redis-client` to `~> 0.30.0` (patch-only). redis-rb couples tightly to redis-client internals and redis-client is pre-1.0 (minors may break), so this lets bug/security patches flow automatically while gating minor/major upgrades behind a deliberate release. Includes the reply-desynchronization fix (e.g. `mget` returning `"OK"` after a Sentinel failover/reconnect) that landed in 0.26.4.
+- Run the test suite against prebuilt `redislabs/client-libs-test` Docker images; CI now covers
+  MRI 3.2/3.3/3.4/4.0 and TruffleRuby against Redis 7.2–8.10; JRuby removed. (#1317, #1318, #1344)
+- Drop the unused `executables` config from the gemspec. (#1322)
 
 # 5.4.1
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,38 @@ Servers without RESP3 support (Redis < 6.0, or anything replying `NOPROTO`) are
 detected on connect and the client transparently falls back to RESP2, so no
 configuration is needed for older servers.
 
+### Why RESP3 is the default
+
+RESP3's richer wire types let the parser deliver replies already in their final
+Ruby shape. Under RESP2, structured replies arrive as flat arrays of bulk
+strings and the client re-shapes them in Ruby: `HGETALL` turns a flat
+`[field, value, field, value, ...]` array into a `Hash`, and sorted-set scores
+are converted from `String` to `Float` pair by pair. Under RESP3 the server
+tags these replies as native maps and doubles, so the final `Hash` and `Float`
+values come straight out of the parser and the Ruby-side re-shaping pass
+disappears entirely.
+
+How much that saves depends on where parsing happens. In our benchmarks
+([bench/resp_comparison.rb](bench/resp_comparison.rb), Ruby 3.4, 100-element
+replies), hash reads (`HGETALL`) consistently use ~10–25% less client CPU per
+call on both drivers. With the [hiredis driver](#hiredis-binding), where
+parsing runs in C, sorted-set reads with scores gain up to 16% throughput and
+~20% less CPU per call on top of that; with the pure-Ruby driver they are
+unchanged, since the parser then spends in Ruby roughly what the re-shaping
+pass used to cost. Simple string commands and stream commands are unaffected
+either way — their reply shapes are the same in both protocols. In short:
+RESP3 is never slower where it matters, and it pairs best with hiredis — that
+combination moves all reply construction out of Ruby and into C.
+
+Beyond performance, RESP3 unlocks protocol capabilities RESP2 simply doesn't
+have. The most important is out-of-band **push messages**: the server can send
+notifications on a connection without the client asking, which is the
+foundation for server-assisted client-side caching (`CLIENT TRACKING`
+invalidation events), pub/sub messages delivered over the regular command
+connection instead of a dedicated one, and other server-initiated
+notifications. Defaulting to RESP3 in 6.0 lays the groundwork for building
+these features in future releases without another protocol migration.
+
 See [the RESP3 migration guide](specs/migration-resp3.md) for full details.
 
 ## Connection Pooling and Thread safety

--- a/bench/resp_comparison.rb
+++ b/bench/resp_comparison.rb
@@ -35,7 +35,7 @@ def seed
   r = new_client(2)
   r.set(SKEY, "x" * 50)
   r.del(HKEY, ZKEY, XKEY)
-  fields = ELEMS.times.to_h { |i| ["field#{i}", "value-#{i}-#{"y" * 20}"] }
+  fields = ELEMS.times.to_h { |i| ["field#{i}", "value-#{i}-#{'y' * 20}"] }
   r.hset(HKEY, fields)
   r.zadd(ZKEY, ELEMS.times.map { |i| [i * 1.5, "member-#{i}"] })
   ELEMS.times { |i| r.xadd(XKEY, { "sensor" => "s#{i}", "temp" => (20 + i).to_s }) }
@@ -48,6 +48,7 @@ def verify_shapes!
   raise "hgetall mismatch" unless c2.hgetall(HKEY) == c3.hgetall(HKEY)
   raise "zrange mismatch" unless c2.zrange(ZKEY, 0, -1, with_scores: true) == c3.zrange(ZKEY, 0, -1, with_scores: true)
   raise "xrange mismatch" unless c2.xrange(XKEY) == c3.xrange(XKEY)
+
   [c2, c3].each(&:close)
 end
 
@@ -91,7 +92,8 @@ puts
 
 [1, THREADS].each do |threads|
   puts "== #{threads} thread#{'s' if threads > 1} =="
-  puts format("  %-28s %12s %12s %8s %14s %14s", "workload", "RESP2 RPS", "RESP3 RPS", "Δ RPS", "RESP2 usCPU/op", "RESP3 usCPU/op")
+  puts format("  %-28s %12s %12s %8s %14s %14s", "workload", "RESP2 RPS", "RESP3 RPS", "Δ RPS", "RESP2 usCPU/op",
+              "RESP3 usCPU/op")
   WORKLOADS.each do |label, op|
     r2 = run_cell(2, threads, op)
     r3 = run_cell(3, threads, op)

--- a/bench/resp_comparison.rb
+++ b/bench/resp_comparison.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+# RESP2 vs RESP3 for redis-rb across reply-reshape complexity:
+#   1. GET               (string — no reshape, baseline)
+#   2. HGETALL           (Hashify: flat array -> Hash under RESP2, native map under RESP3)
+#   3. ZRANGE WITHSCORES (FloatifyPairs: pairs -> [member, Float] under RESP2, native doubles under RESP3)
+#   4. XRANGE            (HashifyStreamEntries — deeply nested reshape)
+# Each cell runs single-threaded and multi-threaded (one client per thread).
+#
+#   DURATION=6 THREADS=8 bundle exec ruby bench/resp_comparison.rb
+
+require "redis"
+
+PORT     = Integer(ENV.fetch("REDIS_PORT", "6381"))
+DURATION = Float(ENV.fetch("DURATION", "6"))
+THREADS  = Integer(ENV.fetch("THREADS", "8"))
+ELEMS    = Integer(ENV.fetch("ELEMENTS", "100"))
+DRIVER   = ENV.fetch("DRIVER", "ruby").to_sym
+require "hiredis-client" if DRIVER == :hiredis
+
+SKEY = "bench:str"
+HKEY = "bench:hash"
+ZKEY = "bench:zset"
+XKEY = "bench:stream"
+
+def new_client(protocol)
+  Redis.new(host: "127.0.0.1", port: PORT, protocol: protocol, driver: DRIVER)
+end
+
+def monotonic
+  Process.clock_gettime(Process::CLOCK_MONOTONIC)
+end
+
+def seed
+  r = new_client(2)
+  r.set(SKEY, "x" * 50)
+  r.del(HKEY, ZKEY, XKEY)
+  fields = ELEMS.times.to_h { |i| ["field#{i}", "value-#{i}-#{"y" * 20}"] }
+  r.hset(HKEY, fields)
+  r.zadd(ZKEY, ELEMS.times.map { |i| [i * 1.5, "member-#{i}"] })
+  ELEMS.times { |i| r.xadd(XKEY, { "sensor" => "s#{i}", "temp" => (20 + i).to_s }) }
+  r.close
+end
+
+# Sanity: both protocols must produce identical Ruby shapes.
+def verify_shapes!
+  c2, c3 = new_client(2), new_client(3)
+  raise "hgetall mismatch" unless c2.hgetall(HKEY) == c3.hgetall(HKEY)
+  raise "zrange mismatch" unless c2.zrange(ZKEY, 0, -1, with_scores: true) == c3.zrange(ZKEY, 0, -1, with_scores: true)
+  raise "xrange mismatch" unless c2.xrange(XKEY) == c3.xrange(XKEY)
+  [c2, c3].each(&:close)
+end
+
+WORKLOADS = {
+  "GET (50B string)" => ->(r) { r.get(SKEY) },
+  "HGETALL (#{ELEMS} fields)" => ->(r) { r.hgetall(HKEY) },
+  "ZRANGE WITHSCORES (#{ELEMS})" => ->(r) { r.zrange(ZKEY, 0, -1, with_scores: true) },
+  "XRANGE (#{ELEMS} entries)" => ->(r) { r.xrange(XKEY) }
+}.freeze
+
+def cpu_now
+  t = Process.times
+  t.utime + t.stime
+end
+
+def run_cell(protocol, threads, op)
+  clients = Array.new(threads) { new_client(protocol) }
+  clients.each { |r| 200.times { op.call(r) } } # warmup: connect + JIT
+  GC.start
+  stop_at = monotonic + DURATION
+  counts = Array.new(threads, 0)
+  cpu0, t0 = cpu_now, monotonic
+  threads.times.map do |i|
+    Thread.new do
+      r = clients[i]
+      n = 0
+      n += 1 while op.call(r) && monotonic < stop_at
+      counts[i] = n
+    end
+  end.each(&:join)
+  wall, cpu = monotonic - t0, cpu_now - cpu0
+  clients.each(&:close)
+  total = counts.sum
+  { rps: total / wall, us_cpu: (cpu / total) * 1_000_000.0 }
+end
+
+seed
+verify_shapes!
+puts "redis-rb #{Redis::VERSION}  ruby #{RUBY_VERSION}  driver=#{DRIVER}  duration=#{DURATION}s/cell  elements=#{ELEMS}"
+puts
+
+[1, THREADS].each do |threads|
+  puts "== #{threads} thread#{'s' if threads > 1} =="
+  puts format("  %-28s %12s %12s %8s %14s %14s", "workload", "RESP2 RPS", "RESP3 RPS", "Δ RPS", "RESP2 usCPU/op", "RESP3 usCPU/op")
+  WORKLOADS.each do |label, op|
+    r2 = run_cell(2, threads, op)
+    r3 = run_cell(3, threads, op)
+    delta = (r3[:rps] / r2[:rps] - 1) * 100
+    puts format("  %-28s %12.0f %12.0f %+7.1f%% %14.1f %14.1f",
+                label, r2[:rps], r3[:rps], delta, r2[:us_cpu], r3[:us_cpu])
+  end
+  puts
+end

--- a/cluster/CHANGELOG.md
+++ b/cluster/CHANGELOG.md
@@ -1,37 +1,23 @@
-# Unreleased
+# 6.0.0
 
-- **Experimental**: add first-class support for the `HIMPORT` command family (Redis 8.10) — the
-  client API may change in a future minor release without a major version bump: `himport_prepare`,
-  `himport_discard` and `himport_discard_all` execute on all master nodes (per the commands'
-  `request_policy:all_shards` tip) and return a single aggregated reply; `himport_set` routes by its
-  key's hash slot with MOVED/ASK handling preserved. Routing is performed natively by
-  redis-cluster-client, which since 0.16.6 parses command tips and per-subcommand key specs (see
-  the pin entry below). Fieldset loss (node failover, topology reload, redirection to a
-  fresh connection) is repaired automatically by re-fanning out the last prepared schema and
-  retrying the SET once; disable with `himport_auto_prepare: false`. Partial fan-out failures raise
-  `Redis::Cluster::CommandErrorCollection`. Inside `multi`, an `himport_set` pins the transaction to
-  its key's slot and an accompanying `himport_prepare` executes on that same pinned connection.
-- **Breaking**: redis-cluster-client 0.16.6+ routes commands by their server-declared command tips
-  (`request_policy`/`response_policy`), which changes the behavior of a few commands that were
-  previously sent to one arbitrary node:
-  - `SLOWLOG GET` now returns an **array with one entry list per master** (previously a single
-    node's entry list) — the only reply-*shape* change.
-  - `SLOWLOG LEN` and `LATENCY RESET` still return an `Integer`, but now the **sum across all
-    masters** instead of one node's value.
-  - `FUNCTION LOAD`/`DELETE`/`FLUSH`/`RESTORE` now execute on **all masters** (reply unchanged).
-    This corrects a bug where functions were loaded onto a single arbitrary node and `FCALL`
-    failed for keys owned by the other masters.
-  - Container commands with keys in subcommands (e.g. `XINFO STREAM`) now route directly to the
-    key's slot owner and can pin a `multi` transaction (previously they raised
-    `Redis::Cluster::TransactionConsistencyError`).
-  Everything covered by the driver's legacy routing table (`PING`, `DBSIZE`, `KEYS`, `FLUSHALL`,
-  `SCRIPT`, `CONFIG`, `CLIENT`, `ACL`, `MEMORY`, `INFO`, multi-key commands, …) is unchanged.
-- **Breaking**: the client now negotiates RESP3 (`HELLO 3`) by default; pass `protocol: 2` to keep
-  RESP2. The only command whose return value changes is GEO — `GEOPOS` and `GEOSEARCH`/`GEORADIUS`
-  with `WITHCOORD` now return coordinates as `Float` instead of `String`. Nodes without RESP3
-  (Redis < 6.0, or anything replying `NOPROTO`) transparently fall back to RESP2. See
-  [the RESP3 migration guide](../specs/migration-resp3.md).
-- **Breaking**: now requires Ruby 3.2 or newer.
-- Pin `redis-cluster-client` to the exact version `0.16.7`: the driver ships behavior changes in
-  patch releases (see the command-tips entry above), so upgrades — including patches — are gated
-  behind a deliberate, suite-verified release.
+## Breaking changes
+
+- Route commands by their server-declared command tips (redis-cluster-client 0.16.6+):
+  `SLOWLOG GET` now returns one entry list per master; `SLOWLOG LEN` and `LATENCY RESET` return
+  the sum across all masters; `FUNCTION LOAD`/`DELETE`/`FLUSH`/`RESTORE` now execute on all
+  masters; commands with keys in subcommands (e.g. `XINFO STREAM`) route to the key's slot owner.
+- Use RESP3 (`HELLO 3`) by default; pass `protocol: 2` to keep RESP2. `GEOPOS` and
+  `GEOSEARCH`/`GEORADIUS` with `WITHCOORD` now return coordinates as `Float` instead of `String`.
+  See [the RESP3 migration guide](../specs/migration-resp3.md). (#1351)
+- Require Ruby 3.2+. (#1353, #1365)
+
+## Experimental
+
+- Add `himport_prepare`, `himport_set`, `himport_discard` and `himport_discard_all`
+  (Redis 8.10 `HIMPORT`). Prepare/discard fan out to all masters; `himport_set` routes by its
+  key's hash slot. Lost fieldsets are re-prepared and retried automatically; disable with
+  `himport_auto_prepare: false`. The API may change in a future minor release. (#1364)
+
+## Maintenance
+
+- Pin `redis-cluster-client` to the exact version `0.16.7`.

--- a/lib/redis/version.rb
+++ b/lib/redis/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Redis
-  VERSION = '5.4.1'
+  VERSION = '6.0.0'
 end

--- a/test/redis/error_replies_test.rb
+++ b/test/redis/error_replies_test.rb
@@ -7,12 +7,14 @@ class TestErrorReplies < Minitest::Test
 
   # Every test shouldn't disconnect from the server. Also, when error replies are
   # in play, the protocol should never get into an invalid state where there are
-  # pending replies in the connection. Calling INFO after every test ensures that
-  # the protocol is still in a valid state.
+  # pending replies in the connection. Comparing CLIENT ID before and after ensures
+  # the connection wasn't replaced and the protocol is still in a valid state.
+  # (CLIENT ID is connection-local; server-global counters like
+  # total_connections_received race with the Docker healthcheck's redis-cli pings.)
   def with_reconnection_check
-    before = r.info["total_connections_received"]
+    before = r.client(:id)
     yield(r)
-    after = r.info["total_connections_received"]
+    after = r.client(:id)
   ensure
     assert_equal before, after
   end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are release documentation, CI matrix pin, benchmark script, and test harness stability—not client runtime behavior.
> 
> **Overview**
> Switches CI from Redis **8.10-rc2** to **8.10.0** in the test matrix so the suite runs against the GA server.
> 
> Bumps **`Redis::VERSION`** to **6.0.0** and replaces the “Unreleased” sections in **`CHANGELOG.md`** and **`cluster/CHANGELOG.md`** with structured **6.0.0** release notes (breaking changes, features, experimental HIMPORT, fixes, maintenance).
> 
> Adds README **“Why RESP3 is the default”** (performance, hiredis, push messages) and **`bench/resp_comparison.rb`** to compare RESP2 vs RESP3 workloads.
> 
> In **`test/redis/error_replies_test.rb`**, the post-error connection check uses **`CLIENT ID`** before/after instead of **`INFO total_connections_received`**, avoiding races with Docker healthcheck pings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19f8a639026ca4964f73764046959e4acfff6b42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->