### PR TITLE
Filter hash ring positions once when removing a node

### DIFF
--- a/lib/redis/hash_ring.rb
+++ b/lib/redis/hash_ring.rb
@@ -38,8 +38,9 @@ class Redis
       @replicas.times do |i|
         key = server_hash_for("#{node.id}:#{i}")
         @ring.delete(key)
-        @sorted_keys.reject! { |k| k == key }
       end
+      @sorted_keys.select! { |key| @ring.key?(key) }
+      @replicas
     end
 
     # get the node in the hash ring for this key


### PR DESCRIPTION
## Summary

Remove all virtual-node entries from the ring first, then filter sorted positions once. Previously remove_node rescanned the entire sorted array for every replica (160 passes by default).

The ring ordering, hashing, mutable array identity and existing integer return value are preserved.

## Measurement and correctness comparison

Temporary local Ruby 4.0.6 comparison: construct rings with the default 160 replicas per node, Marshal-copy each prepared ring outside the timed region, remove its middle node, and take the median of 20 removals.

| Nodes | Before | After |
| --- | --- | --- |
| 1 | 0.361 ms | 0.106 ms |
| 10 | 5.033 ms | 0.155 ms |
| 100 | 50.270 ms | 0.689 ms |

For each size, compared complete remaining node IDs, sorted positions, ring mappings and routing of 1,000 sample keys: identical SHA-256 fingerprints. Also checked absent-node removal, repeated removal, duplicate-node membership and removal to an empty ring.

This is a local component benchmark, excluding construction/copying, not a production throughput claim.

## Verification

- Existing non-JSON distributed suite on the individual patch: 442 runs, 1532 assertions, zero failures/errors/skips.
- Targeted RuboCop and whitespace checks pass. No new or modified test files.
- Existing JSON distributed checks could not run successfully because the local Redis 8.10.1 build lacks ReJSON; those checks are excluded explicitly from the reported distributed pass.
- Checked current master and related PR search, including historical distributed refactoring #817; no overlapping open optimization found.

## Breaking changes and limitations

No intended breaking change; remove_node still returns the replica count. This preserves existing collision/duplicate semantics rather than redefining ring membership. It does not add concurrent mutation guarantees or change the cost of adding nodes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized algorithm change in consistent-hash ring maintenance with reported equivalence checks and no API change beyond the same return value.
> 
> **Overview**
> **`remove_node`** no longer runs **`@sorted_keys.reject!`** on every virtual replica (160 by default). It deletes all replica keys from **`@ring`** first, then rebuilds **`@sorted_keys`** in one **`select!`** pass keyed off **`@ring`**.
> 
> Ring membership, ordering, routing, and the **`@replicas`** return value stay the same; only removal cost drops from roughly O(replicas × positions) to O(positions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc8fb3688ce185e4b6f9c6a8c1ee6d5705ede065. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->