### PR TITLE
Added support for Redis 8.8 new commands

### DIFF
--- a/lib/redis/commands/streams.rb
+++ b/lib/redis/commands/streams.rb
@@ -295,6 +295,45 @@ class Redis
         send_command(args)
       end
 
+      # Releases pending entries back to the consumer group's Pending Entries
+      # List without acknowledging them. Released entries become unowned, are
+      # placed at the head of the PEL and are immediately available for
+      # re-delivery via `xreadgroup` CLAIM, `xclaim` or `xautoclaim`,
+      # bypassing the usual idle-timeout delay.
+      #
+      # @example Let another consumer retry two entries
+      #   redis.xnack('mystream', 'mygroup', 'FAIL', '0-1', '0-2')
+      # @example Graceful shutdown with arrayed entry ids
+      #   redis.xnack('mystream', 'mygroup', :silent, %w[0-1 0-2])
+      # @example Mark a poison message as permanently failed
+      #   redis.xnack('mystream', 'mygroup', 'FATAL', '0-1')
+      #
+      # @param key   [String]         the stream key
+      # @param group [String]         the consumer group name
+      # @param mode  [String, Symbol] how the entry's delivery counter is
+      #   adjusted: `SILENT` decrements it by one (the delivery "didn't
+      #   count"), `FAIL` keeps it unchanged, `FATAL` sets it to the maximum,
+      #   marking the entry permanently failed
+      # @param ids   [Array<String>]  one or multiple entry ids
+      # @param retrycount [Integer]   set the delivery counter to an explicit
+      #   value, overriding the mode adjustment (internal, rarely needed)
+      # @param force [Boolean]        create unowned PEL entries for ids that
+      #   are not currently pending; each must exist in the stream (internal,
+      #   rarely needed)
+      #
+      # @return [Integer] the number of entries released back to the group
+      #   PEL; ids that are not pending are ignored and not counted
+      def xnack(key, group, mode, *ids, retrycount: nil, force: nil)
+        mode = mode.to_s.upcase
+        raise ArgumentError, "mode must be SILENT, FAIL or FATAL" unless %w[SILENT FAIL FATAL].include?(mode)
+
+        ids = ids.flatten
+        args = [:xnack, key, group, mode, "IDS", ids.size].concat(ids)
+        args << "RETRYCOUNT" << Integer(retrycount) if retrycount
+        args << "FORCE" if force
+        send_command(args)
+      end
+
       # Changes the ownership of a pending entry
       #
       # @example With splatted entry ids

--- a/lib/redis/commands/strings.rb
+++ b/lib/redis/commands/strings.rb
@@ -94,9 +94,12 @@ class Redis
       #   `BYFLOAT` (stored value may be integer or float, replies with
       #   Floats) — so `by: 5` and `by: 5.0` behave differently. Other types
       #   raise `TypeError`. Without `by:`, increments by 1 in integer mode.
-      # @param [Integer, Float] lbound lower bound for the result (coerced to
-      #   the mode selected by `by:`)
-      # @param [Integer, Float] ubound upper bound for the result
+      # @param [Integer, Float] lbound lower bound for the result. In float
+      #   mode any numeric is accepted; in integer mode it must be an
+      #   `Integer` (a `Float` raises `TypeError` rather than silently
+      #   truncating, since bounds decide whether the increment applies)
+      # @param [Integer, Float] ubound upper bound for the result, with the
+      #   same typing rules as `lbound`
       # @param [Boolean] saturate cap/floor an out-of-bounds result at the
       #   bound instead of skipping the operation
       # @param [Integer] ex expiration in seconds
@@ -113,6 +116,9 @@ class Redis
       #   is 0 when the operation was skipped as out of bounds
       def increx(key, by: nil, lbound: nil, ubound: nil, saturate: nil,
                  ex: nil, px: nil, exat: nil, pxat: nil, persist: nil, enx: nil)
+        if [ex, px, exat, pxat, persist].count { |option| option } > 1
+          raise ArgumentError, "ex, px, exat, pxat and persist are mutually exclusive"
+        end
         raise ArgumentError, "enx is incompatible with persist" if enx && persist
         raise ArgumentError, "enx requires one of ex, px, exat or pxat" if enx && !(ex || px || exat || pxat)
 
