### PR TITLE
Count flattened aggregate LOAD fields correctly

### DIFF
--- a/lib/redis/commands/modules/search/aggregation.rb
+++ b/lib/redis/commands/modules/search/aggregation.rb
@@ -108,7 +108,8 @@ class Redis
           @steps << if fields.empty?
             ["LOAD", "*"]
           else
-            ["LOAD", fields.size, *fields.flatten]
+            fields.flatten!(1)
+            ["LOAD", fields.size, *fields]
           end
           self
         end


### PR DESCRIPTION
`AggregateRequest#load` accepts nested arrays and flattens them into command arguments, but records the count before flattening. For `load(["@name", "@age"])` it emits `LOAD 1` followed by two fields, so the remaining arguments are parsed incorrectly.

Flatten once before computing the count and building the command.

Verification:
- Standalone model changes `LOAD 1 @name @age` to `LOAD 2 @name @age`.
- Existing offline Search suite: 79 runs / 234 assertions, zero failures/errors.
- Full Redis suite: 656 runs / 6,229 assertions, zero failures/errors, three skips.
- All runtime files compile; targeted RuboCop and whitespace checks pass.

No test files were modified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line behavioral fix in Search aggregation command serialization; no auth, persistence, or broad API surface changes.
> 
> **Overview**
> **`AggregateRequest#load`** now flattens field arguments with `flatten!(1)` before computing the Redis **`LOAD`** count, so nested arrays (e.g. `load(["@name", "@age"])`) emit **`LOAD 2 @name @age`** instead of **`LOAD 1`** with a mismatched argument list.
> 
> Previously the count used the outer arity while `*fields.flatten` expanded in the command, which could break **`FT.AGGREGATE`** parsing on the server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60467d03a61a19c90317d333db6d1c2be475174a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->