### PR TITLE
Added support for Redis 8.8 new command arguments

### DIFF
--- a/lib/redis/commands/modules/json.rb
+++ b/lib/redis/commands/modules/json.rb
@@ -14,6 +14,10 @@ class Redis
     # JSON.NUMINCRBY — DO return differently shaped replies under RESP3 and will need
     # protocol-aware reshaping once RESP3 is supported at this layer.
     module Json
+      # Floating-point precisions accepted by JSON.SET's FPHA argument (Redis 8.8+).
+      JSON_SET_FPHA_TYPES = %w[BF16 FP16 FP32 FP64].freeze
+      private_constant :JSON_SET_FPHA_TYPES
+
       # Normalize a JSON.NUMINCRBY reply to a protocol-independent value: an array of numbers for
       # a JSONPath, a single number for a legacy path. Under RESP2 the result arrives as a
       # JSON-encoded string ("[3,4]" / "7"); under RESP3 it arrives as native numbers (an array,
@@ -76,16 +80,29 @@ class Redis
       # @param [Boolean] nx only set when the path does not already exist
       # @param [Boolean] xx only set when the path already exists
       # @param [Boolean] raw treat +value+ as an already-encoded JSON string and send it as-is
+      # @param [String, Symbol] fpha store a numeric array as a Floating-Point
+      #   Homogeneous Array of the given precision — one of +:bf16+, +:fp16+,
+      #   +:fp32+, +:fp64+ (case-insensitive; Redis 8.8+). Reduces memory by
+      #   forcing all values of the array into a fixed floating-point type.
       # @return [Boolean, String] when +nx+ or +xx+ is given, +true+ on success and +false+
       #   when the condition was not met; otherwise the raw +"OK"+ reply
-      # @raise [ArgumentError] if both +nx+ and +xx+ are given (they are mutually exclusive)
-      def json_set(key, path, value, nx: false, xx: false, raw: false)
+      # @raise [ArgumentError] if both +nx+ and +xx+ are given (they are mutually exclusive),
+      #   or if +fpha+ is not one of the supported types
+      def json_set(key, path, value, nx: false, xx: false, raw: false, fpha: nil)
         raise ArgumentError, "nx and xx are mutually exclusive" if nx && xx
+
+        if fpha
+          fpha = fpha.to_s.upcase
+          unless JSON_SET_FPHA_TYPES.include?(fpha)
+            raise ArgumentError, "fpha accepts only: #{JSON_SET_FPHA_TYPES.join(', ')}"
+          end
+        end
 
         value = ::JSON.generate(value) unless raw
         args = [:"JSON.SET", key, path, value]
         args << "NX" if nx
         args << "XX" if xx
+        args << "FPHA" << fpha if fpha
 
         if nx || xx
           send_command(args, &BoolifySet)

--- a/lib/redis/commands/modules/json.rb
+++ b/lib/redis/commands/modules/json.rb
@@ -82,12 +82,15 @@ class Redis
       # @param [Boolean] raw treat +value+ as an already-encoded JSON string and send it as-is
       # @param [String, Symbol] fpha store a numeric array as a Floating-Point
       #   Homogeneous Array of the given precision — one of +:bf16+, +:fp16+,
-      #   +:fp32+, +:fp64+ (case-insensitive; Redis 8.8+). Reduces memory by
-      #   forcing all values of the array into a fixed floating-point type.
+      #   +:fp32+, +:fp64+ (case-insensitive; Redis 8.8+). All values of the array
+      #   are forced into the fixed floating-point type: +:bf16+/+:fp16+ halve
+      #   memory at reduced precision, while +:fp32+/+:fp64+ keep higher precision.
       # @return [Boolean, String] when +nx+ or +xx+ is given, +true+ on success and +false+
       #   when the condition was not met; otherwise the raw +"OK"+ reply
       # @raise [ArgumentError] if both +nx+ and +xx+ are given (they are mutually exclusive),
       #   or if +fpha+ is not one of the supported types