@@ -126,8 +132,8 @@ class Redis
 
         args = [:increx, key]
         args << (float_mode ? "BYFLOAT" : "BYINT") << by if by
-        args << "LBOUND" << (float_mode ? Float(lbound) : Integer(lbound)) if lbound
-        args << "UBOUND" << (float_mode ? Float(ubound) : Integer(ubound)) if ubound
+        args << "LBOUND" << increx_bound(:lbound, lbound, float_mode) if lbound
+        args << "UBOUND" << increx_bound(:ubound, ubound, float_mode) if ubound
         args << "SATURATE" if saturate
         args << "EX" << Integer(ex) if ex
         args << "PX" << Integer(px) if px
@@ -387,6 +393,18 @@ class Redis
       #   if the key does not exist
       def strlen(key)
         send_command([:strlen, key])
+      end
+
+      private
+
+      # INCREX bounds decide whether the increment is applied at all, so a
+      # Float bound in integer mode must raise rather than silently truncate
+      # (`Integer(2.9)` => 2) — mirroring how `by:` selects the mode strictly.
+      def increx_bound(name, value, float_mode)
+        return Float(value) if float_mode
+        raise TypeError, "#{name} must be an Integer in integer mode, got #{value.class}" unless value.is_a?(Integer)
+
+        value
       end
     end
   end

--- a/lib/redis/commands/strings.rb
+++ b/lib/redis/commands/strings.rb
@@ -66,6 +66,85 @@ class Redis
         send_command([:incrbyfloat, key, Float(increment)], &Floatify)
       end
 
+      # Increment the numeric value of a key atomically, with optional bounds
+      # and expiration control. Uses 0 as the initial value if the key does
+      # not exist.
+      #
+      # Unlike `incr`/`incrby`, the reply is a two-element array of the new
+      # value and the increment that was actually applied. When the result
+      # would fall outside `lbound:`/`ubound:` (or the type limits) the
+      # operation is skipped and the reply is `[current_value, 0]`; with
+      # `saturate: true` the result is capped at the bound instead and the
+      # second element reflects the saturated delta.
+      #
+      # @example Increment by 1 (integer mode default)
+      #   redis.increx("counter")
+      #     # => [1, 1]
+      # @example Window counter rate limiter: cap at 100, TTL only on window creation
+      #   value, applied = redis.increx("ratelimit:#{user_id}", by: 1, ubound: 100, ex: 60, enx: true)
+      #   reject_request if applied == 0
+      # @example Float mode — selected by the Ruby type of `by:`
+      #   redis.increx("temp", by: 0.25)
+      #     # => [1.75, 0.25]
+      #
+      # @param [String] key
+      # @param [Integer, Float] by the increment (may be negative). The Ruby
+      #   type selects the mode: an `Integer` is sent as `BYINT` (requires an
+      #   integer-typed stored value, replies with Integers), a `Float` as
+      #   `BYFLOAT` (stored value may be integer or float, replies with
+      #   Floats) — so `by: 5` and `by: 5.0` behave differently. Other types
+      #   raise `TypeError`. Without `by:`, increments by 1 in integer mode.
+      # @param [Integer, Float] lbound lower bound for the result (coerced to
+      #   the mode selected by `by:`)
+      # @param [Integer, Float] ubound upper bound for the result
+      # @param [Boolean] saturate cap/floor an out-of-bounds result at the
+      #   bound instead of skipping the operation
+      # @param [Integer] ex expiration in seconds
+      # @param [Integer] px expiration in milliseconds
+      # @param [Integer] exat expiration as a Unix timestamp in seconds
+      # @param [Integer] pxat expiration as a Unix timestamp in milliseconds
+      # @param [Boolean] persist remove the key's expiration
+      # @param [Boolean] enx only set the expiration when the key has no TTL
+      #   (the increment is applied regardless); requires one of
+      #   `ex`/`px`/`exat`/`pxat`
+      # @return [Array(Integer, Integer), Array(Float, Float)]
+      #   `[new_value, applied_increment]` — Integers in integer mode, Floats
+      #   in float mode (under RESP2 and RESP3 alike); `applied_increment`
+      #   is 0 when the operation was skipped as out of bounds
+      def increx(key, by: nil, lbound: nil, ubound: nil, saturate: nil,
+                 ex: nil, px: nil, exat: nil, pxat: nil, persist: nil, enx: nil)
+        raise ArgumentError, "enx is incompatible with persist" if enx && persist
+        raise ArgumentError, "enx requires one of ex, px, exat or pxat" if enx && !(ex || px || exat || pxat)
+
+        # The Ruby type of `by` selects the wire mode; anything else would
+        # have to silently pick a mode, so it is rejected instead.
+        float_mode = case by
+        when nil, Integer then false
+        when Float then true
+        else raise TypeError, "by must be an Integer (BYINT) or a Float (BYFLOAT), got #{by.class}"
+        end
+
+        args = [:increx, key]
+        args << (float_mode ? "BYFLOAT" : "BYINT") << by if by
+        args << "LBOUND" << (float_mode ? Float(lbound) : Integer(lbound)) if lbound
+        args << "UBOUND" << (float_mode ? Float(ubound) : Integer(ubound)) if ubound
+        args << "SATURATE" if saturate
+        args << "EX" << Integer(ex) if ex
+        args << "PX" << Integer(px) if px
+        args << "EXAT" << Integer(exat) if exat
+        args << "PXAT" << Integer(pxat) if pxat
+        args << "PERSIST" if persist
+        args << "ENX" if enx
+
+        if float_mode
+          # RESP2 replies with bulk strings, RESP3 with native doubles;
+          # converge both on Float.
+          send_command(args) { |reply| reply.is_a?(Array) ? reply.map(&Floatify) : reply }
+        else
+          send_command(args)
+        end
+      end
+
       # Set the string value of a key.
       #
       # @param [String] key

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -296,6 +296,12 @@ class Redis
       node_for(key).incrbyfloat(key, increment)
     end
 
