### PR TITLE
Added support for Array commands + Updated agent specs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,13 +38,16 @@ To run a single test file or method, use Minitest's options via `TESTOPTS`:
 
 ```sh
 bundle exec rake test:redis TEST=test/redis/commands_on_strings_test.rb
-bundle exec rake test:cluster TEST=cluster/test/commands_on_strings_test.rb TESTOPTS="--name=/get/"
+BUNDLE_GEMFILE=cluster/Gemfile bundle exec rake test:cluster TEST=cluster/test/commands_on_strings_test.rb TESTOPTS="--name=/get/"
 ```
+
+The cluster group needs `BUNDLE_GEMFILE=cluster/Gemfile` (the root bundle doesn't include `redis-cluster-client`); CI does the same.
 
 Other useful knobs:
 
 - `REDIS_VERSION=8.X.Y make start_all` — pin the image tag (default is set at the top of `makefile`). Tags are published per Redis minor.patch (e.g. `8.0.6`, `8.2.6`, `8.4.3`, `8.6.3`, `8.8.0`); a bare `8.4` tag generally does not exist.
 - `DRIVER=hiredis bundle exec rake test` — run the suite against the `hiredis-client` C-extension driver instead of the pure-Ruby parser (see `test/helper.rb`).
+- `PROTOCOL=2 bundle exec rake test` — run the suite over RESP2 instead of the default RESP3 (`test/helper.rb:11`). Reply-reshaping changes should be verified under both protocols (and ideally both drivers).
 - `REDIS_SOCKET_PATH=...` — override the Unix socket location. The default expects `tmp/redis.sock`, which the standalone container bind-mounts from `./tmp:/sockets`; `test/helper.rb` aborts if it's missing.
 - `bundle exec rubocop` — lint. The Rubocop config is in `.rubocop.yml` (root) and `cluster/.rubocop.yml`.
 - `bin/console` — IRB session with `redis` preloaded.
@@ -69,9 +72,9 @@ The compose stack uses `network_mode: host` so sentinel and cluster nodes report
 ### Layering
 
 ```
-Redis (lib/redis.rb)                ergonomics: keyword DSL, RESP2 reshape, error translation,
-   ├ Commands (lib/redis/commands)  pub/sub second-socket, pipelined/multi wrappers
-   ├ Monitor (lock)
+Redis (lib/redis.rb)                ergonomics: keyword DSL, reply reshaping, error translation,
+   ├ Commands (lib/redis/commands)  pub/sub second-socket, pipelined/multi wrappers,
+   ├ Monitor (lock)                 RESP3→RESP2 fallback, HIMPORT fieldset registry
    └ @client : Redis::Client < RedisClient
                                     ↓
               redis-client gem (external, vendored as runtime dep)
@@ -82,14 +85,14 @@ Redis (lib/redis.rb)                ergonomics: keyword DSL, RESP2 reshape, erro
 The `Redis` class is the public surface. It delegates all network I/O to `Redis::Client`, which inherits from `RedisClient` (in the `redis-client` gem) and only adds:
 
 1. Error translation: maps `RedisClient::*` exceptions to `Redis::*` via `ERROR_MAPPING` in `lib/redis/client.rb`. Every public method on `Redis::Client` is wrapped in a rescue that calls `Client.translate_error!`.
-2. A hard pin of `protocol: 2` in `lib/redis/client.rb`. RESP3 is intentionally not supported at this layer (see "RESP2 invariant" below).
+2. A default of `protocol: 3` (RESP3) in `lib/redis/client.rb`; callers can pass `protocol: 2`. Servers without RESP3 (Redis < 6.0, or anything replying `NOPROTO`) are detected on connect and `Redis#with_protocol_fallback` (`lib/redis.rb`) transparently rebuilds `@client` for RESP2 — every `@client` access funnels through `Redis#synchronize`, which is what applies the fallback, so pipelines/multi/watch fall back too. Return values are protocol-invariant except GEO coordinates (`Float` under RESP3).
 3. Trivial config delegators (`#host`, `#port`, `#db`, …).
 
 The full command execution flow is: `Redis#some_command` (defined in `lib/redis/commands/<category>.rb`) builds an array → `Redis#send_command` grabs `@monitor` → `Redis::Client#call_v` rescues + re-raises → `RedisClient#call_v` serializes RESP and reads the reply → optional reshape lambda runs → result returned.
 
 ### Commands as a module composition
 
-Every Redis command category is a module under `lib/redis/commands/` (strings, lists, hashes, sets, sorted_sets, streams, scripting, transactions, pubsub, etc.). They are all `include`d into a parent `Redis::Commands` module (`lib/redis/commands.rb`), which is in turn mixed into:
+Every Redis command category is a module under `lib/redis/commands/` (strings, lists, hashes, sets, sorted_sets, streams, arrays, scripting, transactions, pubsub, etc.). Module-provided command families live under `lib/redis/commands/modules/` (`json.rb` for `JSON.*`, `search.rb` + `search/` for the Query Engine `FT.*`, whose replies reshape into `Search::SearchResult`/`Search::AggregateResult` objects). They are all `include`d into a parent `Redis::Commands` module (`lib/redis/commands.rb`), which is in turn mixed into:
 
 - `Redis` (`lib/redis.rb`)
 - `Redis::PipelinedConnection` (`lib/redis/pipeline.rb`) — used inside `pipelined` and `multi` blocks
@@ -99,9 +102,9 @@ This is the **single most important pattern in the codebase**. To add a new comm
 
 There is also a catch-all `method_missing` in `lib/redis/commands.rb` that forwards any unknown method as a Redis command — so unwrapped commands "just work."
 
-### Reply reshaping (RESP2 invariant)
+### Reply reshaping (protocol-aware)
 
-The top of `lib/redis/commands.rb` defines a family of lambdas — `Boolify`, `BoolifySet`, `Hashify`, `Floatify`, `FloatifyPairs`, `HashifyInfo`, `HashifyStreamEntries`, `HashifyClusterNodes`, … — that reshape flat RESP2 replies into idiomatic Ruby (Hash, Float, boolean, etc.). They are passed as blocks to `send_command`:
+The top of `lib/redis/commands.rb` defines a family of lambdas — `Boolify`, `BoolifySet`, `Hashify`, `Floatify`, `FloatifyPairs`, `HashifyInfo`, `HashifyStreamEntries`, `HashifyClusterNodes`, … — that reshape raw replies into idiomatic Ruby (Hash, Float, boolean, etc.). They are passed as blocks to `send_command`:
 
 ```ruby
 def incrbyfloat(key, increment)
@@ -109,9 +112,9 @@ def incrbyfloat(key, increment)
 end
 ```
 
-These lambdas **assume RESP2-shaped replies** — flat arrays the lambda slices into hashes, integer 0/1 it turns into booleans, etc. This is why `Redis::Client.config` hard-codes `protocol: 2`: under RESP3 the server already returns native maps/booleans/doubles and the lambdas would either double-process or break. If you're tempted to enable RESP3, the realistic path is to drop down to `RedisClient` directly rather than touch this layer.
+Since 6.0 the client negotiates RESP3 by default, so these lambdas are **protocol-aware**: they must accept both the RESP2 wire shape (flat arrays, string-encoded numbers) and the RESP3 one (native maps, doubles, pairs) and converge on the same Ruby value. The pattern is "detect the already-final shape and pass it through" — e.g. `Hashify` returns a `Hash` unchanged and `each_slice(2).to_h`'s a flat array; `FloatifyPairs` skips re-mapping when the reply is already `[[member, Float], ...]`. When adding or changing a lambda, keep both branches, and test the command under both protocols (`PROTOCOL=2` / `PROTOCOL=3`, see below).
 
-When adding a command that needs reply transformation, write or reuse one of these lambdas; do not coerce in the command method itself.
+When adding a command that needs reply transformation, write or reuse one of these lambdas; do not coerce in the command method itself. See `specs/adding-commands.md` for the full catalog and the end-to-end checklist (the `add-new-command` skill automates this flow from a spec file).
 
 ### Connection lifecycle (long-lived, lazy, fork-safe)
 
@@ -128,6 +131,14 @@ When adding a command that needs reply transformation, write or reuse one of the
 
 `pipelined` and `multi` both yield a `Redis::PipelinedConnection` (or `MultiConnection`) that re-includes `Commands` (`lib/redis/pipeline.rb`). Each command inside the block returns a `Redis::Future` that resolves when the batch flushes. `MultiFuture` (in `lib/redis/pipeline.rb`) splits the `EXEC` reply array back across individual command futures. Inside a `MULTI`, blocking commands degrade to non-blocking — that's intentional, matching Redis server semantics.
 
+### HIMPORT — server session state with client-side recovery (experimental)
+
+The `HIMPORT` command family (Redis 8.10) is the one place a command's state outlives a single call: fieldsets are **per-connection server session state**, destroyed by reconnect/failover/`RESET`. `Redis#initialize` keeps a registry of prepared schemas (`@himport_fieldsets`) and the `himport_*` overrides in `lib/redis.rb` repair a lost fieldset reactively — on the server's "no such fieldset" error, re-prepare from the registry and retry the SET exactly once. Recovery is per-fieldset and lazy (there is no reconnect hook); disable with `himport_auto_prepare: false`, in which case re-preparing is the caller's responsibility (the registry has no public reader). The overrides hold `@monitor` across command + registry mutation — don't split them. The cluster subclass adds reply aggregation on top (prepare/discard fan out to all masters).
+
+### Client identification (CLIENT SETINFO)
+
+`Redis::LibIdentity` (`lib/redis/lib_identity.rb`) reports `lib-name=redis-rb lib-ver=<version>` on every connection by **prepending onto `RedisClient::Config` / `RedisClient::SentinelConfig`** and appending a second `SETINFO` pair to the connection prelude (last-write-wins overrides redis-client's own pair; zero extra round trips). The override is gated by a `redis-rb_v<version>` marker in `driver_info`, so applications using redis-client directly are untouched. Downstream gems extend the name via `Redis.new(driver_info: "my-gem_v1.0.0")`; `driver_info: false` disables identification. This couples to redis-client's `connection_prelude` — one of the reasons the gemspec pins redis-client to an exact version; re-audit on every driver bump.
+
 ### Cluster gem differences
 
 `cluster/lib/redis/cluster.rb` defines `Redis::Cluster < ::Redis`, so it inherits the full `Commands` surface but swaps `initialize_client` to build a `RedisClient::Cluster` via the `redis-cluster-client` gem. Cluster-specific differences worth knowing:
@@ -143,7 +154,7 @@ When adding a command that needs reply transformation, write or reuse one of the
 
 It is **separately maintained** from `Commands` — `Redis::Distributed` does *not* include the `Commands` mixin; every method is explicitly defined in `distributed.rb` so it can route to the right node via `node_for(key)`. When adding a new Redis command that should be available here, add a corresponding method to `lib/redis/distributed.rb` and a test under `test/distributed/`. The `test:distributed` Rake task runs as part of the default suite, so missing or broken Distributed implementations will fail CI.
 
-It is supported (recent commits add JSON, HEXPIRE/HPTTL, HSCAN, etc.) and not deprecated. For new applications needing horizontal scaling, `Redis::Cluster` is generally the better choice because the server enforces consistency; `Redis::Distributed` is the right tool when you have N independent standalone Redises and want memcache-style key distribution.
+It is supported (recent commits add JSON, arrays (`AR*`), HEXPIRE/HPTTL, HSCAN, etc.) and not deprecated. For new applications needing horizontal scaling, `Redis::Cluster` is generally the better choice because the server enforces consistency; `Redis::Distributed` is the right tool when you have N independent standalone Redises and want memcache-style key distribution.
 
 ## Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,8 @@ end
 
 Since 6.0 the client negotiates RESP3 by default, so these lambdas are **protocol-aware**: they must accept both the RESP2 wire shape (flat arrays, string-encoded numbers) and the RESP3 one (native maps, doubles, pairs) and converge on the same Ruby value. The pattern is "detect the already-final shape and pass it through" — e.g. `Hashify` returns a `Hash` unchanged and `each_slice(2).to_h`'s a flat array; `FloatifyPairs` skips re-mapping when the reply is already `[[member, Float], ...]`. When adding or changing a lambda, keep both branches, and test the command under both protocols (`PROTOCOL=2` / `PROTOCOL=3`, see below).
 
+`Boolify` is the exception: it assumes an integer reply (`value != 0 unless value.nil?`) and would invert a native RESP3 boolean — `Boolify.call(false)` returns `true`. That's unreachable for commands that reply with integers under both protocols (the case for all current uses), but confirm the command's `reply_schema` says `"type": "integer"` before reaching for it.
+
 When adding a command that needs reply transformation, write or reuse one of these lambdas; do not coerce in the command method itself. See `specs/adding-commands.md` for the full catalog and the end-to-end checklist (the `add-new-command` skill automates this flow from a spec file).
 
 ### Connection lifecycle (long-lived, lazy, fork-safe)

--- a/cluster/test/commands_on_arrays_test.rb
+++ b/cluster/test/commands_on_arrays_test.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestClusterCommandsOnArrays < Minitest::Test
+  include Helper::Cluster
+  include Lint::Arrays
+end

--- a/lib/redis/commands.rb
+++ b/lib/redis/commands.rb
@@ -110,6 +110,18 @@ class Redis
       end
     }
 
+    # ARINFO: the avg-* slice statistics arrive as native doubles under RESP3
+    # but as bulk strings under RESP2; floatify them after hashifying so both
+    # protocols return the same Ruby types.
+    HashifyArrayInfo = lambda { |value|
+      reply = Hashify.call(value)
+      return reply unless reply.is_a?(Hash)
+
+      reply.each do |field, field_value|
+        reply[field] = Floatify.call(field_value) if field.start_with?("avg-")
+      end
+    }
+
     HashifyInfo = lambda { |reply|
       lines = reply.split("\r\n").grep_v(/^(#|$)/)
       lines.map! { |line| line.split(':', 2) }

--- a/lib/redis/commands.rb
+++ b/lib/redis/commands.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "redis/commands/arrays"
 require "redis/commands/bitmaps"
 require "redis/commands/cluster"
 require "redis/commands/connection"
@@ -21,6 +22,7 @@ require "redis/commands/transactions"
 
 class Redis
   module Commands
+    include Arrays
     include Bitmaps
     include Cluster
     include Connection

--- a/lib/redis/commands/arrays.rb
+++ b/lib/redis/commands/arrays.rb
@@ -327,13 +327,14 @@ class Redis
       #
       # @param [String] key
       # @param [Boolean] full include per-slice statistics
-      # @return [Hash{String => Integer}] metadata fields such as `count`,
-      #   `len`, `next-insert-index` and `slices`
+      # @return [Hash{String => Integer, Float}] metadata fields such as
+      #   `count`, `len`, `next-insert-index` and `slices`; with `full:` the
+      #   `avg-*` slice statistics are returned as `Float`
       # @raise [Redis::CommandError] when the key does not exist
       def arinfo(key, full: false)
         args = [:arinfo, key]
         args << "FULL" if full
-        send_command(args, &Hashify)
+        send_command(args, &HashifyArrayInfo)
       end
 
       private

--- a/lib/redis/commands/arrays.rb
+++ b/lib/redis/commands/arrays.rb
@@ -1,0 +1,331 @@
+# frozen_string_literal: true
+
+class Redis
+  module Commands
+    module Arrays
+      # Set one or more contiguous values starting at an index in an array.
+      #
+      # When multiple values are given they are stored at consecutive indices
+      # beginning at `index`. Writing past the current end of the array
+      # extends it; slots that are skipped over stay empty. Only non-negative
+      # indices are valid.
+      #
+      # @example Set two values at the head of the array
+      #   redis.arset("foo", 0, "a", "b")
+      #     # => 2
+      # @example Overwrite an existing slot (no new slot is filled)
+      #   redis.arset("foo", 1, "B")
+      #     # => 0
+      #
+      # @param [String] key
+      # @param [Integer] index zero-based index at which to start writing
+      # @param [String] values one or more values stored at consecutive
+      #   indices beginning at `index`
+      # @return [Integer] the number of previously empty slots that were set
+      def arset(key, index, *values)
+        send_command([:arset, key, Integer(index), *values])
+      end
+
+      # Get the value at an index in an array.
+      #
+      # @example
+      #   redis.arget("foo", 0)
+      #     # => "a"
+      # @example A missing key, an empty slot or an index past the end
+      #   redis.arget("foo", 99)
+      #     # => nil
+      #
+      # @param [String] key
+      # @param [Integer] index zero-based index of the element to retrieve
+      # @return [String, nil] the value at the given index, or `nil` if the
+      #   key does not exist or the index holds no value
+      def arget(key, index)
+        send_command([:arget, key, Integer(index)])
+      end
+
+      # Set multiple index-value pairs in an array.
+      #
+      # Pairs may be non-contiguous and given in any order, as a flat list or
+      # a Hash.
+      #
+      # @example With a flat list of pairs
+      #   redis.armset("foo", 0, "a", 5, "f")
+      #     # => 2
+      # @example With a Hash
+      #   redis.armset("foo", { 0 => "a", 5 => "f" })
+      #     # => 2
+      #
+      # @param [String] key
+      # @param [Array<Integer, String>, Hash{Integer => String}] pairs index-value pairs
+      # @return [Integer] the number of previously empty slots that were set
+      def armset(key, *pairs)
+        pairs = pairs.first.flatten if pairs.size == 1 && pairs.first.is_a?(Hash)
+        raise ArgumentError, "wrong number of arguments" if pairs.empty? || pairs.size.odd?
+
+        args = pairs.each_slice(2).flat_map { |index, value| [Integer(index), value] }
+        send_command([:armset, key, *args])
+      end
+
+      # Get values at multiple indices in an array.
+      #
+      # The reply preserves the order of the requested indices and contains
+      # `nil` for any index that is not set.
+      #
+      # @example
+      #   redis.armget("foo", 0, 1, 9)
+      #     # => ["a", "b", nil]
+      #
+      # @param [String] key
+      # @param [Integer] indices one or more zero-based indices
+      # @return [Array<String, nil>] the values at the requested indices
+      def armget(key, *indices)
+        indices = indices.flatten(1).map { |index| Integer(index) }
+        send_command([:armget, key, *indices])
+      end
+
+      # Get values in a range of indices.
+      #
+      # Empty slots inside the range are returned as `nil`. When `start` is
+      # greater than `stop`, elements are returned in reverse index order.
+      #
+      # @example
+      #   redis.argetrange("foo", 0, 2)
+      #     # => ["a", nil, "c"]
+      # @example Reverse order
+      #   redis.argetrange("foo", 2, 0)
+      #     # => ["c", nil, "a"]
+      #
+      # @param [String] key
+      # @param [Integer] start zero-based index of the first element (inclusive)
+      # @param [Integer] stop zero-based index of the last element (inclusive)
+      # @return [Array<String, nil>] the values in traversal order
+      def argetrange(key, start, stop)
+        send_command([:argetrange, key, Integer(start), Integer(stop)])
+      end
+
+      # Get the length of an array (max index + 1).
+      #
+      # @param [String] key
+      # @return [Integer] the array length, or 0 if the key does not exist
+      def arlen(key)
+        send_command([:arlen, key])
+      end
+
+      # Get the number of non-empty elements in an array.
+      #
+      # @param [String] key
+      # @return [Integer] the number of set elements, or 0 if the key does not exist
+      def arcount(key)
+        send_command([:arcount, key])
+      end
+
+      # Delete elements at the specified indices in an array.
+      #
+      # Deleting an index that is not set counts as zero elements deleted and
+      # does not modify the array.
+      #
+      # @param [String] key
+      # @param [Integer] indices one or more zero-based indices to delete
+      # @return [Integer] the number of elements deleted
+      def ardel(key, *indices)
+        indices = indices.flatten(1).map { |index| Integer(index) }
+        send_command([:ardel, key, *indices])
+      end
+
+      # Delete elements in one or more inclusive index ranges.
+      #
+      # Ranges may overlap; each element is counted at most once. A range
+      # given with `start > stop` is processed in ascending order regardless.
+      #
+      # @example Delete two ranges
+      #   redis.ardelrange("foo", 0, 2, 5, 7)
+      #     # => 6
+      # @example Ranges as pairs
+      #   redis.ardelrange("foo", [0, 2], [5, 7])
+      #     # => 6
+      #
+      # @param [String] key
+      # @param [Array<Integer>] ranges one or more start/stop pairs
+      # @return [Integer] the number of elements deleted
+      def ardelrange(key, *ranges)
+        ranges = ranges.flatten(1).map { |index| Integer(index) }
+        raise ArgumentError, "ranges must be given as start/stop pairs" if ranges.empty? || ranges.size.odd?
+
+        send_command([:ardelrange, key, *ranges])
+      end
+
+      # Insert one or more values at consecutive indices, beginning at the
+      # array's insert cursor. The cursor advances by one for each value.
+      #
+      # @see #arnext inspect the current cursor position
+      # @see #arseek reposition the cursor
+      #
+      # @param [String] key
+      # @param [String] values one or more values to insert
+      # @return [Integer] the last index where a value was inserted
+      def arinsert(key, *values)
+        send_command([:arinsert, key, *values])
+      end
+
+      # Set the insert cursor of an array to a specific index.
+      #
+      # @param [String] key
+      # @param [Integer] index zero-based index for the new cursor position
+      # @return [Boolean] whether the cursor was set (`false` if the key does not exist)
+      def arseek(key, index)
+        send_command([:arseek, key, Integer(index)], &Boolify)
+      end
+
+      # Get the next index {#arinsert} would use.
+      #
+      # @param [String] key
+      # @return [Integer, nil] the next insert index (0 for missing keys or
+      #   before any insert), or `nil` when the insertion cursor is exhausted
+      def arnext(key)
+        send_command([:arnext, key])
+      end
+
+      # Get the most recently inserted elements.
+      #
+      # @param [String] key
+      # @param [Integer] count maximum number of elements to return; if the
+      #   array holds fewer elements, all of them are returned
+      # @param [Boolean] rev return elements most recent first instead of the
+      #   default oldest-first order
+      # @return [Array<String>] the most recently inserted elements
+      def arlastitems(key, count, rev: false)
+        args = [:arlastitems, key, Integer(count)]
+        args << "REV" if rev
+        send_command(args)
+      end
+
+      # Insert one or more values into an array used as a fixed-size ring
+      # buffer. Each value is placed at the next position in the ring and the
+      # cursor advances, wrapping around to index 0 once the ring is full.
+      #
+      # @param [String] key
+      # @param [Integer] size the size of the ring buffer window
+      # @param [String] values one or more values to insert
+      # @return [Integer] the last index where a value was inserted
+      def arring(key, size, *values)
+        send_command([:arring, key, Integer(size), *values])
+      end
+
+      # Iterate existing elements in an index range.
+      #
+      # Empty slots are excluded. When `start` is greater than `stop` the
+      # iteration is reversed.
+      #
+      # @example
+      #   redis.arscan("foo", 0, 9)
+      #     # => [[0, "a"], [3, "d"]]
+      #
+      # @param [String] key
+      # @param [Integer] start zero-based start index (inclusive)
+      # @param [Integer] stop zero-based end index (inclusive)
+      # @param [Integer] limit cap on the number of elements returned;
+      #   all populated elements in range are returned when omitted
+      # @return [Array<Array(Integer, String)>] `[index, value]` pairs in
+      #   traversal order; empty when the key does not exist
+      def arscan(key, start, stop, limit: nil)
+        args = [:arscan, key, Integer(start), Integer(stop)]
+        args << "LIMIT" << Integer(limit) if limit
+        send_command(args)
+      end
+
+      # Search array elements within an inclusive index range using one or
+      # more textual predicates. Empty slots are skipped.
+      #
+      # Each predicate keyword accepts a single value or an array of values;
+      # multiple predicates are combined with `logic:` (`:or` by default).
+      #
+      # @example Substring search
+      #   redis.argrep("foo", 0, 9, match: "an")
+      #     # => [1, 2]
+      # @example Combined predicates with values
+      #   redis.argrep("foo", 0, 9, glob: "a*", exact: "cherry", logic: :or, with_values: true)
+      #     # => [[0, "apple"], [2, "cherry"]]
+      #
+      # @param [String] key
+      # @param [Integer] start zero-based start index (inclusive); iteration
+      #   is reversed when greater than `stop`
+      # @param [Integer] stop zero-based end index (inclusive)
+      # @param [String, Array<String>] exact match by exact equality
+      # @param [String, Array<String>] match match by substring
+      # @param [String, Array<String>] glob match by glob-style pattern (`*`, `?`, `[...]`)
+      # @param [String, Array<String>] re match by regular expression
+      # @param [Symbol] logic `:and` or `:or` — how multiple predicates combine (server default is OR)
+      # @param [Integer] limit stop after this many matches
+      # @param [Boolean] with_values return `[index, value]` pairs instead of indices
+      # @param [Boolean] nocase case-insensitive comparison for all predicates
+      # @return [Array<Integer>, Array<Array(Integer, String)>] matching
+      #   indices in traversal order, or `[index, value]` pairs with `with_values`
+      def argrep(key, start, stop, exact: nil, match: nil, glob: nil, re: nil,
+                 logic: nil, limit: nil, with_values: nil, nocase: nil)
+        args = [:argrep, key, Integer(start), Integer(stop)]
+        { "EXACT" => exact, "MATCH" => match, "GLOB" => glob, "RE" => re }.each do |predicate, values|
+          Array(values).each { |value| args << predicate << value }
+        end
+        if logic
+          operator = logic.to_s.upcase
+          raise ArgumentError, "logic must be :and or :or" unless %w[AND OR].include?(operator)
+
+          args << operator
+        end
+        args << "LIMIT" << Integer(limit) if limit
+        args << "WITHVALUES" if with_values
+        args << "NOCASE" if nocase
+        send_command(args)
+      end
+
+      # Perform an aggregate operation on the non-empty elements in a range.
+      #
+      # Supported operations: `:sum`, `:min`, `:max` (numeric, returned as
+      # Float), `:and`, `:or`, `:xor` (bitwise, floats truncated toward
+      # zero), `:match` (count of elements equal to `value`) and `:used`
+      # (count of non-empty elements).
+      #
+      # @example
+      #   redis.arop("foo", 0, 9, :sum)
+      #     # => 6.0
+      # @example Count elements equal to a value
+      #   redis.arop("foo", 0, 9, :match, value: "2")
+      #     # => 1
+      #
+      # @param [String] key
+      # @param [Integer] start zero-based index of the first element (inclusive);
+      #   the range is always scanned from the lower to the higher index
+      # @param [Integer] stop zero-based index of the last element (inclusive)
+      # @param [Symbol, String] operation one of `:sum`, `:min`, `:max`,
+      #   `:and`, `:or`, `:xor`, `:match`, `:used`
+      # @param [String] value the value to compare against (required for `:match`)
+      # @return [Float, Integer, nil] the aggregate result — a Float for
+      #   `:sum`/`:min`/`:max`, an Integer otherwise; `nil` when no elements
+      #   qualify
+      def arop(key, start, stop, operation, value: nil)
+        operation = operation.to_s.upcase
+        args = [:arop, key, Integer(start), Integer(stop), operation]
+        args << value if operation == "MATCH"
+
+        if %w[SUM MIN MAX].include?(operation)
+          send_command(args, &Floatify)
+        else
+          send_command(args)
+        end
+      end
+
+      # Get metadata about an array.
+      #
+      # @param [String] key
+      # @param [Boolean] full include per-slice statistics
+      # @return [Hash{String => Integer}] metadata fields such as `count`,
+      #   `len`, `next-insert-index` and `slices`
+      # @raise [Redis::CommandError] when the key does not exist
+      def arinfo(key, full: false)
+        args = [:arinfo, key]
+        args << "FULL" if full
+        send_command(args, &Hashify)
+      end
+    end
+  end
+end

--- a/lib/redis/commands/arrays.rb
+++ b/lib/redis/commands/arrays.rb
@@ -59,7 +59,9 @@ class Redis
       #     # => 2
       #
       # @param [String] key
-      # @param [Array<Integer, String>, Hash{Integer => String}] pairs index-value pairs
+      # @param [Integer, String, Array<Integer, String>, Array<Array(Integer, String)>,
+      #   Hash{Integer => String}] pairs index-value pairs — as alternating
+      #   index/value arguments, a single flat array, one array per pair, or a Hash
       # @return [Integer] the number of previously empty slots that were set
       def armset(key, *pairs)
         pairs = if pairs.size == 1 && pairs.first.is_a?(Hash)
@@ -81,9 +83,12 @@ class Redis
       # @example
       #   redis.armget("foo", 0, 1, 9)
       #     # => ["a", "b", nil]
+      # @example With an array of indices
+      #   redis.armget("foo", [0, 1, 9])
+      #     # => ["a", "b", nil]
       #
       # @param [String] key
-      # @param [Integer] indices one or more zero-based indices
+      # @param [Integer, Array<Integer>] indices one or more zero-based indices
       # @return [Array<String, nil>] the values at the requested indices
       def armget(key, *indices)
         indices = indices.flatten(1).map { |index| Integer(index) }
@@ -132,7 +137,7 @@ class Redis
       # does not modify the array.
       #
       # @param [String] key
-      # @param [Integer] indices one or more zero-based indices to delete
+      # @param [Integer, Array<Integer>] indices one or more zero-based indices to delete
       # @return [Integer] the number of elements deleted
       def ardel(key, *indices)
         indices = indices.flatten(1).map { |index| Integer(index) }
@@ -152,7 +157,8 @@ class Redis
       #     # => 6
       #
       # @param [String] key
-      # @param [Array<Integer>] ranges one or more start/stop pairs
+      # @param [Integer, Array<Integer>] ranges one or more start/stop pairs,
+      #   as flat alternating integers or one array per range
       # @return [Integer] the number of elements deleted
       def ardelrange(key, *ranges)
         ranges = ranges.flatten(1).map { |index| Integer(index) }
@@ -313,6 +319,8 @@ class Redis
       #   qualify
       def arop(key, start, stop, operation, value: nil)
         operation = operation.to_s.upcase
+        raise ArgumentError, "value is required for the MATCH operation" if operation == "MATCH" && value.nil?
+
         args = [:arop, key, Integer(start), Integer(stop), operation]
         args << value if operation == "MATCH"
 

--- a/lib/redis/commands/arrays.rb
+++ b/lib/redis/commands/arrays.rb
@@ -51,6 +51,9 @@ class Redis
       # @example With a flat list of pairs
       #   redis.armset("foo", 0, "a", 5, "f")
       #     # => 2
+      # @example With an array (flat, or one array per pair)
+      #   redis.armset("foo", [0, "a"], [5, "f"])
+      #     # => 2
       # @example With a Hash
       #   redis.armset("foo", { 0 => "a", 5 => "f" })
       #     # => 2
@@ -59,7 +62,11 @@ class Redis
       # @param [Array<Integer, String>, Hash{Integer => String}] pairs index-value pairs
       # @return [Integer] the number of previously empty slots that were set
       def armset(key, *pairs)
-        pairs = pairs.first.flatten if pairs.size == 1 && pairs.first.is_a?(Hash)
+        pairs = if pairs.size == 1 && pairs.first.is_a?(Hash)
+          pairs.first.flatten
+        else
+          pairs.flatten(1)
+        end
         raise ArgumentError, "wrong number of arguments" if pairs.empty? || pairs.size.odd?
 
         args = pairs.each_slice(2).flat_map { |index, value| [Integer(index), value] }
@@ -247,9 +254,11 @@ class Redis
       #     # => [[0, "apple"], [2, "cherry"]]
       #
       # @param [String] key
-      # @param [Integer] start zero-based start index (inclusive); iteration
-      #   is reversed when greater than `stop`
-      # @param [Integer] stop zero-based end index (inclusive)
+      # @param [Integer, String] start zero-based start index (inclusive), or
+      #   `"-"` for the start of the array; iteration is reversed when greater
+      #   than `stop`
+      # @param [Integer, String] stop zero-based end index (inclusive), or
+      #   `"+"` for the end of the array
       # @param [String, Array<String>] exact match by exact equality
       # @param [String, Array<String>] match match by substring
       # @param [String, Array<String>] glob match by glob-style pattern (`*`, `?`, `[...]`)
@@ -262,7 +271,7 @@ class Redis
       #   indices in traversal order, or `[index, value]` pairs with `with_values`
       def argrep(key, start, stop, exact: nil, match: nil, glob: nil, re: nil,
                  logic: nil, limit: nil, with_values: nil, nocase: nil)
-        args = [:argrep, key, Integer(start), Integer(stop)]
+        args = [:argrep, key, argrep_bound(start), argrep_bound(stop)]
         { "EXACT" => exact, "MATCH" => match, "GLOB" => glob, "RE" => re }.each do |predicate, values|
           Array(values).each { |value| args << predicate << value }
         end
@@ -325,6 +334,15 @@ class Redis
         args = [:arinfo, key]
         args << "FULL" if full
         send_command(args, &Hashify)
+      end
+
+      private
+
+      # ARGREP accepts "-" / "+" as full-range bounds — unlike the other AR*
+      # range commands, which take numeric indices only (verified on Redis
+      # 8.8). Anything else is coerced so typos still fail fast client-side.
+      def argrep_bound(index)
+        index == "-" || index == "+" ? index : Integer(index)
       end
     end
   end

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -1289,6 +1289,96 @@ class Redis
       on_each_node(:script, subcommand, *args)
     end
 
+    # Set one or more contiguous values starting at an index in an array.
+    def arset(key, index, *values)
+      node_for(key).arset(key, index, *values)
+    end
+
+    # Get the value at an index in an array.
+    def arget(key, index)
+      node_for(key).arget(key, index)
+    end
+
+    # Set multiple index-value pairs in an array.
+    def armset(key, *pairs)
+      node_for(key).armset(key, *pairs)
+    end
+
+    # Get values at multiple indices in an array.
+    def armget(key, *indices)
+      node_for(key).armget(key, *indices)
+    end
+
+    # Get values in a range of indices.
+    def argetrange(key, start, stop)
+      node_for(key).argetrange(key, start, stop)
+    end
+
+    # Get the length of an array (max index + 1).
+    def arlen(key)
+      node_for(key).arlen(key)
+    end
+
+    # Get the number of non-empty elements in an array.
+    def arcount(key)
+      node_for(key).arcount(key)
+    end
+
+    # Delete elements at the specified indices in an array.
+    def ardel(key, *indices)
+      node_for(key).ardel(key, *indices)
+    end
+
+    # Delete elements in one or more inclusive index ranges.
+    def ardelrange(key, *ranges)
+      node_for(key).ardelrange(key, *ranges)
+    end
+
+    # Insert one or more values at the array's insert cursor.
+    def arinsert(key, *values)
+      node_for(key).arinsert(key, *values)
+    end
+
+    # Set the insert cursor of an array to a specific index.
+    def arseek(key, index)
+      node_for(key).arseek(key, index)
+    end
+
+    # Get the next index ARINSERT would use.
+    def arnext(key)
+      node_for(key).arnext(key)
+    end
+
+    # Get the most recently inserted elements.
+    def arlastitems(key, count, rev: false)
+      node_for(key).arlastitems(key, count, rev: rev)
+    end
+
+    # Insert one or more values into an array used as a fixed-size ring buffer.
+    def arring(key, size, *values)
+      node_for(key).arring(key, size, *values)
+    end
+
+    # Iterate existing elements in an index range.
+    def arscan(key, start, stop, limit: nil)
+      node_for(key).arscan(key, start, stop, limit: limit)
+    end
+
+    # Search array elements within an index range using textual predicates.
+    def argrep(key, start, stop, **options)
+      node_for(key).argrep(key, start, stop, **options)
+    end
+
+    # Perform an aggregate operation on the elements in a range.
+    def arop(key, start, stop, operation, value: nil)
+      node_for(key).arop(key, start, stop, operation, value: value)
+    end
+
+    # Get metadata about an array.
+    def arinfo(key, full: false)
+      node_for(key).arinfo(key, full: full)
+    end
+
     # Add one or more members to a HyperLogLog structure.
     def pfadd(key, member)
       node_for(key).pfadd(key, member)

--- a/specs/adding-commands.md
+++ b/specs/adding-commands.md
@@ -248,7 +248,8 @@ Important facts:
 | A Ruby wrapper around an existing Redis verb | `lib/redis/commands/<category>.rb` | None. `redis-client` already knows how to serialize/parse it; `redis-cluster-client` already knows how to route it. |
 | A Ruby wrapper around a brand-new Redis verb (newly added in some Redis version) | Same as above | None *at runtime*, provided your Redis server is recent enough that `COMMAND` describes the new verb. For routing-fast-path optimization, `redis-cluster-client` may need a catalog update, but routing is correct either way (it falls back to MOVED-follow). |
 | A new client-side reshape of an existing verb | Same as above + a reshape lambda (§4) | None. Reshapes live entirely in redis-rb. |
-| Behavior that needs RESP3 protocol features (push messages, native maps, client tracking) | Not supported in redis-rb. Drop down to `RedisClient` directly. | n/a — see CLAUDE.md "RESP2 invariant" |
+| A command whose RESP3 reply shape differs from RESP2 (native map/double vs flat array) | Same as above — make the reshape lambda protocol-aware (accept both shapes, converge on one Ruby value) and test under `PROTOCOL=2` and `PROTOCOL=3` | None. The client negotiates RESP3 by default since 6.0 and falls back to RESP2 automatically. |
+| Behavior that needs RESP3 **push messages** (client tracking / invalidation) | Not yet supported in redis-rb. Drop down to `RedisClient` directly. | n/a |
 
 ### The error translation contract
 
@@ -504,7 +505,7 @@ When you add a new command, add tests in this order:
 
 ### Version constraints
 
-The makefile defaults to building Redis `8.4` from source (`makefile:1`: `REDIS_BRANCH ?= 8.4`), but tests still need to skip cleanly on older versions where appropriate. Two helpers in `test/helper.rb`:
+The dev stack runs prebuilt `redislabs/client-libs-test` Docker images (override the tag with `REDIS_VERSION=8.X.Y`), but tests still need to skip cleanly on older versions where appropriate — CI runs a matrix from 7.2 up. Two helpers in `test/helper.rb`:
 
 - **`target_version(version) { ... }`** (`test/helper.rb:153-159`) — runs the block only if the server is at least that version, skips otherwise. Use this when most of a test depends on a newer feature:
 
@@ -556,7 +557,10 @@ bundle exec rake test:redis TEST=test/redis/commands_on_strings_test.rb \
 DRIVER=hiredis bundle exec rake test
 
 # Target a different Redis version
-REDIS_BRANCH=7.2 make start_all && make test
+REDIS_VERSION=7.2.14 make start_all && make test
+
+# Run over RESP2 instead of the default RESP3
+PROTOCOL=2 bundle exec rake test:redis
 
 make stop_all
 ```
@@ -596,7 +600,7 @@ By convention the first element of a command array is a **Symbol** (`:incr`, `:s
 
 ### Rubocop
 
-The project uses Rubocop with `rubocop ~> 1.25.1` (intentionally pinned to an older version — see Gemfile). Run before sending a PR:
+The project uses Rubocop (`~> 1.88`, see Gemfile). Run before sending a PR:
 
 ```sh
 bundle exec rubocop

--- a/test/distributed/commands_on_arrays_test.rb
+++ b/test/distributed/commands_on_arrays_test.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestDistributedCommandsOnArrays < Minitest::Test
+  include Helper::Distributed
+  include Lint::Arrays
+end

--- a/test/lint/arrays.rb
+++ b/test/lint/arrays.rb
@@ -510,6 +510,11 @@ module Lint
 
         assert info.key?("dense-slices")
         assert info.key?("sparse-slices")
+        # The avg-* statistics are doubles under RESP3 but bulk strings under
+        # RESP2; HashifyArrayInfo converges both on Float.
+        %w[avg-dense-size avg-dense-fill avg-sparse-size].each do |field|
+          assert_kind_of Float, info[field], "expected #{field} to be a Float"
+        end
       end
     end
 

--- a/test/lint/arrays.rb
+++ b/test/lint/arrays.rb
@@ -1,0 +1,491 @@
+# frozen_string_literal: true
+
+module Lint
+  module Arrays
+    def test_arset
+      target_version "8.8" do
+        assert_equal 1, r.arset("foo", 0, "s1")
+        assert_equal 1, r.arset("foo", 1, "s2")
+      end
+    end
+
+    def test_arset_with_multiple_values
+      target_version "8.8" do
+        assert_equal 3, r.arset("foo", 0, "s1", "s2", "s3")
+      end
+    end
+
+    def test_arset_counts_only_new_slots
+      target_version "8.8" do
+        assert_equal 2, r.arset("foo", 0, "s1", "s2")
+        # Overwriting existing slots fills no new ones.
+        assert_equal 0, r.arset("foo", 1, "s2b")
+        # One overwrite (index 1) plus one new slot (index 2).
+        assert_equal 1, r.arset("foo", 1, "s2c", "s3")
+      end
+    end
+
+    def test_arset_past_the_end_leaves_a_gap
+      target_version "8.8" do
+        assert_equal 1, r.arset("foo", 0, "s1")
+        assert_equal 1, r.arset("foo", 3, "s4")
+      end
+    end
+
+    def test_arset_with_negative_index
+      target_version "8.8" do
+        error = assert_raises(Redis::CommandError) { r.arset("foo", -1, "s1") }
+        assert_match(/invalid array index/i, error.message)
+      end
+    end
+
+    def test_arset_coerces_index
+      target_version "8.8" do
+        assert_equal 1, r.arset("foo", "0", "s1")
+        assert_raises(TypeError) { r.arset("foo", nil, "s1") }
+        assert_raises(ArgumentError) { r.arset("foo", "first", "s1") }
+      end
+    end
+
+    def test_arget
+      target_version "8.8" do
+        r.arset("foo", 0, "s1", "s2")
+
+        assert_equal "s1", r.arget("foo", 0)
+        assert_equal "s2", r.arget("foo", 1)
+      end
+    end
+
+    def test_arget_on_missing_key
+      target_version "8.8" do
+        assert_nil r.arget("foo", 0)
+      end
+    end
+
+    def test_arget_on_missing_index
+      target_version "8.8" do
+        r.arset("foo", 0, "s1")
+        # Past the end of the array.
+        assert_nil r.arget("foo", 9)
+
+        # An empty slot inside the array (gap left by a sparse ARSET).
+        r.arset("foo", 2, "s3")
+
+        assert_nil r.arget("foo", 1)
+      end
+    end
+
+    def test_arget_with_negative_index
+      target_version "8.8" do
+        r.arset("foo", 0, "s1")
+        error = assert_raises(Redis::CommandError) { r.arget("foo", -1) }
+        assert_match(/invalid array index/i, error.message)
+      end
+    end
+
+    def test_armset
+      target_version "8.8" do
+        assert_equal 2, r.armset("foo", 0, "s1", 5, "s6")
+        assert_equal "s1", r.arget("foo", 0)
+        assert_equal "s6", r.arget("foo", 5)
+      end
+    end
+
+    def test_armset_counts_only_new_slots
+      target_version "8.8" do
+        r.armset("foo", 0, "s1", 5, "s6")
+
+        assert_equal 1, r.armset("foo", 0, "s1b", 1, "s2")
+      end
+    end
+
+    def test_armset_with_hash
+      target_version "8.8" do
+        assert_equal 2, r.armset("foo", { 0 => "s1", 5 => "s6" })
+        assert_equal "s6", r.arget("foo", 5)
+      end
+    end
+
+    def test_armset_with_invalid_args
+      target_version "8.8" do
+        assert_raises(ArgumentError) { r.armset("foo") }
+        assert_raises(ArgumentError) { r.armset("foo", 0, "s1", 1) }
+      end
+    end
+
+    def test_armget
+      target_version "8.8" do
+        r.arset("foo", 0, "s1", "s2", "s3")
+
+        assert_equal %w[s3 s1], r.armget("foo", 2, 0)
+      end
+    end
+
+    def test_armget_on_missing_key_and_indices
+      target_version "8.8" do
+        assert_equal [nil, nil], r.armget("foo", 0, 1)
+
+        r.arset("foo", 0, "s1")
+
+        assert_equal ["s1", nil], r.armget("foo", 0, 9)
+      end
+    end
+
+    def test_argetrange
+      target_version "8.8" do
+        r.arset("foo", 0, "s1")
+        r.arset("foo", 2, "s3")
+
+        assert_equal ["s1", nil, "s3"], r.argetrange("foo", 0, 2)
+      end
+    end
+
+    def test_argetrange_reversed
+      target_version "8.8" do
+        r.arset("foo", 0, "s1", "s2", "s3")
+
+        assert_equal %w[s3 s2 s1], r.argetrange("foo", 2, 0)
+      end
+    end
+
+    def test_argetrange_on_missing_key
+      target_version "8.8" do
+        assert_equal [nil, nil, nil], r.argetrange("foo", 0, 2)
+      end
+    end
+
+    def test_arlen
+      target_version "8.8" do
+        r.arset("foo", 0, "s1")
+        r.arset("foo", 3, "s4")
+
+        assert_equal 4, r.arlen("foo")
+        assert_equal 0, r.arlen("bar")
+      end
+    end
+
+    def test_arcount
+      target_version "8.8" do
+        r.arset("foo", 0, "s1")
+        r.arset("foo", 3, "s4")
+
+        assert_equal 2, r.arcount("foo")
+        assert_equal 0, r.arcount("bar")
+      end
+    end
+
+    def test_ardel
+      target_version "8.8" do
+        r.arset("foo", 0, "s1", "s2", "s3")
+
+        assert_equal 2, r.ardel("foo", 0, 2)
+        assert_nil r.arget("foo", 0)
+        assert_equal "s2", r.arget("foo", 1)
+      end
+    end
+
+    def test_ardel_on_missing_index
+      target_version "8.8" do
+        r.arset("foo", 0, "s1")
+
+        assert_equal 0, r.ardel("foo", 9)
+      end
+    end
+
+    def test_ardelrange
+      target_version "8.8" do
+        r.arset("foo", 0, "s1", "s2", "s3", "s4", "s5", "s6")
+
+        assert_equal 4, r.ardelrange("foo", 0, 1, 4, 5)
+        assert_equal 2, r.arcount("foo")
+      end
+    end
+
+    def test_ardelrange_with_reversed_range
+      target_version "8.8" do
+        r.arset("foo", 0, "s1", "s2", "s3")
+
+        assert_equal 2, r.ardelrange("foo", 1, 0)
+      end
+    end
+
+    def test_ardelrange_on_missing_key_and_invalid_args
+      target_version "8.8" do
+        assert_equal 0, r.ardelrange("foo", 0, 9)
+        assert_raises(ArgumentError) { r.ardelrange("foo") }
+        assert_raises(ArgumentError) { r.ardelrange("foo", 0, 1, 2) }
+      end
+    end
+
+    def test_arinsert
+      target_version "8.8" do
+        assert_equal 2, r.arinsert("foo", "s1", "s2", "s3")
+        assert_equal %w[s1 s2 s3], r.argetrange("foo", 0, 2)
+        assert_equal 3, r.arinsert("foo", "s4")
+      end
+    end
+
+    def test_arseek_repositions_the_insert_cursor
+      target_version "8.8" do
+        r.arinsert("foo", "s1", "s2", "s3")
+
+        assert_equal true, r.arseek("foo", 1)
+        assert_equal 1, r.arnext("foo")
+        assert_equal 1, r.arinsert("foo", "s2b")
+        assert_equal "s2b", r.arget("foo", 1)
+      end
+    end
+
+    def test_arseek_on_missing_key
+      target_version "8.8" do
+        assert_equal false, r.arseek("foo", 1)
+      end
+    end
+
+    def test_arnext
+      target_version "8.8" do
+        assert_equal 0, r.arnext("foo")
+
+        r.arinsert("foo", "s1", "s2")
+
+        assert_equal 2, r.arnext("foo")
+      end
+    end
+
+    def test_arlastitems
+      target_version "8.8" do
+        r.arinsert("foo", "s1", "s2", "s3", "s4")
+
+        assert_equal %w[s3 s4], r.arlastitems("foo", 2)
+      end
+    end
+
+    def test_arlastitems_reversed
+      target_version "8.8" do
+        r.arinsert("foo", "s1", "s2", "s3", "s4")
+
+        assert_equal %w[s4 s3], r.arlastitems("foo", 2, rev: true)
+      end
+    end
+
+    def test_arlastitems_with_count_greater_than_size
+      target_version "8.8" do
+        r.arinsert("foo", "s1", "s2")
+
+        assert_equal %w[s1 s2], r.arlastitems("foo", 99)
+      end
+    end
+
+    def test_arring
+      target_version "8.8" do
+        assert_equal 1, r.arring("foo", 3, "s1", "s2")
+        assert_equal %w[s1 s2], r.argetrange("foo", 0, 1)
+      end
+    end
+
+    def test_arring_wraps_around
+      target_version "8.8" do
+        r.arring("foo", 3, "s1", "s2", "s3")
+
+        assert_equal 0, r.arring("foo", 3, "s4")
+        assert_equal %w[s4 s2 s3], r.argetrange("foo", 0, 2)
+      end
+    end
+
+    def test_arring_truncates_when_size_shrinks
+      target_version "8.8" do
+        r.arring("foo", 5, "s1", "s2", "s3", "s4")
+        r.arring("foo", 2, "s5")
+
+        assert_equal 2, r.arlen("foo")
+      end
+    end
+
+    def test_arscan
+      target_version "8.8" do
+        r.arset("foo", 0, "s1")
+        r.arset("foo", 3, "s4")
+
+        assert_equal [[0, "s1"], [3, "s4"]], r.arscan("foo", 0, 9)
+      end
+    end
+
+    def test_arscan_reversed
+      target_version "8.8" do
+        r.arset("foo", 0, "s1")
+        r.arset("foo", 3, "s4")
+
+        assert_equal [[3, "s4"], [0, "s1"]], r.arscan("foo", 9, 0)
+      end
+    end
+
+    def test_arscan_with_limit
+      target_version "8.8" do
+        r.arset("foo", 0, "s1", "s2", "s3")
+
+        assert_equal [[0, "s1"], [1, "s2"]], r.arscan("foo", 0, 9, limit: 2)
+      end
+    end
+
+    def test_arscan_on_missing_key
+      target_version "8.8" do
+        assert_equal [], r.arscan("foo", 0, 9)
+      end
+    end
+
+    def test_argrep_with_exact_predicate
+      target_version "8.8" do
+        r.arset("foo", 0, "apple", "banana", "cherry")
+
+        assert_equal [0], r.argrep("foo", 0, 9, exact: "apple")
+      end
+    end
+
+    def test_argrep_with_match_predicate
+      target_version "8.8" do
+        r.arset("foo", 0, "apple", "banana", "cherry")
+
+        assert_equal [1], r.argrep("foo", 0, 9, match: "an")
+      end
+    end
+
+    def test_argrep_with_glob_predicate
+      target_version "8.8" do
+        r.arset("foo", 0, "apple", "banana", "cherry")
+
+        assert_equal [0], r.argrep("foo", 0, 9, glob: "a*e")
+      end
+    end
+
+    def test_argrep_with_re_predicate
+      target_version "8.8" do
+        r.arset("foo", 0, "apple", "banana", "cherry")
+
+        assert_equal [0], r.argrep("foo", 0, 9, re: "^ap+le$")
+      end
+    end
+
+    def test_argrep_with_nocase
+      target_version "8.8" do
+        r.arset("foo", 0, "apple", "APPLE")
+
+        assert_equal [0, 1], r.argrep("foo", 0, 9, exact: "Apple", nocase: true)
+      end
+    end
+
+    def test_argrep_with_values
+      target_version "8.8" do
+        r.arset("foo", 0, "apple", "banana")
+
+        assert_equal [[0, "apple"]], r.argrep("foo", 0, 9, exact: "apple", with_values: true)
+      end
+    end
+
+    def test_argrep_with_limit
+      target_version "8.8" do
+        r.arset("foo", 0, "s", "s", "s")
+
+        assert_equal [0, 1], r.argrep("foo", 0, 9, exact: "s", limit: 2)
+      end
+    end
+
+    def test_argrep_with_multiple_predicates
+      target_version "8.8" do
+        r.arset("foo", 0, "apple", "banana", "cherry")
+
+        # OR is the server default: either predicate matches.
+        assert_equal [0, 1], r.argrep("foo", 0, 9, exact: ["apple", "banana"], logic: :or)
+        # AND: every predicate must match the same element.
+        assert_equal [0], r.argrep("foo", 0, 9, match: %w[a p], logic: :and)
+        assert_raises(ArgumentError) { r.argrep("foo", 0, 9, match: "a", logic: :xor) }
+      end
+    end
+
+    def test_argrep_reversed_and_missing_key
+      target_version "8.8" do
+        assert_equal [], r.argrep("foo", 0, 9, match: "a")
+
+        r.arset("foo", 0, "apple", "avocado")
+
+        assert_equal [1, 0], r.argrep("foo", 9, 0, match: "a")
+      end
+    end
+
+    def test_arop_numeric_operations
+      target_version "8.8" do
+        r.arset("foo", 0, "1", "2", "3")
+
+        assert_equal 6.0, r.arop("foo", 0, 2, :sum)
+        assert_equal 1.0, r.arop("foo", 0, 2, :min)
+        assert_equal 3.0, r.arop("foo", 0, 2, :max)
+      end
+    end
+
+    def test_arop_bitwise_operations
+      target_version "8.8" do
+        r.arset("foo", 0, "1", "2", "3")
+
+        assert_equal 0, r.arop("foo", 0, 2, :and)
+        assert_equal 3, r.arop("foo", 0, 2, :or)
+        assert_equal 0, r.arop("foo", 0, 2, :xor)
+      end
+    end
+
+    def test_arop_match_and_used
+      target_version "8.8" do
+        r.arset("foo", 0, "1", "2", "2")
+
+        assert_equal 2, r.arop("foo", 0, 2, :match, value: "2")
+        assert_equal 3, r.arop("foo", 0, 2, :used)
+      end
+    end
+
+    def test_arop_skips_non_numeric_values
+      target_version "8.8" do
+        r.arset("foo", 0, "1", "abc", "3")
+
+        assert_equal 4.0, r.arop("foo", 0, 2, :sum)
+      end
+    end
+
+    def test_arop_on_empty_range
+      target_version "8.8" do
+        r.arset("foo", 0, "1")
+
+        assert_nil r.arop("foo", 5, 9, :sum)
+      end
+    end
+
+    def test_arinfo
+      target_version "8.8" do
+        r.arset("foo", 0, "s1", "s2")
+
+        info = r.arinfo("foo")
+
+        assert_kind_of Hash, info
+        assert_equal 2, info["count"]
+        assert_equal 2, info["len"]
+        assert info.key?("next-insert-index")
+        assert info.key?("slices")
+      end
+    end
+
+    def test_arinfo_full
+      target_version "8.8" do
+        r.arset("foo", 0, "s1")
+
+        info = r.arinfo("foo", full: true)
+
+        assert info.key?("dense-slices")
+        assert info.key?("sparse-slices")
+      end
+    end
+
+    def test_arinfo_on_missing_key
+      target_version "8.8" do
+        error = assert_raises(Redis::CommandError) { r.arinfo("foo") }
+        assert_match(/no such key/i, error.message)
+      end
+    end
+  end
+end

--- a/test/lint/arrays.rb
+++ b/test/lint/arrays.rb
@@ -106,6 +106,16 @@ module Lint
       end
     end
 
+    def test_armset_with_arrays
+      target_version "8.8" do
+        # A single flat array and one-array-per-pair are both accepted,
+        # consistent with armget/ardel/ardelrange flattening one level.
+        assert_equal 2, r.armset("foo", [0, "s1", 5, "s6"])
+        assert_equal 2, r.armset("bar", [0, "s1"], [5, "s6"])
+        assert_equal "s6", r.arget("bar", 5)
+      end
+    end
+
     def test_armset_with_invalid_args
       target_version "8.8" do
         assert_raises(ArgumentError) { r.armset("foo") }
@@ -333,6 +343,18 @@ module Lint
       end
     end
 
+    def test_zero_limit_is_sent_and_rejected_by_the_server
+      target_version "8.8" do
+        r.arset("foo", 0, "s1")
+
+        # 0 is truthy in Ruby, so LIMIT 0 goes on the wire; the server
+        # defines it as invalid rather than "no results".
+        error = assert_raises(Redis::CommandError) { r.arscan("foo", 0, 9, limit: 0) }
+        assert_match(/LIMIT must be positive/i, error.message)
+        assert_raises(Redis::CommandError) { r.argrep("foo", 0, 9, match: "s", limit: 0) }
+      end
+    end
+
     def test_argrep_with_exact_predicate
       target_version "8.8" do
         r.arset("foo", 0, "apple", "banana", "cherry")
@@ -408,6 +430,16 @@ module Lint
         r.arset("foo", 0, "apple", "avocado")
 
         assert_equal [1, 0], r.argrep("foo", 9, 0, match: "a")
+      end
+    end
+
+    def test_argrep_with_full_range_sentinels
+      target_version "8.8" do
+        r.arset("foo", 0, "apple", "banana")
+
+        assert_equal [0, 1], r.argrep("foo", "-", "+", match: "a")
+        # Other bounds must still be numeric and fail fast client-side.
+        assert_raises(ArgumentError) { r.argrep("foo", "first", "+", match: "a") }
       end
     end
 

--- a/test/lint/arrays.rb
+++ b/test/lint/arrays.rb
@@ -469,6 +469,7 @@ module Lint
 
         assert_equal 2, r.arop("foo", 0, 2, :match, value: "2")
         assert_equal 3, r.arop("foo", 0, 2, :used)
+        assert_raises(ArgumentError) { r.arop("foo", 0, 2, :match) }
       end
     end
 

--- a/test/redis/commands_on_arrays_test.rb
+++ b/test/redis/commands_on_arrays_test.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestCommandsOnArrays < Minitest::Test
+  include Helper::Client
+  include Lint::Arrays
+end


### PR DESCRIPTION
## Summary

Adds support for the array type command family (AR*, Redis 8.8): a new `Redis::Commands::Arrays` module with all 18 commands, available on standalone clients, pipelines/transactions, `Redis::Cluster`, and `Redis::Distributed`.

```
redis.arset("key", 0, "a", "b")                 # => 2 (new slots filled)
redis.arget("key", 1)                            # => "b"
redis.armset("key", { 4 => "e", 9 => "j" })      # => 2
redis.arscan("key", 0, 9)                        # => [[0, "a"], [1, "b"], [4, "e"], [9, "j"]]
redis.argrep("key", 0, 9, glob: "a*", with_values: true)  # => [[0, "a"]]
redis.arop("key", 0, 9, :sum)                    # => 6.0
redis.arinfo("key")                              # => {"count"=>4, "len"=>10, ...}
```

Full surface: `arset, arget, armset, armget, argetrange, arlen, arcount, ardel, ardelrange, arinsert, arseek, arnext, arlastitems, arring, arscan, argrep, arop, arinfo`.

Also updates the agent/contributor documentation (`AGENTS.md`, `specs/adding-commands.md`) that had gone stale after the 6.0 release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new public API surface and RESP2/RESP3 reshape paths for `arinfo`/`arop`, but changes follow existing command/lint patterns and are version-gated in tests; no auth or connection-layer changes.
> 
> **Overview**
> Introduces **`Redis::Commands::Arrays`** with all **18 `AR*` commands** (set/get, multi-set/get, range ops, insert cursor, ring buffer, scan/grep, aggregates, and `arinfo`), mixed into the main `Commands` module so they work on **standalone, pipelines/multi, and cluster** via inheritance.
> 
> **Reply shaping:** adds **`HashifyArrayInfo`** so `arinfo` `avg-*` fields are **`Float` under both RESP2 and RESP3**; numeric **`arop`** results use **`Floatify`**. **`argrep`** exposes keyword predicates (`exact`, `match`, `glob`, `re`, `logic`, `limit`, `with_values`, `nocase`) and accepts **`"-"` / `"+"`** range bounds.
> 
> **`Redis::Distributed`** gets matching **`node_for(key)`** wrappers for every AR command. **Tests** live in **`Lint::Arrays`** (gated with **`target_version "8.8"`**) and are included from redis, distributed, and cluster test stubs.
> 
> **Documentation:** **`AGENTS.md`** and **`specs/adding-commands.md`** are updated for current behavior—**RESP3 default**, **`PROTOCOL=2` testing**, cluster **`BUNDLE_GEMFILE`**, Docker **`REDIS_VERSION`**, and protocol-aware reshape guidance—rather than describing arrays alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e184fe7d70c583c21486142d4ca7d0318ee3c622. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->