+      # @raise [Redis::CommandError] if a value in the array does not fit the chosen
+      #   +fpha+ type ("value out of range for ...")
       def json_set(key, path, value, nx: false, xx: false, raw: false, fpha: nil)
         raise ArgumentError, "nx and xx are mutually exclusive" if nx && xx
 

--- a/lib/redis/commands/sorted_sets.rb
+++ b/lib/redis/commands/sorted_sets.rb
@@ -725,7 +725,7 @@ class Redis
       # @param [Hash] options
       #   - `:weights => [Float, Float, ...]`: weights to associate with source
       #   sorted sets
-      #   - `:aggregate => String`: aggregate function to use (sum, min, max, ...)
+      #   - `:aggregate => String`: aggregate function to use (sum, min, max; count since Redis 8.8)
       #   - `:with_scores => true`: include scores in output
       #
       # @return [Array<String>, Array<[String, Float]>]
@@ -748,7 +748,7 @@ class Redis
       # @param [Hash] options
       #   - `:weights => [Array<Float>]`: weights to associate with source
       #   sorted sets
-      #   - `:aggregate => String`: aggregate function to use (sum, min, max)
+      #   - `:aggregate => String`: aggregate function to use (sum, min, max; count since Redis 8.8)
       # @return [Integer] number of elements in the resulting sorted set
       def zinterstore(*args)
         _zsets_operation_store(:zinterstore, *args)
@@ -768,7 +768,7 @@ class Redis
       # @param [Hash] options
       #   - `:weights => [Array<Float>]`: weights to associate with source
       #   sorted sets
-      #   - `:aggregate => String`: aggregate function to use (sum, min, max)
+      #   - `:aggregate => String`: aggregate function to use (sum, min, max; count since Redis 8.8)
       #   - `:with_scores => true`: include scores in output
       #
       # @return [Array<String>, Array<[String, Float]>]
@@ -790,7 +790,7 @@ class Redis
       # @param [Hash] options
       #   - `:weights => [Float, Float, ...]`: weights to associate with source
       #   sorted sets
-      #   - `:aggregate => String`: aggregate function to use (sum, min, max, ...)
+      #   - `:aggregate => String`: aggregate function to use (sum, min, max; count since Redis 8.8)
       # @return [Integer] number of elements in the resulting sorted set
       def zunionstore(*args)
         _zsets_operation_store(:zunionstore, *args)

--- a/test/lint/json.rb
+++ b/test/lint/json.rb
@@ -15,6 +15,37 @@ module Lint
       assert_equal "OK", r.json_set("doc", "$", '{"a":1}', raw: true)
     end
 
+    def test_set_with_fpha_types
+      target_version "8.8" do
+        %i[bf16 fp16 fp32 fp64].each do |type|
+          r.json_del("doc")
+
+          assert_equal "OK", r.json_set("doc", "$", [1.1, 2.2, 3.3], fpha: type),
+                       "expected OK for fpha: #{type.inspect}"
+          assert_kind_of Array, r.json_get("doc", "$").first
+        end
+      end
+    end
+
+    def test_set_with_fpha_accepts_strings_case_insensitively
+      target_version "8.8" do
+        assert_equal "OK", r.json_set("doc", "$", [1.5], fpha: "FP32")
+        assert_equal "OK", r.json_set("doc2", "$", [1.5], fpha: "fp64")
+      end
+    end
+
+    def test_set_with_nx_and_fpha
+      target_version "8.8" do
+        assert_equal true, r.json_set("doc", "$", [1.5], nx: true, fpha: :fp32)
+        assert_equal false, r.json_set("doc", "$", [2.5], nx: true, fpha: :fp32)
+      end
+    end
+
+    def test_set_with_invalid_fpha
+      error = assert_raises(ArgumentError) { r.json_set("doc", "$", [1.5], fpha: :fp99) }
+      assert_equal "fpha accepts only: BF16, FP16, FP32, FP64", error.message
+    end
+
     def test_set_and_get_whole_document
       doc = { "a" => 1, "nested" => { "b" => 2 } }
 

