### PR TITLE
Restrict RESP3 fallback to unsupported HELLO replies

### DIFF
--- a/lib/redis/client.rb
+++ b/lib/redis/client.rb
@@ -41,7 +41,9 @@ class Redis
       # by redis-client as UnsupportedServer) and any server replying NOPROTO to `HELLO 3`.
       def resp3_unsupported?(error)
         return true if error.is_a?(::RedisClient::UnsupportedServer)
-        return true if error.is_a?(::RedisClient::CommandError) && error.message.include?("NOPROTO")
+        if error.is_a?(::RedisClient::CommandError)
+          return error.command&.first&.casecmp?("HELLO") && error.message.match?(/\ANOPROTO(?: |$)/)
+        end
 
         # Redis::Cluster discovers its topology by connecting to each startup node. When those nodes
         # don't speak RESP3, redis-cluster-client collects the per-node failures and re-raises them


### PR DESCRIPTION
## Summary

Restrict automatic RESP3 → RESP2 fallback to a NOPROTO reply to HELLO, rather than any command error containing that text. An ordinary Lua command can currently execute twice after making a write, solely because its error message contains NOPROTO.

The existing UnsupportedServer and cluster InitialSetupError fallback paths are unchanged.

## Reproduction

Against a disposable local Redis instance, start a client with protocol: 3 and an empty counter:

```ruby
redis.eval("redis.call('INCR', KEYS[1]); return redis.error_reply(ARGV[1])",
           keys: ["repro-counter"], argv: ["application NOPROTO diagnostic"])
```

After rescuing the command error, inspect the counter through a separate client. Before: 2 and the original client is downgraded to protocol 2. After: 1 and protocol 3 remains selected. The same result holds for a custom leading `NOPROTO application error`; checking only the message prefix would not fix that case.

## Verification

- Existing core suite on reviewed master and this individual patch: 752 runs, 6453 assertions, zero failures/errors, 3 skips.
- Existing focused internals/pipeline/transaction/pubsub files: 112 runs, 283 assertions, zero failures/errors, 1 skip.
- Temporary local repros verify both application-error variants.
- The existing RedisMock helper returning `-NOPROTO unsupported protocol version` to HELLO still produces PONG after fallback to RESP2. Existing unknown-HELLO checks also pass.
- Ruby 4.0.6 via rbenv, redis-client 0.30.1, local Redis 8.10.1; targeted RuboCop and syntax/whitespace checks pass.
- Source-only patch; no test files added or modified.

## Limitations and breaking changes

No intended breaking change. Ordinary command errors now propagate once without retry/downgrade. Cluster topology initialization retains its existing message-based handling and was not exercised against a live cluster. JSON modules and live Sentinel topology were not verified. This does not claim general retry/exactly-once guarantees.

Checked current master and existing PRs, including the RESP3 introduction #1351; no overlapping open fix found.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error classification on the hot path for all Redis calls when using protocol 3; wrong matching could break RESP2 fallback for old servers or reintroduce double-execution on application errors.
> 
> **Overview**
> **Tightens when a failed command triggers automatic RESP3 → RESP2 reconnect.** `Client.resp3_unsupported?` no longer treats every `CommandError` whose message contains `NOPROTO` as a handshake failure.
> 
> For `RedisClient::CommandError`, fallback now requires the failing command to be **HELLO** and the message to start with **`NOPROTO`** (prefix match). That stops ordinary command/Lua errors that embed `NOPROTO` in the text from being re-raised for protocol downgrade—which could **retry the command and double side effects** (e.g. an `INCR` running twice).
> 
> **UnsupportedServer** and **cluster `InitialSetupError`** message-based fallback paths are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fede88fe225ef2ff580bb0c96337f4e64745365d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->