+    # Increment the numeric value of a key atomically, with optional bounds
+    # and expiration control.
+    def increx(key, **options)
+      node_for(key).increx(key, **options)
+    end
+
     # Set the string value of a key.
     def set(key, value, **options)
       node_for(key).set(key, value, **options)

--- a/test/lint/streams.rb
+++ b/test/lint/streams.rb
@@ -772,6 +772,88 @@ module Lint
       assert_equal 2, redis.xack('s1', 'g1', %w[0-2 0-3])
     end
 
+    def test_xnack_with_fail_mode
+      target_version "8.8" do
+        redis.xadd('s1', { f: 'v1' }, id: '0-1')
+        redis.xadd('s1', { f: 'v2' }, id: '0-2')
+        redis.xgroup(:create, 's1', 'g1', '0')
+        redis.xreadgroup('g1', 'c1', 's1', '>')
+
+        assert_equal 2, redis.xnack('s1', 'g1', 'FAIL', '0-1', '0-2')
+
+        # Released entries stay pending but become unowned (empty consumer).
+        consumers = redis.xpending('s1', 'g1', '-', '+', 10).map { |d| d['consumer'] }
+        assert_equal ['', ''], consumers
+      end
+    end
+
+    def test_xnack_with_silent_and_fatal_modes_and_arrayed_ids
+      target_version "8.8" do
+        redis.xadd('s1', { f: 'v1' }, id: '0-1')
+        redis.xadd('s1', { f: 'v2' }, id: '0-2')
+        redis.xgroup(:create, 's1', 'g1', '0')
+        redis.xreadgroup('g1', 'c1', 's1', '>')
+
+        # Modes are accepted as symbols or strings, ids splatted or arrayed.
+        assert_equal 1, redis.xnack('s1', 'g1', :silent, %w[0-1])
+        assert_equal 1, redis.xnack('s1', 'g1', 'FATAL', '0-2')
+      end
+    end
+
+    def test_xnack_ignores_non_pending_ids
+      target_version "8.8" do
+        redis.xadd('s1', { f: 'v1' }, id: '0-1')
+        redis.xgroup(:create, 's1', 'g1', '0')
+
+        # 0-1 was never delivered to a consumer, so it is not in the PEL.
+        assert_equal 0, redis.xnack('s1', 'g1', 'FAIL', '0-1')
+      end
+    end
+
+    def test_xnack_released_entries_are_immediately_claimable
+      target_version "8.8" do
+        redis.xadd('s1', { f: 'v1' }, id: '0-1')
+        redis.xgroup(:create, 's1', 'g1', '0')
+        redis.xreadgroup('g1', 'c1', 's1', '>')
+        redis.xnack('s1', 'g1', 'FAIL', '0-1')
+
+        # Delivery time is reset to 0, so a claim succeeds regardless of idle time.
+        claimed = redis.xclaim('s1', 'g1', 'c2', 0, '0-1')
+
+        assert_equal ['0-1'], claimed.map(&:first)
+      end
+    end
+
+    def test_xnack_with_retrycount
+      target_version "8.8" do
+        redis.xadd('s1', { f: 'v1' }, id: '0-1')
+        redis.xgroup(:create, 's1', 'g1', '0')
+        redis.xreadgroup('g1', 'c1', 's1', '>')
+
+        assert_equal 1, redis.xnack('s1', 'g1', 'FAIL', '0-1', retrycount: 5)
+        assert_equal 5, redis.xpending('s1', 'g1', '-', '+', 10).first['count']
+      end
+    end
+
+    def test_xnack_with_force
+      target_version "8.8" do
+        redis.xadd('s1', { f: 'v1' }, id: '0-1')
+        redis.xgroup(:create, 's1', 'g1', '0')
+        redis.xreadgroup('g1', 'c1', 's1', '>')
+        redis.xack('s1', 'g1', '0-1')
+
+        # Acked entry is no longer pending; FORCE recreates an unowned PEL entry.
+        assert_equal 0, redis.xnack('s1', 'g1', 'FAIL', '0-1')
+        assert_equal 1, redis.xnack('s1', 'g1', 'FAIL', '0-1', force: true)
+      end
+    end
+
+    def test_xnack_with_invalid_mode
+      target_version "8.8" do
+        assert_raises(ArgumentError) { redis.xnack('s1', 'g1', 'BOGUS', '0-1') }
+      end
+    end
+
     def test_xack_with_invalid_arguments
       assert_raises(TypeError) { redis.xack(nil, nil, nil) }
       assert_equal 0, redis.xack('', '', '')

