### PR TITLE
Updated client options with missing himport_auto_prepare option

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,10 +371,10 @@ disconnect or `RESET`. A `himport_set` on a connection without the fieldset
 fails with `ERR no such fieldset`.
 
 Because a `Redis` instance transparently replaces a dead connection (see
-[Reconnections](#reconnections)), the client keeps the last schema prepared for
-each fieldset name and, when a `himport_set` reports the fieldset is gone,
-re-prepares it and retries the command once. Explicitly discarded fieldsets are
-never restored. To keep the fieldset lifecycle fully explicit instead, disable
+[Reconnections](#reconnections)), the client keeps all fieldset schemas
+and, when a `himport_set` reports the fieldset is gone, re-prepares it 
+and retries the command once. Explicitly discarded fieldsets are never 
+restored. To keep the fieldset lifecycle fully explicit instead, disable
 the recovery:
 
 ```ruby

--- a/cluster/lib/redis/cluster.rb
+++ b/cluster/lib/redis/cluster.rb
@@ -70,8 +70,8 @@ class Redis
     # @option options [Boolean] :himport_auto_prepare (true) Whether to automatically repair a lost
     #   `HIMPORT` fieldset (re-fan out the last prepared schema to all masters and retry the
     #   `himport_set` once) when a node reports it was lost (failover, topology reload, redirection).
-    #   When `false`, the error is raised to the caller; prepared schemas are still recorded for
-    #   manual recovery.
+    #   When `false`, the error is raised to the caller, who is responsible for retaining the schema
+    #   and calling `himport_prepare` again.
     #
     # @return [Redis::Cluster] a new client instance
     def initialize(*)

--- a/cluster/lib/redis/cluster.rb
+++ b/cluster/lib/redis/cluster.rb
@@ -67,6 +67,11 @@ class Redis
     #   `redis-rb` reports to every node via `CLIENT SETINFO`, shown as `lib-name=redis-rb(<driver_info>)`
     #   in `CLIENT LIST`. The recommended format is `<name>_v<version>`; an Array is joined with `;`.
     #   Pass `false` to disable client identification entirely.
+    # @option options [Boolean] :himport_auto_prepare (true) Whether to automatically repair a lost
+    #   `HIMPORT` fieldset (re-fan out the last prepared schema to all masters and retry the
+    #   `himport_set` once) when a node reports it was lost (failover, topology reload, redirection).
+    #   When `false`, the error is raised to the caller; prepared schemas are still recorded for
+    #   manual recovery.
     #
     # @return [Redis::Cluster] a new client instance
     def initialize(*)

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -64,6 +64,11 @@ class Redis
   # @option options [Integer, Array<Integer, Float>] :reconnect_attempts Number of attempts trying to connect,
   #   or a list of sleep duration between attempts.
   # @option options [Boolean] :inherit_socket (false) Whether to use socket in forked process or not
+  # @option options [Boolean] :himport_auto_prepare (true) Whether to automatically re-prepare a
+  #   `HIMPORT` fieldset and retry the `himport_set` once when the server reports the fieldset was
+  #   lost (reconnect, failover, `RESET`). When `false`, the error is raised to the caller; prepared
+  #   schemas are still recorded for manual recovery. See the README "Bulk hash ingestion (HIMPORT)"
+  #   section.
   # @option options [String] :name The name of the server group to connect to.
   # @option options [Array] :sentinels List of sentinels to contact
   #

--- a/lib/redis.rb
+++ b/lib/redis.rb
@@ -66,9 +66,9 @@ class Redis
   # @option options [Boolean] :inherit_socket (false) Whether to use socket in forked process or not
   # @option options [Boolean] :himport_auto_prepare (true) Whether to automatically re-prepare a
   #   `HIMPORT` fieldset and retry the `himport_set` once when the server reports the fieldset was
-  #   lost (reconnect, failover, `RESET`). When `false`, the error is raised to the caller; prepared
-  #   schemas are still recorded for manual recovery. See the README "Bulk hash ingestion (HIMPORT)"
-  #   section.
+  #   lost (reconnect, failover, `RESET`). When `false`, the error is raised to the caller, who is
+  #   responsible for retaining the schema and calling `himport_prepare` again. See the README
+  #   "Bulk hash ingestion (HIMPORT)" section.
   # @option options [String] :name The name of the server group to connect to.
   # @option options [Array] :sentinels List of sentinels to contact
   #
@@ -165,7 +165,9 @@ class Redis
   # session was lost. These overrides remember the last schema prepared per fieldset name and,
   # on that error, re-prepare it and retry the SET exactly once. An explicitly discarded
   # fieldset is removed from the registry and is never resurrected. Disable the recovery with
-  # `Redis.new(himport_auto_prepare: false)`; the registry is still recorded for manual use.
+  # `Redis.new(himport_auto_prepare: false)`: the loss error then propagates, and re-preparing is
+  # the caller's responsibility — the registry is internal state with no public reader, so callers
+  # must retain their schemas themselves.
 
   # Each method holds @monitor across the server command AND its registry mutation: the two must
   # be atomic with respect to other threads, otherwise a himport_set failing between another


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and comment-only changes; no runtime behavior modified.
> 
> **Overview**
> Documents the existing **`himport_auto_prepare`** option on **`Redis.new`** and **`Redis::Cluster.new`** via YARD `@option` comments, describing automatic fieldset re-prepare/retry on loss versus raising when set to **`false`**.
> 
> The **README** HIMPORT section is lightly reworded (client keeps **all** fieldset schemas). **`lib/redis.rb`** comments now spell out that with auto-prepare off, callers must keep schemas themselves because the internal registry has no public API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca1cc0dd4ff1be5dbdf3dfc3e9e662c3edbfa01b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->