### PR TITLE
Identify redis-rb to the server via CLIENT SETINFO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# Unreleased
+
+- Identify `redis-rb` to the server via `CLIENT SETINFO`, so that `CLIENT LIST` / `CLIENT INFO`
+  report `lib-name=redis-rb` and `lib-ver=<version>`; previously no identity was reported at all.
+  Applies to standalone, sentinel and cluster clients, under both RESP3 and RESP2. Applications
+  using `redis-client` directly are unaffected. Libraries built on top of `redis-rb` can identify
+  themselves by passing `driver_info:`, and are reported alongside it, e.g.
+  `lib-name=redis-rb(my-gem_v1.0.0)`. Servers older than 7.2 reject `CLIENT SETINFO`; the error is
+  ignored and the connection is kept. Under RESP2 with no password, db 0 and no `id:`, connecting
+  previously sent no commands at all; it now issues `CLIENT SETINFO`. Peers that can't tolerate
+  unknown commands during the handshake can disable identification with `driver_info: false`.
+
 # 6.0.0
 
 ## Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,3 @@
-# Unreleased
-
-- Identify `redis-rb` to the server via `CLIENT SETINFO`, so that `CLIENT LIST` / `CLIENT INFO`
-  report `lib-name=redis-rb` and `lib-ver=<version>`; previously no identity was reported at all.
-  Applies to standalone, sentinel and cluster clients, under both RESP3 and RESP2. Applications
-  using `redis-client` directly are unaffected. Libraries built on top of `redis-rb` can identify
-  themselves by passing `driver_info:`, and are reported alongside it, e.g.
-  `lib-name=redis-rb(my-gem_v1.0.0)`. Servers older than 7.2 reject `CLIENT SETINFO`; the error is
-  ignored and the connection is kept. Under RESP2 with no password, db 0 and no `id:`, connecting
-  previously sent no commands at all; it now issues `CLIENT SETINFO`. Peers that can't tolerate
-  unknown commands during the handshake can disable identification with `driver_info: false`.
-
 # 6.0.0
 
 ## Breaking changes