--- a/test/lint/strings.rb
+++ b/test/lint/strings.rb
@@ -250,12 +250,26 @@ module Lint
       end
     end
 
+    def test_increx_with_lbound
+      target_version "8.8" do
+        r.set("foo", "1")
+
+        assert_equal [1, 0], r.increx("foo", by: -5, lbound: 0)
+        assert_equal [0, -1], r.increx("foo", by: -5, lbound: 0, saturate: true)
+      end
+    end
+
     def test_increx_bounds_follow_the_mode
       target_version "8.8" do
         r.set("foo", "1.5")
 
         # Float mode coerces bounds to floats; integer-typed bounds are accepted.
         assert_equal [2.0, 0.5], r.increx("foo", by: 0.5, ubound: 2, saturate: true)
+
+        # Integer mode rejects Float bounds instead of silently truncating
+        # (Integer(2.9) => 2 would change whether the increment applies).
+        assert_raises(TypeError) { r.increx("foo", by: 1, ubound: 2.9) }
+        assert_raises(TypeError) { r.increx("foo", by: 1, lbound: -0.5) }
       end
     end
 
@@ -289,6 +303,9 @@ module Lint
       target_version "8.8" do
         assert_raises(ArgumentError) { r.increx("foo", ex: 5, persist: true, enx: true) }
         assert_raises(ArgumentError) { r.increx("foo", enx: true) }
+        # At most one expiration option may be given.
+        assert_raises(ArgumentError) { r.increx("foo", ex: 5, px: 5_000) }
+        assert_raises(ArgumentError) { r.increx("foo", exat: 1, persist: true) }
       end
     end
 

--- a/test/lint/strings.rb
+++ b/test/lint/strings.rb
@@ -199,6 +199,99 @@ module Lint
       assert_equal 1.9, r.incrbyfloat("foo", -0.1)
     end
 