--- a/test/lint/sorted_sets.rb
+++ b/test/lint/sorted_sets.rb
@@ -656,6 +656,50 @@ module Lint
       assert_equal 5, r.zunionstore('{1}baz', %w[{1}foo {1}bar])
     end
 
+    # The COUNT aggregator (Redis 8.8) scores each member by the number of
+    # input sets it appears in. `aggregate:` is passed through to the server
+    # verbatim, so no client-side changes gate these.
+
+    def test_zunion_with_count_aggregate
+      target_version "8.8" do
+        r.zadd '{1}foo', [[1, 'm1'], [2, 'm2'], [3, 'm3']]
+        r.zadd '{1}bar', [[1, 'm1'], [2, 'm2']]
+
+        expected = [['m3', 1.0], ['m1', 2.0], ['m2', 2.0]]
+
+        assert_equal expected, r.zunion('{1}foo', '{1}bar', aggregate: :count, with_scores: true)
+      end
+    end
+
+    def test_zunionstore_with_count_aggregate
+      target_version "8.8" do
+        r.zadd '{1}foo', [[1, 'm1'], [2, 'm2'], [3, 'm3']]
+        r.zadd '{1}bar', [[1, 'm1'], [2, 'm2']]
+
+        assert_equal 3, r.zunionstore('{1}baz', %w[{1}foo {1}bar], aggregate: :count)
+        assert_equal [['m3', 1.0], ['m1', 2.0], ['m2', 2.0]], r.zrange('{1}baz', 0, -1, with_scores: true)
+      end
+    end
+
+    def test_zinter_with_count_aggregate
+      target_version "8.8" do
+        r.zadd '{1}foo', [[1, 'm1'], [2, 'm2'], [3, 'm3']]
+        r.zadd '{1}bar', [[1, 'm1'], [2, 'm2']]
+
+        assert_equal [['m1', 2.0], ['m2', 2.0]], r.zinter('{1}foo', '{1}bar', aggregate: :count, with_scores: true)
+      end
+    end
+
+    def test_zinterstore_with_count_aggregate
+      target_version "8.8" do
+        r.zadd '{1}foo', [[1, 'm1'], [2, 'm2'], [3, 'm3']]
+        r.zadd '{1}bar', [[1, 'm1'], [2, 'm2']]
+
+        assert_equal 2, r.zinterstore('{1}baz', %w[{1}foo {1}bar], aggregate: 'count')
+        assert_equal [['m1', 2.0], ['m2', 2.0]], r.zrange('{1}baz', 0, -1, with_scores: true)
+      end
+    end
+
     def test_zdiff
       target_version("6.2") do
         r.zadd 'foo', 1, 's1'


### PR DESCRIPTION
Added support for new `FPHA` argument for `JSON.SET` and testing with new COUNT aggregator for Sorted Set commands

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, backward-compatible API extensions with client-side validation for `fpha`; sorted-set behavior is server-driven with no new client logic.
> 
> **Overview**
> Adds **Redis 8.8** client support for **`JSON.SET`**’s **`FPHA`** option and documents/tests the sorted-set **`COUNT`** aggregator.
> 
> **`json_set`** now accepts an optional **`fpha:`** keyword (`:bf16`, `:fp16`, `:fp32`, `:fp64`, case-insensitive). Invalid types raise **`ArgumentError`** before the command is sent; valid values append **`FPHA`** and the normalized type to **`JSON.SET`**, including alongside **`nx`** / **`xx`**.
> 
> For **`zinter`**, **`zinterstore`**, **`zunion`**, and **`zunionstore`**, only YARD comments note that **`aggregate:`** may use **`count`** (Redis 8.8+); existing pass-through of **`AGGREGATE`** is unchanged. Lint tests under **`target_version "8.8"`** cover **`fpha`** and **`aggregate: :count`** / **`'count'`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c04099f747bd479ce958b0ec18d4e06c8418fa5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->