### PR TITLE
Added support for remaining HFE commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 - Add `sunioncard` and `sdiffcard` (Redis 8.10). (#1357)
 - `xread` and `xreadgroup` now accept `max_count:` and `max_size:` (Redis 8.10). (#1358)
 - Add `hexpire`, `hpexpire`, `httl` and `hpttl` (Redis 7.4). (#1324, #1325, #1331)
+- Add `hexpireat`, `hpexpireat`, `hexpiretime`, `hpexpiretime` and `hpersist`; `hexpire` and
+  `hpexpire` now accept the `nx:`/`xx:`/`gt:`/`lt:` condition options (Redis 7.4). All are
+  available on `Redis::Distributed`. (#1374)
 - `hscan` and `hscan_each` now accept `novalues: true` (Redis 7.4). (#1327)
 - Add `geosearch` and `geosearchstore` (Redis 6.2); geo commands are now available on
   `Redis::Distributed`. (#1342)

--- a/lib/redis/commands/hashes.rb
+++ b/lib/redis/commands/hashes.rb
@@ -267,15 +267,27 @@ class Redis
       # @example
       #   redis.hset("hash", "f1", "v1")
       #   redis.hexpire("hash", 10, "f1", "f2") # => [1, -2]
+      #   redis.hexpire("hash", 10, "f1", "f2", nx: true) # => [0, -2]
       #
       # @param [String] key
       # @param [Integer] ttl
+      # @param [Hash] options
+      #   - `:nx => true`: Set expiry only when the field has no expiry.
+      #   - `:xx => true`: Set expiry only when the field has an existing expiry.
+      #   - `:gt => true`: Set expiry only when the new expiry is greater than current one.
+      #   - `:lt => true`: Set expiry only when the new expiry is less than current one.
       # @param [Array<String>] fields
       # @return [Array<Integer>] Feedback on if the fields have been updated.
+      # @raise [ArgumentError] when more than one of `:nx`, `:xx`, `:gt`, `:lt` is given
       #
       # See https://redis.io/docs/latest/commands/hexpire/#return-information for array reply.
-      def hexpire(key, ttl, *fields)
-        send_command([:hexpire, key, ttl, 'FIELDS', fields.length, *fields])
+      def hexpire(key, ttl, *fields, nx: nil, xx: nil, gt: nil, lt: nil)
+        fields.flatten!(1)
+        args = [:hexpire, key, Integer(ttl)]
+        args.concat(hash_field_expiration_condition(nx, xx, gt, lt))
+        args.concat(['FIELDS', fields.length, *fields])
+
+        send_command(args)
       end
 
       # Returns the time to live in seconds for one or more fields.
@@ -291,6 +303,7 @@ class Redis
       #
       # See https://redis.io/docs/latest/commands/httl/#return-information for array reply.
       def httl(key, *fields)
+        fields.flatten!(1)
         send_command([:httl, key, 'FIELDS', fields.length, *fields])
       end
 
@@ -310,14 +323,13 @@ class Redis
       #   - `:lt => true`: Set expiry only when the new expiry is less than current one.
       # @param [Array<String>] fields
       # @return [Array<Integer>] Feedback on if the fields have been updated.
+      # @raise [ArgumentError] when more than one of `:nx`, `:xx`, `:gt`, `:lt` is given
       #
       # See https://redis.io/docs/latest/commands/hpexpire/#return-information for array reply.
       def hpexpire(key, ttl, *fields, nx: nil, xx: nil, gt: nil, lt: nil)
-        args = [:hpexpire, key, ttl]
-        args << "NX" if nx
-        args << "XX" if xx
-        args << "GT" if gt
-        args << "LT" if lt
+        fields.flatten!(1)
+        args = [:hpexpire, key, Integer(ttl)]
+        args.concat(hash_field_expiration_condition(nx, xx, gt, lt))
         args.concat(['FIELDS', fields.length, *fields])
 
         send_command(args)
@@ -336,6 +348,7 @@ class Redis
       #
       # See https://redis.io/docs/latest/commands/hpttl/#return-information for array reply.
       def hpttl(key, *fields)
+        fields.flatten!(1)
         send_command([:hpttl, key, 'FIELDS', fields.length, *fields])
       end
 
@@ -357,14 +370,13 @@ class Redis
       #   - `:lt => true`: Set expiry only when the new expiry is less than current one.
       # @param [Array<String>] fields
       # @return [Array<Integer>] Feedback on if the fields have been updated.
+      # @raise [ArgumentError] when more than one of `:nx`, `:xx`, `:gt`, `:lt` is given
       #
       # See https://redis.io/docs/latest/commands/hexpireat/#return-information for array reply.
       def hexpireat(key, unix_time_seconds, *fields, nx: nil, xx: nil, gt: nil, lt: nil)
-        args = [:hexpireat, key, unix_time_seconds]
-        args << "NX" if nx
-        args << "XX" if xx
-        args << "GT" if gt
-        args << "LT" if lt
+        fields.flatten!(1)
+        args = [:hexpireat, key, Integer(unix_time_seconds)]
+        args.concat(hash_field_expiration_condition(nx, xx, gt, lt))
         args.concat(['FIELDS', fields.length, *fields])
 
         send_command(args)
@@ -388,14 +400,13 @@ class Redis
       #   - `:lt => true`: Set expiry only when the new expiry is less than current one.
       # @param [Array<String>] fields
       # @return [Array<Integer>] Feedback on if the fields have been updated.
+      # @raise [ArgumentError] when more than one of `:nx`, `:xx`, `:gt`, `:lt` is given
       #
       # See https://redis.io/docs/latest/commands/hpexpireat/#return-information for array reply.
       def hpexpireat(key, unix_time_milliseconds, *fields, nx: nil, xx: nil, gt: nil, lt: nil)
-        args = [:hpexpireat, key, unix_time_milliseconds]
-        args << "NX" if nx
-        args << "XX" if xx
-        args << "GT" if gt
-        args << "LT" if lt
+        fields.flatten!(1)
+        args = [:hpexpireat, key, Integer(unix_time_milliseconds)]
+        args.concat(hash_field_expiration_condition(nx, xx, gt, lt))
         args.concat(['FIELDS', fields.length, *fields])
 
         send_command(args)
@@ -406,8 +417,8 @@ class Redis
       #
       # @example
       #   redis.hset("hash", "f1", "v1", "f2", "v2")
-      #   redis.hexpireat("hash", 1715705914, "f1")
-      #   redis.hexpiretime("hash", "f1", "f2", "f3") # => [1715705914, -1, -2]
+      #   redis.hexpireat("hash", Time.now.to_i + 100, "f1")
+      #   redis.hexpiretime("hash", "f1", "f2", "f3") # => [<unix timestamp in seconds>, -1, -2]
       #
       # @param [String] key
       # @param [Array<String>] fields
@@ -415,6 +426,7 @@ class Redis
       #
       # See https://redis.io/docs/latest/commands/hexpiretime/#return-information for array reply.
       def hexpiretime(key, *fields)
+        fields.flatten!(1)
         send_command([:hexpiretime, key, 'FIELDS', fields.length, *fields])
       end
 
@@ -423,8 +435,8 @@ class Redis
       #
       # @example
       #   redis.hset("hash", "f1", "v1", "f2", "v2")
-      #   redis.hpexpireat("hash", 1715705913659, "f1")
-      #   redis.hpexpiretime("hash", "f1", "f2", "f3") # => [1715705913659, -1, -2]
+      #   redis.hpexpireat("hash", (Time.now.to_f * 1000).to_i + 100_000, "f1")
+      #   redis.hpexpiretime("hash", "f1", "f2", "f3") # => [<unix timestamp in milliseconds>, -1, -2]
       #
       # @param [String] key
       # @param [Array<String>] fields
@@ -432,7 +444,26 @@ class Redis
       #
       # See https://redis.io/docs/latest/commands/hpexpiretime/#return-information for array reply.
       def hpexpiretime(key, *fields)
+        fields.flatten!(1)
         send_command([:hpexpiretime, key, 'FIELDS', fields.length, *fields])
+      end
+
+      # Removes the expiration from one or more fields, making them persistent.
+      #
+      # @example
+      #   redis.hset("hash", "f1", "v1", "f2", "v2")
+      #   redis.hexpire("hash", 100, "f1")
+      #   redis.hpersist("hash", "f1", "f2", "f3") # => [1, -1, -2]
+      #
+      # @param [String] key
+      # @param [Array<String>] fields
+      # @return [Array<Integer>] `1` when the expiration was removed, `-1` when the
+      #   field has no expiration, `-2` when the field or key does not exist.
+      #
+      # See https://redis.io/docs/latest/commands/hpersist/#return-information for array reply.
+      def hpersist(key, *fields)
+        fields.flatten!(1)
+        send_command([:hpersist, key, 'FIELDS', fields.length, *fields])
       end
 
       # Register an ordered list of hash field names under +fieldset_name+ for
@@ -512,6 +543,21 @@ class Redis
       # @api experimental
       def himport_discard_all
         send_command([:himport, "DISCARDALL"])
+      end
+
+      private
+
+      # The HEXPIRE command family accepts a single optional condition token
+      # (`[NX | XX | GT | LT]`); the server rejects combinations, so fail fast in Ruby.
+      def hash_field_expiration_condition(nx, xx, gt, lt)
+        condition = []
+        condition << "NX" if nx
+        condition << "XX" if xx
+        condition << "GT" if gt
+        condition << "LT" if lt
+        raise ArgumentError, "only one of :nx, :xx, :gt, :lt can be specified" if condition.size > 1
+
+        condition
       end
     end
   end

--- a/lib/redis/commands/hashes.rb
+++ b/lib/redis/commands/hashes.rb
@@ -339,6 +339,102 @@ class Redis
         send_command([:hpttl, key, 'FIELDS', fields.length, *fields])
       end
 
+      # Sets the expiration for one or more fields as an absolute Unix
+      # timestamp in seconds. A timestamp in the past deletes the field
+      # immediately.
+      #
+      # @example
+      #   redis.hset("hash", "f1", "v1")
+      #   redis.hexpireat("hash", Time.now.to_i + 10, "f1", "f2") # => [1, -2]
+      #   redis.hexpireat("hash", Time.now.to_i - 10, "f1") # => [2]
+      #
+      # @param [String] key
+      # @param [Integer] unix_time_seconds absolute expiration timestamp in seconds since epoch
+      # @param [Hash] options
+      #   - `:nx => true`: Set expiry only when the field has no expiry.
+      #   - `:xx => true`: Set expiry only when the field has an existing expiry.
+      #   - `:gt => true`: Set expiry only when the new expiry is greater than current one.
+      #   - `:lt => true`: Set expiry only when the new expiry is less than current one.
+      # @param [Array<String>] fields
+      # @return [Array<Integer>] Feedback on if the fields have been updated.
+      #
+      # See https://redis.io/docs/latest/commands/hexpireat/#return-information for array reply.
+      def hexpireat(key, unix_time_seconds, *fields, nx: nil, xx: nil, gt: nil, lt: nil)
+        args = [:hexpireat, key, unix_time_seconds]
+        args << "NX" if nx
+        args << "XX" if xx
+        args << "GT" if gt
+        args << "LT" if lt
+        args.concat(['FIELDS', fields.length, *fields])
+
+        send_command(args)
+      end
+
+      # Sets the expiration for one or more fields as an absolute Unix
+      # timestamp in milliseconds. A timestamp in the past deletes the field
+      # immediately.
+      #
+      # @example
+      #   redis.hset("hash", "f1", "v1")
+      #   redis.hpexpireat("hash", (Time.now.to_f * 1000).to_i + 500, "f1", "f2") # => [1, -2]
+      #   redis.hpexpireat("hash", (Time.now.to_f * 1000).to_i - 500, "f1") # => [2]
+      #
+      # @param [String] key
+      # @param [Integer] unix_time_milliseconds absolute expiration timestamp in milliseconds since epoch
+      # @param [Hash] options
+      #   - `:nx => true`: Set expiry only when the field has no expiry.
+      #   - `:xx => true`: Set expiry only when the field has an existing expiry.
+      #   - `:gt => true`: Set expiry only when the new expiry is greater than current one.
+      #   - `:lt => true`: Set expiry only when the new expiry is less than current one.
+      # @param [Array<String>] fields
+      # @return [Array<Integer>] Feedback on if the fields have been updated.
+      #
+      # See https://redis.io/docs/latest/commands/hpexpireat/#return-information for array reply.
+      def hpexpireat(key, unix_time_milliseconds, *fields, nx: nil, xx: nil, gt: nil, lt: nil)
+        args = [:hpexpireat, key, unix_time_milliseconds]
+        args << "NX" if nx
+        args << "XX" if xx
+        args << "GT" if gt
+        args << "LT" if lt
+        args.concat(['FIELDS', fields.length, *fields])
+
+        send_command(args)
+      end
+
+      # Returns the expiration time of one or more fields as an absolute Unix
+      # timestamp in seconds.
+      #
+      # @example
+      #   redis.hset("hash", "f1", "v1", "f2", "v2")
+      #   redis.hexpireat("hash", 1715705914, "f1")
+      #   redis.hexpiretime("hash", "f1", "f2", "f3") # => [1715705914, -1, -2]
+      #
+      # @param [String] key
+      # @param [Array<String>] fields
+      # @return [Array<Integer>] Expiration Unix timestamps of the fields in seconds.
+      #
+      # See https://redis.io/docs/latest/commands/hexpiretime/#return-information for array reply.
+      def hexpiretime(key, *fields)
+        send_command([:hexpiretime, key, 'FIELDS', fields.length, *fields])
+      end
+
+      # Returns the expiration time of one or more fields as an absolute Unix
+      # timestamp in milliseconds.
+      #
+      # @example
+      #   redis.hset("hash", "f1", "v1", "f2", "v2")
+      #   redis.hpexpireat("hash", 1715705913659, "f1")
+      #   redis.hpexpiretime("hash", "f1", "f2", "f3") # => [1715705913659, -1, -2]
+      #
+      # @param [String] key
+      # @param [Array<String>] fields
+      # @return [Array<Integer>] Expiration Unix timestamps of the fields in milliseconds.
+      #
+      # See https://redis.io/docs/latest/commands/hpexpiretime/#return-information for array reply.
+      def hpexpiretime(key, *fields)
+        send_command([:hpexpiretime, key, 'FIELDS', fields.length, *fields])
+      end
+
       # Register an ordered list of hash field names under +fieldset_name+ for
       # use by subsequent #himport_set calls on the same connection.
       #

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -1088,8 +1088,15 @@ class Redis
       node_for(key).hgetall(key)
     end
 
-    def hexpire(key, ttl, *fields)
-      node_for(key).hexpire(key, ttl, *fields)
+    # Set the time to live in seconds for one or more hash fields.
+    #
+    # @param [String] key
+    # @param [Integer] ttl
+    # @param [Array<String>] fields
+    # @option options [Boolean] :nx, :xx, :gt, :lt at most one expiry condition
+    # @return [Array<Integer>] per-field feedback, see Redis::Commands::Hashes#hexpire
+    def hexpire(key, ttl, *fields, nx: nil, xx: nil, gt: nil, lt: nil)
+      node_for(key).hexpire(key, ttl, *fields, nx: nx, xx: xx, gt: gt, lt: lt)
     end
 
     def httl(key, *fields)
@@ -1119,20 +1126,57 @@ class Redis
       node_for(key).hpttl(key, *fields)
     end
 
+    # Set the expiration for one or more hash fields as an absolute Unix timestamp
+    # in seconds.
+    #
+    # @param [String] key
+    # @param [Integer] unix_time_seconds absolute expiration timestamp in seconds since epoch
+    # @param [Array<String>] fields
+    # @option options [Boolean] :nx, :xx, :gt, :lt at most one expiry condition
+    # @return [Array<Integer>] per-field feedback, see Redis::Commands::Hashes#hexpireat
     def hexpireat(key, unix_time_seconds, *fields, nx: nil, xx: nil, gt: nil, lt: nil)
       node_for(key).hexpireat(key, unix_time_seconds, *fields, nx: nx, xx: xx, gt: gt, lt: lt)
     end
 
+    # Set the expiration for one or more hash fields as an absolute Unix timestamp
+    # in milliseconds.
+    #
+    # @param [String] key
+    # @param [Integer] unix_time_milliseconds absolute expiration timestamp in milliseconds since epoch
+    # @param [Array<String>] fields
+    # @option options [Boolean] :nx, :xx, :gt, :lt at most one expiry condition
+    # @return [Array<Integer>] per-field feedback, see Redis::Commands::Hashes#hpexpireat
     def hpexpireat(key, unix_time_milliseconds, *fields, nx: nil, xx: nil, gt: nil, lt: nil)
       node_for(key).hpexpireat(key, unix_time_milliseconds, *fields, nx: nx, xx: xx, gt: gt, lt: lt)
     end
 
+    # Get the expiration of one or more hash fields as an absolute Unix timestamp
+    # in seconds.
+    #
+    # @param [String] key
+    # @param [Array<String>] fields
+    # @return [Array<Integer>] per-field timestamps in seconds, see Redis::Commands::Hashes#hexpiretime
     def hexpiretime(key, *fields)
       node_for(key).hexpiretime(key, *fields)
     end
 
+    # Get the expiration of one or more hash fields as an absolute Unix timestamp
+    # in milliseconds.
+    #
+    # @param [String] key
+    # @param [Array<String>] fields
+    # @return [Array<Integer>] per-field timestamps in milliseconds, see Redis::Commands::Hashes#hpexpiretime
     def hpexpiretime(key, *fields)
       node_for(key).hpexpiretime(key, *fields)
+    end
+
+    # Remove the expiration from one or more hash fields, making them persistent.
+    #
+    # @param [String] key
+    # @param [Array<String>] fields
+    # @return [Array<Integer>] per-field feedback, see Redis::Commands::Hashes#hpersist
+    def hpersist(key, *fields)
+      node_for(key).hpersist(key, *fields)
     end
 
     # Register a fieldset on every ring node. Fieldsets are scoped to a physical

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -1119,6 +1119,22 @@ class Redis
       node_for(key).hpttl(key, *fields)
     end
 
+    def hexpireat(key, unix_time_seconds, *fields, nx: nil, xx: nil, gt: nil, lt: nil)
+      node_for(key).hexpireat(key, unix_time_seconds, *fields, nx: nx, xx: xx, gt: gt, lt: lt)
+    end
+
+    def hpexpireat(key, unix_time_milliseconds, *fields, nx: nil, xx: nil, gt: nil, lt: nil)
+      node_for(key).hpexpireat(key, unix_time_milliseconds, *fields, nx: nx, xx: xx, gt: gt, lt: lt)
+    end
+
+    def hexpiretime(key, *fields)
+      node_for(key).hexpiretime(key, *fields)
+    end
+
+    def hpexpiretime(key, *fields)
+      node_for(key).hpexpiretime(key, *fields)
+    end
+
     # Register a fieldset on every ring node. Fieldsets are scoped to a physical
     # connection, so every node that may receive an `himport_set` for a key it
     # owns needs the fieldset on its own connection.

--- a/test/lint/hashes.rb
+++ b/test/lint/hashes.rb
@@ -408,5 +408,80 @@ module Lint
         assert_in_range((now_ms + 370_000)..(now_ms + 400_000), r.hpexpiretime("foo", "f1")[0])
       end
     end
+
+    def test_hpersist
+      target_version "7.4.0" do
+        assert_equal [-2], r.hpersist("foo", "f1")
+
+        r.hset("foo", "f1", "v1", "f2", "v2")
+
+        assert_equal [-1], r.hpersist("foo", "f1")
+
+        r.hexpire("foo", 100, "f1")
+
+        assert_equal [1, -1, -2], r.hpersist("foo", "f1", "f2", "f3")
+        assert_equal [-1], r.httl("foo", "f1")
+      end
+    end
+
+    def test_hexpire_options
+      target_version "7.4.0" do
+        r.hset("foo", "f1", "v1")
+
+        assert_equal [0], r.hexpire("foo", 100, "f1", xx: true)
+        assert_equal [1], r.hexpire("foo", 100, "f1", nx: true)
+        assert_equal [0], r.hexpire("foo", 100, "f1", nx: true)
+        assert_equal [1], r.hexpire("foo", 100, "f1", xx: true)
+
+        assert_equal [0], r.hexpire("foo", 1_000, "f1", lt: true)
+        assert_equal [1], r.hexpire("foo", 50, "f1", lt: true)
+        assert_equal [1], r.hexpire("foo", 1_000, "f1", gt: true)
+        assert_in_range(50..1_000, r.httl("foo", "f1")[0])
+      end
+    end
+
+    def test_hash_field_expiration_condition_is_exclusive
+      # Client-side validation: the HEXPIRE command family accepts a single
+      # condition token, so combinations fail fast without a server round trip.
+      [
+        -> { r.hexpire("foo", 100, "f1", nx: true, xx: true) },
+        -> { r.hpexpire("foo", 100_000, "f1", gt: true, lt: true) },
+        -> { r.hexpireat("foo", Time.now.to_i + 100, "f1", nx: true, gt: true) },
+        -> { r.hpexpireat("foo", (Time.now.to_f * 1000).to_i + 100_000, "f1", xx: true, lt: true) }
+      ].each do |call|
+        assert_raises(ArgumentError) { call.call }
+      end
+    end
+
+    def test_hash_field_expiration_accepts_array_form_fields
+      target_version "7.4.0" do
+        r.hset("foo", "f1", "v1", "f2", "v2")
+
+        # Array-form fields (like hdel) must serialize with the right FIELDS count.
+        assert_equal [1, 1], r.hexpire("foo", 100, %w[f1 f2])
+        assert_equal [1, 1], r.hpexpire("foo", 100_000, %w[f1 f2])
+        assert_equal [1, 1], r.hexpireat("foo", Time.now.to_i + 100, %w[f1 f2])
+        assert_equal [1, 1], r.hpexpireat("foo", (Time.now.to_f * 1000).to_i + 100_000, %w[f1 f2])
+        assert_equal 2, r.httl("foo", %w[f1 f2]).size
+        assert_equal 2, r.hpttl("foo", %w[f1 f2]).size
+        assert_equal 2, r.hexpiretime("foo", %w[f1 f2]).size
+        assert_equal 2, r.hpexpiretime("foo", %w[f1 f2]).size
+        assert_equal [1, 1], r.hpersist("foo", %w[f1 f2])
+      end
+    end
+
+    def test_hash_field_expiration_coerces_time_values
+      target_version "7.4.0" do
+        r.hset("foo", "f1", "v1")
+
+        # Integer-convertible inputs are coerced at the client boundary, like
+        # expire/expireat; non-convertible inputs raise in Ruby, not on the server.
+        assert_equal [1], r.hexpire("foo", "100", "f1")
+        assert_equal [1], r.hexpireat("foo", (Time.now.to_i + 100).to_s, "f1")
+        assert_equal [1], r.hexpireat("foo", Time.now + 100, "f1")
+        assert_equal [1], r.hpexpireat("foo", ((Time.now.to_f * 1000).to_i + 100_000).to_s, "f1")
+        assert_raises(ArgumentError) { r.hexpireat("foo", "tomorrow", "f1") }
+      end
+    end
   end
 end

--- a/test/lint/hashes.rb
+++ b/test/lint/hashes.rb
@@ -294,5 +294,119 @@ module Lint
         assert_in_range(1..400, r.hpttl("foo", "f1")[0])
       end
     end
+
+    def test_hexpireat
+      target_version "7.4.0" do
+        r.hset("foo", "f1", "v2")
+
+        assert_equal [1, -2], r.hexpireat("foo", Time.now.to_i + 400, "f1", "f2")
+        assert_in_range(1..405, r.httl("foo", "f1")[0])
+      end
+    end
+
+    def test_hexpireat_with_past_timestamp
+      target_version "7.4.0" do
+        r.hset("foo", "f1", "v2")
+
+        assert_equal [2], r.hexpireat("foo", Time.now.to_i - 4, "f1")
+        assert_equal [-2], r.httl("foo", "f1")
+      end
+    end
+
+    def test_hexpireat_options
+      target_version "7.4.0" do
+        now = Time.now.to_i
+
+        r.hset("foo", "f1", "v2")
+        assert_equal [0], r.hexpireat("foo", now + 5_000, "f1", xx: true)
+        assert_equal [-1], r.httl("foo", "f1")
+
+        assert_equal [1], r.hexpireat("foo", now + 5_000, "f1", nx: true)
+        assert_in_range(1..5_005, r.httl("foo", "f1")[0])
+        assert_equal [0], r.hexpireat("foo", now + 5_000, "f1", nx: true)
+
+        assert_equal [1], r.hexpireat("foo", now + 5_000, "f1", xx: true)
+
+        assert_equal [0], r.hexpireat("foo", now + 50_000, "f1", lt: true)
+        assert_equal [1], r.hexpireat("foo", now + 500, "f1", lt: true)
+
+        assert_in_range(1..505, r.httl("foo", "f1")[0])
+        assert_equal [1], r.hexpireat("foo", now + 50_000, "f1", gt: true)
+        assert_in_range(500..50_005, r.httl("foo", "f1")[0])
+      end
+    end
+
+    def test_hpexpireat
+      target_version "7.4.0" do
+        r.hset("foo", "f1", "v2")
+
+        now_ms = (Time.now.to_f * 1000).to_i
+        assert_equal [1, -2], r.hpexpireat("foo", now_ms + 400_000, "f1", "f2")
+        assert_in_range(1..405_000, r.hpttl("foo", "f1")[0])
+      end
+    end
+
+    def test_hpexpireat_with_past_timestamp
+      target_version "7.4.0" do
+        r.hset("foo", "f1", "v2")
+
+        assert_equal [2], r.hpexpireat("foo", (Time.now.to_f * 1000).to_i - 4_000, "f1")
+        assert_equal [-2], r.hpttl("foo", "f1")
+      end
+    end
+
+    def test_hpexpireat_options
+      target_version "7.4.0" do
+        now_ms = (Time.now.to_f * 1000).to_i
+
+        r.hset("foo", "f1", "v2")
+        assert_equal [0], r.hpexpireat("foo", now_ms + 5_000_000, "f1", xx: true)
+        assert_equal [-1], r.hpttl("foo", "f1")
+
+        assert_equal [1], r.hpexpireat("foo", now_ms + 5_000_000, "f1", nx: true)
+        assert_in_range(1..5_005_000, r.hpttl("foo", "f1")[0])
+        assert_equal [0], r.hpexpireat("foo", now_ms + 5_000_000, "f1", nx: true)
+
+        assert_equal [1], r.hpexpireat("foo", now_ms + 5_000_000, "f1", xx: true)
+
+        assert_equal [0], r.hpexpireat("foo", now_ms + 50_000_000, "f1", lt: true)
+        assert_equal [1], r.hpexpireat("foo", now_ms + 500_000, "f1", lt: true)
+
+        assert_in_range(1..505_000, r.hpttl("foo", "f1")[0])
+        assert_equal [1], r.hpexpireat("foo", now_ms + 50_000_000, "f1", gt: true)
+        assert_in_range(500_000..50_005_000, r.hpttl("foo", "f1")[0])
+      end
+    end
+
+    def test_hexpiretime
+      target_version "7.4.0" do
+        assert_equal [-2], r.hexpiretime("foo", "f1")
+
+        r.hset("foo", "f1", "v2")
+
+        assert_equal [-1], r.hexpiretime("foo", "f1")
+
+        r.hexpireat("foo", Time.now.to_i + 400, "f1")
+
+        # Tolerate clock movement between the write and the assertion.
+        assert_in_range((Time.now.to_i + 370)..(Time.now.to_i + 400), r.hexpiretime("foo", "f1")[0])
+      end
+    end
+
+    def test_hpexpiretime
+      target_version "7.4.0" do
+        assert_equal [-2], r.hpexpiretime("foo", "f1")
+
+        r.hset("foo", "f1", "v2")
+
+        assert_equal [-1], r.hpexpiretime("foo", "f1")
+
+        r.hpexpireat("foo", (Time.now.to_f * 1000).to_i + 400_000, "f1")
+
+        # Tolerate clock movement between the write and the assertion.
+        now_ms = (Time.now.to_f * 1000).to_i
+        assert_in_range((now_ms + 370_000)..(now_ms + 400_000), r.hpexpiretime("foo", "f1")[0])
+      end
+    end
   end
 end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive client API mapping to Redis 7.4 HFE commands with validation and tests; no changes to auth, persistence, or core connection behavior.
> 
> **Overview**
> Completes **hash field expiration (HFE)** support for Redis 7.4 by adding client methods for the remaining server commands and tightening how existing ones build requests.
> 
> **New commands** on `Redis` (and `Redis::Distributed`): `hexpireat`, `hpexpireat`, `hexpiretime`, `hpexpiretime`, and `hpersist`, with the same per-field array replies and `FIELDS` encoding as `hexpire` / `httl`.
> 
> **`hexpire` and `hpexpire`** now accept optional **`nx:` / `xx:` / `gt:` / `lt:`** (at most one); condition tokens are built via a shared `hash_field_expiration_condition` helper that raises `ArgumentError` on invalid combinations. TTL and absolute timestamps are coerced with `Integer`, and field lists are **`flatten!(1)`** so array-style fields work like `hdel`.
> 
> Lint tests cover absolute expiry, past timestamps, conditional updates, `hpersist`, array fields, and client-side validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e637ce3c82c6430ffcdf8489f9a0eb2170146e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->