+    def test_increx
+      target_version "8.8" do
+        assert_equal [1, 1], r.increx("foo")
+        assert_equal [2, 1], r.increx("foo")
+      end
+    end
+
+    def test_increx_with_integer_selects_byint
+      target_version "8.8" do
+        assert_equal [5, 5], r.increx("foo", by: 5)
+        assert_equal [-5, -10], r.increx("foo", by: -10)
+      end
+    end
+
+    def test_increx_with_float_selects_byfloat
+      target_version "8.8" do
+        r.set("foo", "1.5")
+
+        # RESP2 replies with bulk strings, RESP3 with doubles; both must
+        # converge on Floats.
+        assert_equal [1.75, 0.25], r.increx("foo", by: 0.25)
+      end
+    end
+
+    def test_increx_mode_follows_the_ruby_type_of_by
+      target_version "8.8" do
+        # by: 5 and by: 5.0 are different commands: BYINT replies with
+        # Integers, BYFLOAT with Floats.
+        assert_equal [5, 5], r.increx("foo", by: 5)
+        assert_equal [10.0, 5.0], r.increx("foo", by: 5.0)
+        assert_raises(TypeError) { r.increx("foo", by: "5") }
+      end
+    end
+
+    def test_increx_with_ubound_skips_out_of_bounds
+      target_version "8.8" do
+        r.set("foo", "99")
+
+        assert_equal [99, 0], r.increx("foo", by: 5, ubound: 100)
+        assert_equal "99", r.get("foo")
+      end
+    end
+
+    def test_increx_with_saturate_caps_at_the_bound
+      target_version "8.8" do
+        r.set("foo", "99")
+
+        assert_equal [100, 1], r.increx("foo", by: 5, ubound: 100, saturate: true)
+      end
+    end
+
+    def test_increx_bounds_follow_the_mode
+      target_version "8.8" do
+        r.set("foo", "1.5")
+
+        # Float mode coerces bounds to floats; integer-typed bounds are accepted.
+        assert_equal [2.0, 0.5], r.increx("foo", by: 0.5, ubound: 2, saturate: true)
+      end
+    end
+
+    def test_increx_with_expiration
+      target_version "8.8" do
+        r.increx("foo", by: 1, ex: 100)
+
+        assert_in_range 0..100, r.ttl("foo")
+      end
+    end
+
+    def test_increx_with_enx_preserves_existing_ttl
+      target_version "8.8" do
+        r.set("foo", "10", ex: 500)
+
+        assert_equal [11, 1], r.increx("foo", by: 1, ex: 10, enx: true)
+        assert_in_range 400..500, r.ttl("foo")
+      end
+    end
+
+    def test_increx_with_persist
+      target_version "8.8" do
+        r.set("foo", "5", ex: 1000)
+        r.increx("foo", by: 1, persist: true)
+
+        assert_equal(-1, r.ttl("foo"))
+      end
+    end
+
+    def test_increx_with_invalid_option_combinations
+      target_version "8.8" do
+        assert_raises(ArgumentError) { r.increx("foo", ex: 5, persist: true, enx: true) }
+        assert_raises(ArgumentError) { r.increx("foo", enx: true) }
+      end
+    end
+
     def test_decr
       r.set("foo", 3)
 


### PR DESCRIPTION
Added support for two new commands: `INCREX` and `XNACK`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive command wrappers and tests; behavior depends on Redis 8.8+ and does not change existing commands.
> 
> **Overview**
> Adds client support for two **Redis 8.8** commands: **`increx`** and **`xnack`**, with lint tests gated on server version 8.8.
> 
> **`increx`** wraps the atomic increment-with-bounds command. It returns `[new_value, applied_delta]` instead of a single scalar, maps keyword options to `BYINT`/`BYFLOAT`, `LBOUND`/`UBOUND`, `SATURATE`, and TTL flags (`ex`, `px`, `enx`, etc.), and validates conflicting expiration options in Ruby. Integer vs float mode follows the Ruby type of `by:` (`5` vs `5.0`); float replies are normalized across RESP2/RESP3. **`Redis::Distributed`** forwards **`increx`** to the node for the key.
> 
> **`xnack`** releases pending stream entries back to the group PEL without acking, with modes `SILENT`/`FAIL`/`FATAL`, optional `retrycount:` and `force:`, and splatted or array entry IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63d42fe192a76bf27bb15cb073f539298c5567c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->