@@ -38,6 +26,9 @@
 - `geoadd` now accepts `nx:`, `xx:` and `ch:`; geo radius searches accept `count_any:`; `xadd`
   accepts `limit:` (Redis 6.2). (#1345)
 - `Redis::Distributed` now implements `hscan`, `hscan_each` and `hstrlen`. (#1319)
+- Identify the client to the server via `CLIENT SETINFO` (`lib-name=redis-rb`,
+  `lib-ver=<version>`). Extend the reported name with `driver_info:`, or disable with
+  `driver_info: false`. See the README "Client identification" section. (#1369)
 
 ## Experimental
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,37 @@ these features in future releases without another protocol migration.
 
 See [the RESP3 migration guide](specs/migration-resp3.md) for full details.
 
+## Client identification
+
+On connect the client identifies itself to the server with `CLIENT SETINFO`, so
+`redis-rb` and its version are visible in `CLIENT LIST` and `CLIENT INFO`:
+
+```
+lib-name=redis-rb lib-ver=<Redis::VERSION>
+```
+
+Libraries built on top of `redis-rb` can add their own identity with
+`driver_info:`, which is reported alongside it. The recommended suffix format
+is `<name>_v<version>`, following the convention used by the official client
+libraries:
+
+```ruby
+Redis.new(driver_info: "my-gem_v#{MyGem::VERSION}")
+# reported as: lib-name=redis-rb(my-gem_v1.0.0) lib-ver=<Redis::VERSION>
+```
+
+`driver_info:` also accepts an array, joined with `;` (the conventional
+delimiter for multiple suffixes). It extends the reported name rather than
+replacing it, so `redis-rb` stays identifiable either way. Runs of characters
+the server would reject (spaces, non-printable bytes) and of the parentheses
+that delimit the suffix are each replaced with a single `_`, or dropped at the
+edges of the value.
+
+Servers older than 7.2 don't support `CLIENT SETINFO`; they reject it, the error
+is ignored, and the connection is used as normal. If a proxy or server can't
+tolerate the command at all, pass `driver_info: false` to disable client
+identification entirely.
+
 ## Connection Pooling and Thread safety
 
 The client does not provide connection pooling. Each `Redis` instance

--- a/cluster/CHANGELOG.md
+++ b/cluster/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Unreleased
+
+- Identify `redis-rb` to the server via `CLIENT SETINFO`, so that `CLIENT LIST` / `CLIENT INFO` on
+  every cluster node report `lib-name=redis-rb` and `lib-ver=<version>`; previously no identity was
+  reported at all. Libraries built on top of `Redis::Cluster` can identify themselves by passing
+  `driver_info:`, and are reported alongside it, e.g. `lib-name=redis-rb(my-gem_v1.0.0)`. Servers older
+  than 7.2 reject `CLIENT SETINFO`; the error is ignored and the connection is kept. Identification
+  can be disabled entirely with `driver_info: false`.
+
 # 6.0.0
 
 ## Breaking changes

--- a/cluster/CHANGELOG.md
+++ b/cluster/CHANGELOG.md
@@ -1,12 +1,3 @@
-# Unreleased
-
-- Identify `redis-rb` to the server via `CLIENT SETINFO`, so that `CLIENT LIST` / `CLIENT INFO` on
-  every cluster node report `lib-name=redis-rb` and `lib-ver=<version>`; previously no identity was
-  reported at all. Libraries built on top of `Redis::Cluster` can identify themselves by passing
-  `driver_info:`, and are reported alongside it, e.g. `lib-name=redis-rb(my-gem_v1.0.0)`. Servers older
-  than 7.2 reject `CLIENT SETINFO`; the error is ignored and the connection is kept. Identification
-  can be disabled entirely with `driver_info: false`.
-
 # 6.0.0
 
 ## Breaking changes
@@ -19,6 +10,12 @@
   `GEOSEARCH`/`GEORADIUS` with `WITHCOORD` now return coordinates as `Float` instead of `String`.
   See [the RESP3 migration guide](../specs/migration-resp3.md). (#1351)
 - Require Ruby 3.2+. (#1353, #1365)
+
+## New features
+
+- Identify the client to every node via `CLIENT SETINFO` (`lib-name=redis-rb`,
+  `lib-ver=<version>`). Extend the reported name with `driver_info:`, or disable with
+  `driver_info: false`. (#1369)
 
 ## Experimental
 

--- a/cluster/lib/redis/cluster.rb
+++ b/cluster/lib/redis/cluster.rb
@@ -63,6 +63,10 @@ class Redis
     # @option options [String] :fixed_hostname Specify a FQDN if cluster mode enabled and
     #   client has to connect nodes via single endpoint with SSL/TLS
     # @option options [Class] :connector Class of custom connector
+    # @option options [String, Array<String>, false] :driver_info Identity a library built on top of
+    #   `redis-rb` reports to every node via `CLIENT SETINFO`, shown as `lib-name=redis-rb(<driver_info>)`
+    #   in `CLIENT LIST`. The recommended format is `<name>_v<version>`; an Array is joined with `;`.
+    #   Pass `false` to disable client identification entirely.
     #
     # @return [Redis::Cluster] a new client instance
     def initialize(*)
@@ -162,7 +166,11 @@ class Redis
 
     def initialize_client(options)
       # protocol defaults to 3 (RESP3) but a caller-provided protocol: in options overrides it.
-      cluster_config = RedisClient.cluster(protocol: 3, **options, client_implementation: ::Redis::Cluster::Client)
+      cluster_config = RedisClient.cluster(
+        protocol: 3, **options,
+        driver_info: ::Redis::LibIdentity.driver_info(options[:driver_info]),
+        client_implementation: ::Redis::Cluster::Client
+      )
       cluster_config.new_client
     end
   end

--- a/cluster/test/client_internals_test.rb
+++ b/cluster/test/client_internals_test.rb
@@ -93,4 +93,34 @@ class TestClusterClientInternals < Minitest::Test
       end
     end
   end
+
+  # `CLIENT INFO` replies as one space-separated line of `key=value` pairs. Parsing it into fields
+  # keeps the assertions exact: `assert_includes info, "lib-name=redis-rb"` would also accept
+  # `lib-name=redis-rb-<version>`.
+  def client_info_fields(client)
+    client.client(:info).split(" ").to_h { |field| field.split("=", 2) }
+  end
+
+  def test_lib_name_set_via_client_setinfo
+    target_version "7.2.0" do
+      redis.ping
+      fields = client_info_fields(redis)
+
+      assert_equal "redis-rb", fields["lib-name"]
+      assert_equal Redis::VERSION, fields["lib-ver"]
+    end
+  end
+
+  def test_lib_name_includes_downstream_driver_info
+    # Pins that `driver_info:` is threaded in a way a caller cannot replace, which is a separate
+    # code path in Redis::Cluster#initialize_client from the standalone client.
+    target_version "7.2.0" do
+      client = _new_client(driver_info: "my-gem-1.0")
+      client.ping
+      fields = client_info_fields(client)
+
+      assert_equal "redis-rb(my-gem-1.0)", fields["lib-name"]
+      assert_equal Redis::VERSION, fields["lib-ver"]
+    end
+  end
 end

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -57,6 +57,10 @@ class Redis
   #   to RESP3; set to `2` for RESP2. Servers without RESP3 support automatically fall back to RESP2.
   # @option options [String] :id ID for the client connection, assigns name to current connection by sending
   #   `CLIENT SETNAME`
+  # @option options [String, Array<String>, false] :driver_info Identity a library built on top of `redis-rb`
+  #   reports to the server via `CLIENT SETINFO`, shown as `lib-name=redis-rb(<driver_info>)` in `CLIENT LIST`.
+  #   The recommended format is `<name>_v<version>`; an Array is joined with `;`. Pass `false` to disable
+  #   client identification entirely.
   # @option options [Integer, Array<Integer, Float>] :reconnect_attempts Number of attempts trying to connect,
   #   or a list of sleep duration between attempts.
   # @option options [Boolean] :inherit_socket (false) Whether to use socket in forked process or not
@@ -316,6 +320,7 @@ class Redis
 end
 
 require "redis/version"
+require "redis/lib_identity"
 require "redis/client"
 require "redis/pipeline"
 require "redis/subscribe"

--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -21,11 +21,14 @@ class Redis
 
     class << self
       def config(protocol: 3, **kwargs)
-        super(protocol: protocol, **kwargs)
+        super(protocol: protocol, **kwargs,
+              driver_info: Redis::LibIdentity.driver_info(kwargs[:driver_info]))
       end
 
       def sentinel(protocol: 3, **kwargs)
-        super(protocol: protocol, **kwargs, client_implementation: ::RedisClient)
+        super(protocol: protocol, **kwargs,
+              driver_info: Redis::LibIdentity.driver_info(kwargs[:driver_info]),
+              client_implementation: ::RedisClient)
       end
 
       def translate_error!(error, mapping: ERROR_MAPPING)

--- a/lib/redis/lib_identity.rb
+++ b/lib/redis/lib_identity.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "redis-client"
+require "redis/version"
+
+class Redis
+  # Reports `redis-rb` as the connecting library via `CLIENT SETINFO`.
+  #
+  # `redis-client` builds its own `LIB-NAME` as `redis-client(<driver_info>)` and always
+  # reports its own version as `LIB-VER`, which would identify `redis-client` rather than
+  # `redis-rb` to the server. We append a second pair of `CLIENT SETINFO` commands, which wins
+  # because the command is last-write-wins, so that `CLIENT LIST` / `CLIENT INFO` report
+  # `lib-name=redis-rb` and `lib-ver=<Redis::VERSION>`.
+  #
+  # Libraries built on top of `redis-rb` can still identify themselves by passing `driver_info`,
+  # in which case they are reported inside the parentheses, e.g. `lib-name=redis-rb(my-gem_v1.0.0)`.
+  # The official convention for such suffixes is `<name>_v<version>` (matching
+  # `(?<custom-name>[ -~]+)[ -~]v(?<custom-version>[\d\.]+)`), with `;` delimiting multiple
+  # suffixes and parentheses avoided inside them — see
+  # https://redis.io/docs/latest/commands/client-setinfo/. Passing `driver_info: false` disables
+  # `CLIENT SETINFO` entirely, for peers that can't tolerate unknown commands during the handshake
+  # (e.g. some proxies).
+  #
+  # Applications that use `redis-client` directly are left untouched: the override only applies
+  # to configurations whose `driver_info` was built by this module.
+  module LibIdentity
+    # Follows the official suffix convention, so that the transient pair `redis-client` itself
+    # builds from this value (`lib-name=redis-client(redis-rb_v<version>)`) is well-formed too.
+    MARKER = "redis-rb_v"
+    LIB_NAME = "redis-rb"
+    SEPARATOR = ";"
+    # Interpolated strings are not frozen by the magic comment; explicit freezes keep these
+    # constants Ractor-shareable (lazy module ivars here would raise Ractor::IsolationError).
+    OWN_INFO = "#{MARKER}#{Redis::VERSION}".freeze
+    OWN_PREFIX = "#{OWN_INFO}#{SEPARATOR}".freeze
+    # `CLIENT SETINFO` values must be printable ASCII with no spaces — the server rejects anything
+    # else, and `redis-client` swallows that error, which would silently leave `lib-name` empty.
+    # Parentheses are excluded as well: they delimit the suffix in `lib-name=redis-rb(<suffix>)`,
+    # so a suffix containing them would corrupt the reported name.
+    INVALID_CHARS = /(?:[^!-~]|[()])+/
+
+    class << self
+      # Combines redis-rb's own identity with the `driver_info` a downstream library passed in,
+      # so that both can be recovered when the connection prelude is built. `false` is passed
+      # through untouched and, being falsy, turns `CLIENT SETINFO` off wholesale (`redis-client`
+      # gates its own commands on `driver_info` too). Any other non-String, non-Array value is
+      # also passed through, leaving `redis-client` to reject it.
+      def driver_info(downstream = nil)
+        case downstream
+        when nil then OWN_INFO
+        when String then combine(downstream)
+        when Array then combine(downstream.join(SEPARATOR))
+        else downstream
+        end
+      end
+
+      # True only for values `driver_info` produced: exactly our own identity, or our identity
+      # followed by a downstream library's. Matching on the bare `MARKER` prefix instead would
+      # also capture a direct `redis-client` user whose own `driver_info` merely starts with
+      # `redis-rb_v` (say `redis-rb_viewer-1.0`) and would silently discard their identity.
+      def ours?(info)
+        info.is_a?(String) && (info == OWN_INFO || info.start_with?(OWN_PREFIX))
+      end
+
+      def setinfo_commands(info)
+        [
+          ["CLIENT", "SETINFO", "LIB-NAME", lib_name(info)].freeze,
+          ["CLIENT", "SETINFO", "LIB-VER", Redis::VERSION].freeze,
+        ].freeze
+      end
+
+      private
+
+      def combine(downstream)
+        downstream = downstream.scrub(" ") # invalid byte sequences would make gsub raise
+                               .gsub(/\A#{INVALID_CHARS}|#{INVALID_CHARS}\z/o, "")
+                               .gsub(INVALID_CHARS, "_")
+        downstream.empty? ? OWN_INFO : "#{OWN_PREFIX}#{downstream}"
+      end
+
+      def lib_name(info)
+        downstream = info == OWN_INFO ? nil : info.delete_prefix(OWN_PREFIX)
+        downstream.nil? || downstream.empty? ? LIB_NAME : "#{LIB_NAME}(#{downstream})".freeze
+      end
+    end
+
+    def connection_prelude
+      prelude = super
+      info = driver_info
+      return prelude unless LibIdentity.ours?(info)
+
+      # `CLIENT SETINFO` is last-write-wins, so appending after the commands `redis-client`
+      # already built overrides them, without having to recognise or remove them.
+      (prelude + LibIdentity.setinfo_commands(info)).freeze
+    end
+  end
+end
+
+# Prepended to the concrete config classes rather than to `RedisClient::Config::Common`, so that
+# the two `redis-client` entry points are covered without altering the shared module for anything
+# else that includes it. `RedisClient::SentinelConfig` is NOT a `RedisClient::Config` subclass, so
+# both lines are required. `RedisClient::Cluster::Node::Config` does subclass `RedisClient::Config`
+# and calls `super` in its own `connection_prelude`, so cluster nodes are covered by the first.
+RedisClient::Config.prepend(Redis::LibIdentity)
+RedisClient::SentinelConfig.prepend(Redis::LibIdentity)

--- a/test/redis/connection_handling_test.rb
+++ b/test/redis/connection_handling_test.rb
@@ -9,7 +9,11 @@ class TestConnectionHandling < Minitest::Test
 
   def test_id
     commands = {
-      client: ->(cmd, name) { @name = [cmd, name]; "+OK" },
+      # The prelude also issues CLIENT SETINFO, so only record the SETNAME call.
+      client: lambda do |subcommand, *args|
+        @name = [subcommand, *args] if subcommand.casecmp("SETNAME").zero?
+        "+OK"
+      end,
       ping: -> { "+PONG" }
     }
 

--- a/test/redis/internals_test.rb
+++ b/test/redis/internals_test.rb
@@ -229,6 +229,176 @@ class TestInternals < Minitest::Test
     Redis.new(OPTIONS.merge(timeout: 0))
   end
 
+  # `CLIENT INFO` replies as one space-separated line of `key=value` pairs. Parsing it into fields
+  # lets the assertions be exact: `assert_includes info, "lib-name=redis-rb"` would also accept
+  # `lib-name=redis-rb-5.4.1` or `lib-name=redis-rb()`. `CLIENT SETINFO` rejects values containing
+  # spaces, so splitting on space is safe.
+  def client_info_fields(client)
+    client.client(:info).split(" ").to_h { |field| field.split("=", 2) }
+  end
+
+  # The last `CLIENT SETINFO <attribute>` value in the prelude is the one the server ends up with.
+  def prelude_setinfo(config, attribute)
+    command = config.connection_prelude.reverse.find { |c| c[1] == "SETINFO" && c[2] == attribute }
+    command && command[3]
+  end
+
+  def test_lib_name_set_via_client_setinfo
+    target_version "7.2.0" do
+      fresh_client = _new_client
+      fresh_client.ping
+      fields = client_info_fields(fresh_client)
+
+      assert_equal "redis-rb", fields["lib-name"]
+      assert_equal Redis::VERSION, fields["lib-ver"]
+    end
+  end
+
+  def test_lib_name_includes_downstream_driver_info
+    target_version "7.2.0" do
+      fresh_client = _new_client(driver_info: "my-gem-1.0")
+      fresh_client.ping
+      fields = client_info_fields(fresh_client)
+
+      assert_equal "redis-rb(my-gem-1.0)", fields["lib-name"]
+      assert_equal Redis::VERSION, fields["lib-ver"]
+    end
+  end
+
+  def test_lib_name_reported_for_every_driver_info_shape
+    # The default case, and each shape `redis-client` accepts for `driver_info`. A downstream
+    # `driver_info:` must never be able to replace redis-rb's own identity, only extend it.
+    {
+      nil => "redis-rb",
+      "" => "redis-rb",
+      [] => "redis-rb",
+      # The officially recommended suffix format, `<name>_v<version>` with `;` between suffixes.
+      "my-gem_v1.0.0" => "redis-rb(my-gem_v1.0.0)",
+      ["my-gem_v1.0.0", "other_v2.0"] => "redis-rb(my-gem_v1.0.0;other_v2.0)",
+      # Free-form values are passed through: the format above is a recommendation, not enforced.
+      "my-gem-1.0" => "redis-rb(my-gem-1.0)",
+      # `CLIENT SETINFO` rejects bytes outside `!`..`~` and redis-client swallows the error, which
+      # would leave `lib-name` empty on the server. Parentheses would corrupt the `redis-rb(...)`
+      # delimiters. Both are sanitized so redis-rb stays identifiable no matter what a downstream
+      # library passes.
+      "my gem 1.0" => "redis-rb(my_gem_1.0)",
+      "sneaky)lib(1.0" => "redis-rb(sneaky_lib_1.0)",
+      ["my gem", "v 1.0"] => "redis-rb(my_gem;v_1.0)",
+      "\t \n" => "redis-rb",
+      # Underscores the caller actually passed survive; only invalid runs are dropped at the edges.
+      "_x_" => "redis-rb(_x_)",
+      "(x)" => "redis-rb(x)",
+      # Invalid bytes must not raise, whether in a binary string or an invalid UTF-8 one; they are
+      # scrubbed like any other invalid character.
+      "bad\xFFgem_v1.0" => "redis-rb(bad_gem_v1.0)",
+      "bad\xFFgem_v1.0".dup.force_encoding(Encoding::UTF_8) => "redis-rb(bad_gem_v1.0)",
+    }.each do |driver_info, expected|
+      config = Redis::Client.config(**(driver_info.nil? ? {} : { driver_info: driver_info }))
+
+      assert_equal expected, prelude_setinfo(config, "LIB-NAME"), "for driver_info: #{driver_info.inspect}"
+      assert_match(/\A[!-~]+\z/, prelude_setinfo(config, "LIB-NAME"), "for driver_info: #{driver_info.inspect}")
+      assert_equal Redis::VERSION, prelude_setinfo(config, "LIB-VER"), "for driver_info: #{driver_info.inspect}"
+    end
+  end
+
+  def test_lib_name_rejected_by_the_server_is_tolerated
+    # Redis < 7.2 has no CLIENT SETINFO; redis-client deliberately swallows exactly that error, so
+    # the connection must survive and stay usable. Simulated by a server erroring on CLIENT.
+    commands = {
+      hello: ->(*_) { "-ERR unknown command 'HELLO'" }, # also exercises the RESP3->RESP2 fallback
+      client: ->(*_) { "-ERR Unknown subcommand or wrong number of arguments for 'SETINFO'" },
+      ping: ->(*_) { "+PONG" },
+    }
+    RedisMock.start(commands) do |port|
+      redis = Redis.new(port: port, driver_info: "my-gem_v1.0.0", reconnect_attempts: 0)
+
+      assert_equal "PONG", redis.ping
+    ensure
+      redis&.close
+    end
+  end
+
+  def test_lib_name_rejects_invalid_driver_info_types
+    # Anything that is not nil/false/String/Array is passed through for redis-client to reject,
+    # matching its documented contract.
+    assert_raises(ArgumentError) do
+      Redis::Client.config(driver_info: :symbol).connection_prelude
+    end
+  end
+
+  def test_lib_name_marker_follows_the_official_suffix_convention
+    # The marker is what redis-client interpolates into its own (transient) pair,
+    # `lib-name=redis-client(redis-rb_v<version>)` — the identity the server keeps if the override
+    # ever fails to apply. The Redis docs recommend suffixes match
+    # `(?<custom-name>[ -~]+)[ -~]v(?<custom-version>[\d\.]+)`; see
+    # https://redis.io/docs/latest/commands/client-setinfo/
+    marker = Redis::LibIdentity.driver_info
+    match = /\A(?<custom_name>[ -~]+)[ -~]v(?<custom_version>[\d.]+)\z/.match(marker)
+
+    refute_nil match, "#{marker.inspect} does not follow the <name>_v<version> suffix convention"
+    assert_equal "redis-rb", match[:custom_name]
+    assert_equal Redis::VERSION, match[:custom_version]
+  end
+
+  def test_lib_name_can_be_disabled_with_driver_info_false
+    # The opt-out for peers that can't tolerate unknown commands in the handshake: `false` gates
+    # off both redis-rb's SETINFO pair and redis-client's own, restoring the pre-identification
+    # prelude (empty under RESP2 with no auth and db 0; just the handshake under RESP3).
+    config = Redis::Client.config(protocol: 2, driver_info: false)
+
+    assert_empty config.connection_prelude
+
+    resp3 = Redis::Client.config(driver_info: false)
+
+    assert_equal [["HELLO", "3"]], resp3.connection_prelude
+  end
+
+  def test_lib_name_reported_for_sentinel_clients
+    # `RedisClient::SentinelConfig` is not a `RedisClient::Config` subclass, so it needs its own
+    # prepend. Nothing else in the suite would notice if that were dropped.
+    refute_operator RedisClient::SentinelConfig, :<, RedisClient::Config
+
+    config = Redis::Client.sentinel(name: "mymaster", sentinels: [{ host: "127.0.0.1", port: 26_379 }])
+
+    assert_equal "redis-rb", prelude_setinfo(config, "LIB-NAME")
+    assert_equal Redis::VERSION, prelude_setinfo(config, "LIB-VER")
+
+    downstream = Redis::Client.sentinel(
+      name: "mymaster", sentinels: [{ host: "127.0.0.1", port: 26_379 }], driver_info: "my-gem-1.0"
+    )
+
+    assert_equal "redis-rb(my-gem-1.0)", prelude_setinfo(downstream, "LIB-NAME")
+
+    # The connections to the sentinel processes themselves (master resolution, failover polling)
+    # are plain RedisClient::Config objects carrying the same driver_info, so they identify too.
+    config.sentinels.each do |sentinel_config|
+      assert_equal "redis-rb", prelude_setinfo(sentinel_config, "LIB-NAME")
+    end
+  end
+
+  def test_lib_name_does_not_affect_plain_redis_client_configs
+    # Loading redis-rb must not change what applications using `redis-client` directly report.
+    plain = RedisClient.config(port: PORT)
+    refute(
+      plain.connection_prelude.any? { |c| c[0] == "CLIENT" && c[1] == "SETINFO" },
+      "a plain redis-client config must not issue CLIENT SETINFO"
+    )
+
+    # Including when their own `driver_info` happens to start with redis-rb's marker: recognising
+    # the marker by prefix alone would silently replace their identity with ours.
+    {
+      "other-gem-1.0" => "redis-client(other-gem-1.0)",
+      "redis-rb-extras-1.0" => "redis-client(redis-rb-extras-1.0)",
+      "redis-rb_viewer-1.0" => "redis-client(redis-rb_viewer-1.0)",
+      "redis-rb_v#{Redis::VERSION}-fork" => "redis-client(redis-rb_v#{Redis::VERSION}-fork)",
+    }.each do |driver_info, expected|
+      config = RedisClient.config(port: PORT, driver_info: driver_info)
+
+      assert_equal expected, prelude_setinfo(config, "LIB-NAME"), "for driver_info: #{driver_info.inspect}"
+      assert_equal RedisClient::VERSION, prelude_setinfo(config, "LIB-VER"), "for driver_info: #{driver_info.inspect}"
+    end
+  end
+
   def test_time
     # Test that the difference between the time that Ruby reports and the time
     # that Redis reports is minimal (prevents the test from being racy).
@@ -344,14 +514,21 @@ class TestInternals < Minitest::Test
       end
     end
 
+    # Consume and ack the whole connection prelude before deciding whether to go silent, so that
+    # the simulated failure lands on the payload write rather than while connecting. The prelude
+    # shape depends on the protocol (RESP2 opens with SELECT, RESP3 with HELLO) and on
+    # CLIENT SETINFO, so derive its length from a config built the same way as the mock's client.
+    # redis-client accepts any non-error reply to these.
+    prelude_size = Redis::Client.config(**OPTIONS, protocol: PROTOCOL).connection_prelude.size
+
     handler = lambda do |session|
       n = @n
       @n += 1
 
-      # Consume and ack the first connection-prelude command. Under RESP2 this is SELECT; under
-      # RESP3 the prelude begins with HELLO (redis-client accepts any non-error reply to it).
-      read_command.call(session)
-      session.write("+OK\r\n")
+      prelude_size.times do
+        read_command.call(session)
+        session.write("+OK\r\n")
+      end
       unless seq.include?(n)
         session.write("+#{n}\r\n") while read_command.call(session)
       end


### PR DESCRIPTION
### What

redis-rb now identifies itself on every connection. `CLIENT LIST` / `CLIENT INFO` report:

```
lib-name=redis-rb lib-ver=5.4.1
```

Previously no identity was reported at all (the released client sends an empty prelude under RESP2 and only `HELLO 3` under RESP3).

Libraries built on top of redis-rb can extend the name per the [official suffix convention](https://redis.io/docs/latest/commands/client-setinfo/): `Redis.new(driver_info: "my-gem_v1.0.0")` → `lib-name=redis-rb(my-gem_v1.0.0)`. Arrays join with `;`; invalid characters (spaces, non-printables, parens) are sanitized so identification can't be silently rejected by the server; `driver_info: false` disables identification entirely.

Covers standalone, sentinel (incl. sentinel-monitor connections) and cluster (every node, via the `redis-clustering` gem), RESP3 + RESP2, both drivers. Identity survives reconnects (lives in the connection prelude). Servers < 7.2 reject `CLIENT SETINFO`; the error is ignored.

### How

`Redis::LibIdentity` (new) is prepended onto `RedisClient::Config` and `RedisClient::SentinelConfig`; it wraps `#connection_prelude` and appends a `LIB-NAME`/`LIB-VER` pair after redis-client's own — `SETINFO` is last-write-wins, so no parsing or stripping of redis-client's commands, and no changes to redis-client or redis-cluster-client. A `redis-rb_v<version>` marker passed as `driver_info:` gates the override, so applications using redis-client directly keep their own identity (including lookalike `driver_info` values).

### Trade-offs

- The prelude carries redis-client's pair plus ours (4 `SETINFO` commands, overwritten server-side; zero extra round trips).
- Under RESP2 with no password/db/id the handshake previously sent nothing; `driver_info: false` restores that for intolerant proxies.
- redis-client's own version is no longer visible server-side (`lib-ver` is redis-rb's).
- This couples to redis-client's `connection_prelude` (see the gemspec pin rationale); the long-term exit is upstreaming `lib_name:`/`lib_ver:` options.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Handshake-only change with ignored errors on Redis < 7.2 and an opt-out; no command or data-path behavior changes beyond extra prelude commands.
> 
> **Overview**
> Connections now send **`CLIENT SETINFO`** on connect so **`CLIENT LIST` / `CLIENT INFO`** show `lib-name=redis-rb` and `lib-ver=<Redis::VERSION>` instead of no library identity.
> 
> **`Redis::LibIdentity`** prepends onto `RedisClient::Config` and `SentinelConfig`, appends its own `LIB-NAME`/`LIB-VER` after redis-client’s prelude commands (last-write-wins), and only overrides when `driver_info` was built by redis-rb so direct **redis-client** users are unchanged. **`driver_info:`** extends the reported name (string, array joined with `;`, sanitized); **`driver_info: false`** disables all SETINFO. Wired through **`Redis::Client.config` / `.sentinel`** and **`Redis::Cluster#initialize_client`**.
> 
> README and changelogs document the feature; tests cover prelude shapes, sentinel/cluster, old servers, and mocks that account for the longer connection prelude.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d869219423054262c1c431185248c4bf7d4a4f77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->