### PR TITLE
Added support for Vector Set commands

### DIFF
--- a/cluster/test/commands_on_vector_sets_test.rb
+++ b/cluster/test/commands_on_vector_sets_test.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestClusterCommandsOnVectorSets < Minitest::Test
+  include Helper::Cluster
+  include Lint::VectorSets
+end

--- a/lib/redis/commands.rb
+++ b/lib/redis/commands.rb
@@ -19,6 +19,7 @@ require "redis/commands/sorted_sets"
 require "redis/commands/streams"
 require "redis/commands/strings"
 require "redis/commands/transactions"
+require "redis/commands/vector_sets"
 
 class Redis
   module Commands
@@ -41,12 +42,25 @@ class Redis
     include Streams
     include Strings
     include Transactions
+    include VectorSets
 
     # Commands returning 1 for true and 0 for false may be executed in a pipeline
     # where the method call will return nil. Propagate the nil instead of falsely
     # returning false.
     Boolify = lambda { |value|
       value != 0 unless value.nil?
+    }
+
+    # For commands whose reply is an integer under RESP2 but a native boolean
+    # under RESP3 (e.g. VADD): pass booleans through, boolify integers, and
+    # propagate nil for pipelined calls.
+    BoolifyBoolean = lambda { |value|
+      case value
+      when true, false, nil
+        value
+      else
+        value != 0
+      end
     }
 
     BoolifySet = lambda { |value|
@@ -93,6 +107,14 @@ class Redis
       end
     }
 
+    # Number arrays (e.g. the VEMB vector) arrive as native doubles under
+    # RESP3 but as bulk strings under RESP2; converge on an array of Floats.
+    FloatifyArray = lambda { |value|
+      return value unless value.is_a?(Array)
+
+      value.first.is_a?(String) ? value.map(&Floatify) : value
+    }
+
     FloatifyPair = lambda { |(first, score)|
       [first, Floatify.call(score)]
     }
@@ -120,6 +142,56 @@ class Redis
       reply.each do |field, field_value|
         reply[field] = Floatify.call(field_value) if field.start_with?("avg-")
       end
+    }
+
+    # VEMB RAW: [quantization, blob, l2, (range, q8 only)] with the numeric
+    # fields as bulk strings under RESP2 but doubles under RESP3.
+    HashifyVectorEmbeddingRaw = lambda { |reply|
+      return reply unless reply.is_a?(Array)
+
+      result = {
+        "quantization" => reply[0],
+        "raw" => reply[1],
+        "l2" => Floatify.call(reply[2])
+      }
+      result["range"] = Floatify.call(reply[3]) if reply.size > 3
+      result
+    }
+
+    # Element => score pairs (VSIM WITHSCORES, one VLINKS layer): a native map
+    # with double scores under RESP3, a flat [name, score, ...] array of bulk
+    # strings under RESP2; converge on a Hash of name => Float.
+    HashifyVectorScores = lambda { |reply|
+      case reply
+      when Hash
+        reply
+      when Array
+        reply.each_slice(2).to_h { |name, score| [name, Floatify.call(score)] }
+      else
+        reply
+      end
+    }
+
+    # VSIM WITHSCORES WITHATTRIBS: a native map of name => [double, attrs]
+    # under RESP3, a flat [name, score, attrs, ...] triplet array under RESP2
+    # (attrs is nil for elements without attributes); converge on a Hash of
+    # name => [Float, attrs].
+    HashifyVectorScoresWithAttribs = lambda { |reply|
+      case reply
+      when Hash
+        reply
+      when Array
+        reply.each_slice(3).to_h { |name, score, attrs| [name, [Floatify.call(score), attrs]] }
+      else
+        reply
+      end
+    }
+
+    # VLINKS WITHSCORES: one name => score map per HNSW layer.
+    HashifyVectorLinksWithScores = lambda { |reply|
+      return reply unless reply.is_a?(Array)
+
+      reply.map(&HashifyVectorScores)
     }
 
     HashifyInfo = lambda { |reply|

--- a/lib/redis/commands/vector_sets.rb
+++ b/lib/redis/commands/vector_sets.rb
@@ -112,7 +112,7 @@ class Redis
       #     # => [0.1004752591252327, 1.2000000476837158, 0.5023762512207031]
       # @example Raw internal representation
       #   redis.vemb("mykey", "my-element", raw: true)
-      #     # => { "quantization" => "q8", "raw" => "\x0b\x7f5", "l2" => 1.3038404, "range" => 0.009448819 }
+      #     # => { "quantization" => "int8", "raw" => "\x0b\x7f5", "l2" => 1.3038404, "range" => 0.009448819 }
       #
       # @param [String] key
       # @param [String] element name of the element whose vector to retrieve
@@ -168,7 +168,7 @@ class Redis
       #     # => { "apple" => 0.9998867657923256, ... }
       # @example With scores and attributes
       #   redis.vsim("mykey", element: "apple", with_scores: true, with_attribs: true)
-      #     # => { "apple" => [0.9998867657923256, "{\"len\": 5}"], ... }
+      #     # => { "apple" => [0.9998867657923256, { "len" => 5 }], ... }
       #
       # @param [String] key
       # @param [Hash] options
@@ -177,8 +177,10 @@ class Redis
       #   as the similarity reference
       # @option options [Boolean] :with_scores include the similarity score
       #   (1 identical … 0 opposite) for each result
-      # @option options [Boolean] :with_attribs include the JSON attributes
-      #   (unparsed, nil when absent) for each result
+      # @option options [Boolean] :with_attribs include the attributes for
+      #   each result, parsed with JSON.parse (nil when absent)
+      # @option options [Boolean] :raw return attribute JSON strings as stored
+      #   instead of parsing them
       # @option options [Integer] :count limit the number of results
       # @option options [Float] :epsilon only return elements with a distance
       #   no further than this delta (similarity better than 1 - delta)
@@ -190,12 +192,13 @@ class Redis
       # @option options [Boolean] :nothread run in the main thread
       # @return [Array<String>, Hash] element names; with `with_scores:` a
       #   `{ name => Float }` Hash; with `with_scores:` and `with_attribs:` a
-      #   `{ name => [Float, String] }` Hash; with `with_attribs:` alone a
-      #   `{ name => String }` Hash. Empty when the key does not exist.
+      #   `{ name => [Float, Object] }` Hash; with `with_attribs:` alone a
+      #   `{ name => Object }` Hash (the attributes as JSON strings when
+      #   `raw: true`). Empty when the key does not exist.
       # @raise [Redis::CommandError] if an `element:` reference does not exist
       def vsim(key, vector: nil, element: nil, withscores: false, with_scores: withscores,
-               withattribs: false, with_attribs: withattribs, count: nil, epsilon: nil,
-               ef: nil, filter: nil, filter_ef: nil, truth: nil, nothread: nil)
+               withattribs: false, with_attribs: withattribs, raw: false, count: nil,
+               epsilon: nil, ef: nil, filter: nil, filter_ef: nil, truth: nil, nothread: nil)
         unless vector.nil? ^ element.nil?
           raise ArgumentError, "must provide exactly one of vector or element"
         end
@@ -220,11 +223,25 @@ class Redis
         args << "NOTHREAD" if nothread
 
         if with_scores && with_attribs
-          send_command(args, &HashifyVectorScoresWithAttribs)
+          send_command(args) do |reply|
+            reply = HashifyVectorScoresWithAttribs.call(reply)
+            if raw || !reply.is_a?(Hash)
+              reply
+            else
+              reply.transform_values { |(score, attribs)| [score, attribs && ::JSON.parse(attribs)] }
+            end
+          end
         elsif with_scores
           send_command(args, &HashifyVectorScores)
         elsif with_attribs
-          send_command(args, &Hashify)
+          send_command(args) do |reply|
+            reply = Hashify.call(reply)
+            if raw || !reply.is_a?(Hash)
+              reply
+            else
+              reply.transform_values { |attribs| attribs && ::JSON.parse(attribs) }
+            end
+          end
         else
           send_command(args)
         end

--- a/lib/redis/commands/vector_sets.rb
+++ b/lib/redis/commands/vector_sets.rb
@@ -1,0 +1,390 @@
+# frozen_string_literal: true
+
+require "json"
+
+class Redis
+  module Commands
+    module VectorSets
+      # Add a new element into a vector set, or update its vector if it
+      # already exists.
+      #
+      # The vector can be given as an Array of numbers (sent as `VALUES`), or
+      # as a String holding a little-endian FP32 blob (sent as `FP32`), e.g.
+      # `values.pack("e*")`.
+      #
+      # @example Add an element with an array of values
+      #   redis.vadd("mykey", [0.1, 1.2, 0.5], "my-element")
+      #     # => true
+      # @example Add an element with an FP32 blob
+      #   redis.vadd("mykey", [0.1, 1.2, 0.5].pack("e*"), "my-element")
+      #     # => true
+      # @example Reduce dimensionality and attach attributes
+      #   redis.vadd("mykey", [0.1, 1.2, 0.5], "my-element", reduce: 2, attributes: { size: "large" })
+      #     # => true
+      #
+      # @param [String] key
+      # @param [Array<Numeric>, String] vector the vector as an array of
+      #   numbers, or a little-endian FP32 blob
+      # @param [String] element name of the element being added
+      # @param [Hash] options
+      # @option options [Integer] :reduce project the vector down to this
+      #   number of dimensions
+      # @option options [Boolean] :cas collect neighbor candidates in a
+      #   background thread, check-and-set style
+      # @option options [Symbol, String] :quantization one of `:noquant`,
+      #   `:q8` (the default) or `:bin`
+      # @option options [Integer] :ef build-time exploration factor (default 200)
+      # @option options [Hash, String] :attributes attributes associated with
+      #   the element, as an object serialized to JSON or a pre-encoded JSON string
+      # @option options [Integer] :m maximum number of connections per graph
+      #   node (default 16)
+      # @return [Boolean] whether the element was added
+      def vadd(key, vector, element, reduce: nil, cas: nil, quantization: nil, ef: nil, attributes: nil, m: nil)
+        args = [:vadd, key]
+        args << "REDUCE" << Integer(reduce) if reduce
+
+        if vector.is_a?(String)
+          args << "FP32" << vector
+        else
+          args << "VALUES" << vector.size
+          args.concat(vector.map { |value| Float(value) })
+        end
+
+        args << element
+        args << "CAS" if cas
+
+        if quantization
+          case quantization.to_s.downcase
+          when "noquant" then args << "NOQUANT"
+          when "q8" then args << "Q8"
+          when "bin" then args << "BIN"
+          else raise ArgumentError, "unknown quantization: #{quantization.inspect}"
+          end
+        end
+
+        args << "EF" << Integer(ef) if ef
+
+        if attributes
+          args << "SETATTR" << (attributes.is_a?(String) ? attributes : ::JSON.generate(attributes))
+        end
+
+        args << "M" << Integer(m) if m
+
+        send_command(args, &BoolifyBoolean)
+      end
+
+      # Return the number of elements in a vector set.
+      #
+      # @example
+      #   redis.vcard("mykey")
+      #     # => 2
+      #
+      # @param [String] key
+      # @return [Integer] the number of elements in the vector set, or 0 if
+      #   the key does not exist
+      def vcard(key)
+        send_command([:vcard, key])
+      end
+
+      # Return the number of dimensions of the vectors in a vector set.
+      #
+      # For a vector set created with the `REDUCE` option this reports the
+      # reduced dimension, although full-size vectors must still be used when
+      # querying with VSIM.
+      #
+      # @example
+      #   redis.vdim("mykey")
+      #     # => 3
+      #
+      # @param [String] key
+      # @return [Integer] the dimension of the vectors in the set
+      # @raise [Redis::CommandError] if the key does not exist
+      def vdim(key)
+        send_command([:vdim, key])
+      end
+
+      # Return the approximate vector associated with an element in a vector
+      # set. The round trip is approximate because vectors are normalized and
+      # (by default) quantized on insertion.
+      #
+      # @example
+      #   redis.vemb("mykey", "my-element")
+      #     # => [0.1004752591252327, 1.2000000476837158, 0.5023762512207031]
+      # @example Raw internal representation
+      #   redis.vemb("mykey", "my-element", raw: true)
+      #     # => { "quantization" => "q8", "raw" => "\x0b\x7f5", "l2" => 1.3038404, "range" => 0.009448819 }
+      #
+      # @param [String] key
+      # @param [String] element name of the element whose vector to retrieve
+      # @param [Boolean] raw return the raw internal representation instead
+      # @return [Array<Float>, Hash, nil] the vector as an array of Floats; with
+      #   `raw: true` a Hash with `"quantization"`, `"raw"` (blob), `"l2"` and,
+      #   for q8 sets, `"range"` keys; nil if the key or element does not exist
+      def vemb(key, element, raw: nil)
+        if raw
+          send_command([:vemb, key, element, "RAW"], &HashifyVectorEmbeddingRaw)
+        else
+          send_command([:vemb, key, element], &FloatifyArray)
+        end
+      end
+
+      # Return the neighbors of an element in a vector set, one entry per
+      # layer of the HNSW graph.
+      #
+      # @example
+      #   redis.vlinks("mykey", "elem-1")
+      #     # => [["elem-2"]]
+      # @example With similarity scores
+      #   redis.vlinks("mykey", "elem-1", with_scores: true)
+      #     # => [{ "elem-2" => 0.9989262223243713 }]
+      #
+      # @param [String] key
+      # @param [String] element name of the element whose neighbors to inspect
+      # @param [Boolean] with_scores include similarity scores for each neighbor
+      # @return [Array<Array<String>>, Array<Hash>, nil] one array of neighbor
+      #   names per layer; with scores, one `{ name => Float }` Hash per layer;
+      #   nil if the key or element does not exist
+      def vlinks(key, element, withscores: false, with_scores: withscores)
+        if with_scores
+          send_command([:vlinks, key, element, "WITHSCORES"], &HashifyVectorLinksWithScores)
+        else
+          send_command([:vlinks, key, element])
+        end
+      end
+
+      # Return elements similar to a given vector or element, by approximate
+      # (HNSW) or exact (`truth: true`) similarity search.
+      #
+      # The query is either a vector — an Array of numbers (sent as `VALUES`)
+      # or a little-endian FP32 String blob (sent as `FP32`) — or the name of
+      # an existing element (sent as `ELE`). Exactly one of `vector:` and
+      # `element:` must be given.
+      #
+      # @example Query by element
+      #   redis.vsim("mykey", element: "apple", count: 3)
+      #     # => ["apple", "apples", "pear"]
+      # @example Query by vector, with similarity scores
+      #   redis.vsim("mykey", vector: [0.1, 1.2, 0.5], with_scores: true)
+      #     # => { "apple" => 0.9998867657923256, ... }
+      # @example With scores and attributes
+      #   redis.vsim("mykey", element: "apple", with_scores: true, with_attribs: true)
+      #     # => { "apple" => [0.9998867657923256, "{\"len\": 5}"], ... }
+      #
+      # @param [String] key
+      # @param [Hash] options
+      # @option options [Array<Numeric>, String] :vector the query vector
+      # @option options [String] :element name of an existing element to use
+      #   as the similarity reference
+      # @option options [Boolean] :with_scores include the similarity score
+      #   (1 identical … 0 opposite) for each result
+      # @option options [Boolean] :with_attribs include the JSON attributes
+      #   (unparsed, nil when absent) for each result
+      # @option options [Integer] :count limit the number of results
+      # @option options [Float] :epsilon only return elements with a distance
+      #   no further than this delta (similarity better than 1 - delta)
+      # @option options [Integer] :ef search exploration factor; higher values
+      #   improve recall at the cost of speed
+      # @option options [String] :filter filter expression over element attributes
+      # @option options [Integer] :filter_ef cap on filtering attempts
+      # @option options [Boolean] :truth exact linear scan instead of HNSW (O(N))
+      # @option options [Boolean] :nothread run in the main thread
+      # @return [Array<String>, Hash] element names; with `with_scores:` a
+      #   `{ name => Float }` Hash; with `with_scores:` and `with_attribs:` a
+      #   `{ name => [Float, String] }` Hash; with `with_attribs:` alone a
+      #   `{ name => String }` Hash. Empty when the key does not exist.
+      # @raise [Redis::CommandError] if an `element:` reference does not exist
+      def vsim(key, vector: nil, element: nil, withscores: false, with_scores: withscores,
+               withattribs: false, with_attribs: withattribs, count: nil, epsilon: nil,
+               ef: nil, filter: nil, filter_ef: nil, truth: nil, nothread: nil)
+        unless vector.nil? ^ element.nil?
+          raise ArgumentError, "must provide exactly one of vector or element"
+        end
+
+        args = [:vsim, key]
+        if element
+          args << "ELE" << element
+        elsif vector.is_a?(String)
+          args << "FP32" << vector
+        else
+          args << "VALUES" << vector.size
+          args.concat(vector.map { |value| Float(value) })
+        end
+        args << "WITHSCORES" if with_scores
+        args << "WITHATTRIBS" if with_attribs
+        args << "COUNT" << Integer(count) if count
+        args << "EPSILON" << Float(epsilon) if epsilon
+        args << "EF" << Integer(ef) if ef
+        args << "FILTER" << filter if filter
+        args << "FILTER-EF" << Integer(filter_ef) if filter_ef
+        args << "TRUTH" if truth
+        args << "NOTHREAD" if nothread
+
+        if with_scores && with_attribs
+          send_command(args, &HashifyVectorScoresWithAttribs)
+        elsif with_scores
+          send_command(args, &HashifyVectorScores)
+        elsif with_attribs
+          send_command(args, &Hashify)
+        else
+          send_command(args)
+        end
+      end
+
+      # Remove an element from a vector set. Memory is reclaimed immediately.
+      #
+      # @example
+      #   redis.vrem("mykey", "my-element")
+      #     # => true
+      #
+      # @param [String] key
+      # @param [String] element name of the element to remove
+      # @return [Boolean] whether the element was removed; false if the key or
+      #   element does not exist
+      def vrem(key, element)
+        send_command([:vrem, key, element], &BoolifyBoolean)
+      end
+
+      # Check if an element exists in a vector set.
+      #
+      # @example
+      #   redis.vismember("mykey", "my-element")
+      #     # => true
+      #
+      # @param [String] key
+      # @param [String] element name of the element to check for membership
+      # @return [Boolean] whether the element exists in the vector set; false
+      #   if the key does not exist
+      def vismember(key, element)
+        send_command([:vismember, key, element], &BoolifyBoolean)
+      end
+
+      # Return one or more random elements from a vector set.
+      #
+      # Behaves like SRANDMEMBER: a positive count returns up to that many
+      # distinct elements, a negative count returns exactly that many elements
+      # possibly with duplicates, and a count exceeding the set size returns
+      # the whole set.
+      #
+      # @example
+      #   redis.vrandmember("mykey")
+      #     # => "elem-2"
+      # @example With a count
+      #   redis.vrandmember("mykey", 2)
+      #     # => ["elem-1", "elem-3"]
+      #
+      # @param [String] key
+      # @param [Integer] count number of elements to return; positive for
+      #   distinct elements, negative to allow duplicates
+      # @return [String, Array<String>, nil] a single element (or nil for a
+      #   missing key) without count; an array of elements (empty for a
+      #   missing key) with count
+      def vrandmember(key, count = nil)
+        if count.nil?
+          send_command([:vrandmember, key])
+        else
+          send_command([:vrandmember, key, Integer(count)])
+        end
+      end
+
+      # Return the elements of a vector set within a lexicographical range,
+      # in lexicographical (byte-by-byte) order.
+      #
+      # Boundaries follow the ZRANGEBYLEX syntax: `"[elem"` inclusive,
+      # `"(elem"` exclusive, `"-"` minimum, `"+"` maximum. A negative count
+      # returns all elements in the range. VRANGE is a stateless iterator: to
+      # paginate, pass the last returned element as an exclusive start on the
+      # next call.
+      #
+      # @example All elements
+      #   redis.vrange("mykey", "-", "+")
+      #     # => ["elem-1", "elem-2", "elem-3"]
+      # @example Paginate, two at a time
+      #   redis.vrange("mykey", "-", "+", 2)
+      #     # => ["elem-1", "elem-2"]
+      #   redis.vrange("mykey", "(elem-2", "+", 2)
+      #     # => ["elem-3"]
+      #
+      # @param [String] key
+      # @param [String] start range start: `"[elem"`, `"(elem"` or `"-"`
+      # @param [String] stop range end: `"[elem"`, `"(elem"` or `"+"`
+      # @param [Integer] count maximum number of elements to return; negative
+      #   returns the whole range
+      # @return [Array<String>] the elements in the range, empty if the key
+      #   does not exist
+      def vrange(key, start, stop, count = nil)
+        args = [:vrange, key, start, stop]
+        args << Integer(count) if count
+        send_command(args)
+      end
+
+      # Return metadata and internal details about a vector set, including
+      # size, dimensions, quantization type, and graph structure.
+      #
+      # @example
+      #   redis.vinfo("mykey")
+      #     # => { "quant-type" => "int8", "vector-dim" => 3, "size" => 1, ... }
+      #
+      # @param [String] key
+      # @return [Hash, nil] the vector set metadata, or nil if the key does
+      #   not exist
+      def vinfo(key)
+        send_command([:vinfo, key], &Hashify)
+      end
+
+      # Associate JSON attributes with an element in a vector set, update
+      # them, or delete them. Attributes can be used in filtered similarity
+      # searches with VSIM.
+      #
+      # @example Set attributes from a Hash
+      #   redis.vsetattr("mykey", "my-element", { type: "fruit", color: "red" })
+      #     # => true
+      # @example Delete the attributes
+      #   redis.vsetattr("mykey", "my-element", nil)
+      #     # => true
+      #
+      # @param [String] key
+      # @param [String] element name of the element whose attributes to set
+      # @param [Hash, String, nil] attributes attributes as an object
+      #   serialized to JSON or a pre-encoded JSON string; nil or an empty
+      #   string deletes the attributes
+      # @return [Boolean] whether the attributes were set; false if the key or
+      #   element does not exist
+      def vsetattr(key, element, attributes)
+        json = case attributes
+        when nil then ""
+        when String then attributes
+        else ::JSON.generate(attributes)
+        end
+        send_command([:vsetattr, key, element, json], &BoolifyBoolean)
+      end
+
+      # Return the JSON attributes associated with an element in a vector set.
+      #
+      # By default the reply is parsed with JSON.parse; pass +raw: true+ to get
+      # the JSON string as stored.
+      #
+      # @example
+      #   redis.vgetattr("mykey", "my-element")
+      #     # => { "size" => "large" }
+      # @example Raw JSON string
+      #   redis.vgetattr("mykey", "my-element", raw: true)
+      #     # => "{\"size\": \"large\"}"
+      #
+      # @param [String] key
+      # @param [String] element name of the element whose attributes to retrieve
+      # @param [Boolean] raw return the JSON string without parsing it
+      # @return [Object, String, nil] the parsed attributes (or the JSON string
+      #   with +raw: true+); nil if the key or element does not exist or has no
+      #   attributes
+      def vgetattr(key, element, raw: false)
+        send_command([:vgetattr, key, element]) do |reply|
+          if reply.nil? || raw
+            reply
+          else
+            ::JSON.parse(reply)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -1356,6 +1356,71 @@ class Redis
       on_each_node(:script, subcommand, *args)
     end
 
+    # Add a new element into a vector set, or update its vector if it already exists.
+    def vadd(key, vector, element, **options)
+      node_for(key).vadd(key, vector, element, **options)
+    end
+
+    # Return the number of elements in a vector set.
+    def vcard(key)
+      node_for(key).vcard(key)
+    end
+
+    # Return the number of dimensions of the vectors in a vector set.
+    def vdim(key)
+      node_for(key).vdim(key)
+    end
+
+    # Return the approximate vector associated with an element in a vector set.
+    def vemb(key, element, **options)
+      node_for(key).vemb(key, element, **options)
+    end
+
+    # Associate, update or delete the JSON attributes of an element in a vector set.
+    def vsetattr(key, element, attributes)
+      node_for(key).vsetattr(key, element, attributes)
+    end
+
+    # Return the JSON attributes associated with an element in a vector set.
+    def vgetattr(key, element, **options)
+      node_for(key).vgetattr(key, element, **options)
+    end
+
+    # Return elements of a vector set by vector similarity.
+    def vsim(key, **options)
+      node_for(key).vsim(key, **options)
+    end
+
+    # Remove an element from a vector set.
+    def vrem(key, element)
+      node_for(key).vrem(key, element)
+    end
+
+    # Check if an element exists in a vector set.
+    def vismember(key, element)
+      node_for(key).vismember(key, element)
+    end
+
+    # Return the neighbors of an element at each layer in the HNSW graph.
+    def vlinks(key, element, **options)
+      node_for(key).vlinks(key, element, **options)
+    end
+
+    # Return metadata and internal details about a vector set.
+    def vinfo(key)
+      node_for(key).vinfo(key)
+    end
+
+    # Return one or more random elements from a vector set.
+    def vrandmember(key, count = nil)
+      node_for(key).vrandmember(key, count)
+    end
+
+    # Return elements of a vector set in a lexicographical range.
+    def vrange(key, start, stop, count = nil)
+      node_for(key).vrange(key, start, stop, count)
+    end
+
     # Set one or more contiguous values starting at an index in an array.
     def arset(key, index, *values)
       node_for(key).arset(key, index, *values)

--- a/test/distributed/commands_on_vector_sets_test.rb
+++ b/test/distributed/commands_on_vector_sets_test.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestDistributedCommandsOnVectorSets < Minitest::Test
+  include Helper::Distributed
+  include Lint::VectorSets
+end

--- a/test/lint/vector_sets.rb
+++ b/test/lint/vector_sets.rb
@@ -1,0 +1,499 @@
+# frozen_string_literal: true
+
+module Lint
+  module VectorSets
+    def test_vadd
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element")
+        assert_equal false, r.vadd("foo", [0.1, 1.2, 0.5], "element")
+      end
+    end
+
+    def test_vadd_with_fp32_blob
+      target_version "8.0" do
+        blob = [0.1, 1.2, 0.5].pack("e*")
+        assert_equal true, r.vadd("foo", blob, "element")
+        assert_equal false, r.vadd("foo", blob, "element")
+      end
+    end
+
+    def test_vadd_with_reduce
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5, 0.8], "element", reduce: 2)
+      end
+    end
+
+    def test_vadd_with_quantization
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element", quantization: :noquant)
+        assert_equal true, r.vadd("bar", [0.1, 1.2, 0.5], "element", quantization: :q8)
+        assert_equal true, r.vadd("baz", [0.1, 1.2, 0.5], "element", quantization: :bin)
+      end
+    end
+
+    def test_vadd_with_unknown_quantization
+      assert_raises(ArgumentError) do
+        r.vadd("foo", [0.1, 1.2, 0.5], "element", quantization: :int4)
+      end
+    end
+
+    def test_vadd_with_cas_ef_and_m
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element", cas: true, ef: 300, m: 32)
+      end
+    end
+
+    def test_vcard
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element-1")
+        assert_equal 1, r.vcard("foo")
+        assert_equal true, r.vadd("foo", [0.3, 0.4, 0.5], "element-2")
+        assert_equal 2, r.vcard("foo")
+      end
+    end
+
+    def test_vcard_with_missing_key
+      target_version "8.0" do
+        assert_equal 0, r.vcard("missing")
+      end
+    end
+
+    def test_vdim
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element")
+        assert_equal 3, r.vdim("foo")
+      end
+    end
+
+    def test_vdim_with_reduce
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5, 0.8], "element", reduce: 2)
+        assert_equal 2, r.vdim("foo")
+      end
+    end
+
+    def test_vdim_with_missing_key
+      target_version "8.0" do
+        assert_raises(Redis::CommandError) { r.vdim("missing") }
+      end
+    end
+
+    def test_vemb
+      target_version "8.0" do
+        values = [0.1, 1.2, 0.5]
+        assert_equal true, r.vadd("foo", values, "element")
+
+        vector = r.vemb("foo", "element")
+        assert_equal 3, vector.size
+        vector.zip(values) do |actual, expected|
+          assert_kind_of Float, actual
+          assert_in_delta expected, actual, 0.05
+        end
+      end
+    end
+
+    def test_vemb_with_noquant
+      target_version "8.0" do
+        values = [0.1, 1.2, 0.5]
+        assert_equal true, r.vadd("foo", values, "element", quantization: :noquant)
+
+        vector = r.vemb("foo", "element")
+        vector.zip(values) do |actual, expected|
+          assert_in_delta expected, actual, 0.001
+        end
+      end
+    end
+
+    def test_vemb_with_missing_element_or_key
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element")
+        assert_nil r.vemb("foo", "missing")
+        assert_nil r.vemb("missing", "element")
+      end
+    end
+
+    def test_vemb_raw
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element")
+
+        reply = r.vemb("foo", "element", raw: true)
+        assert_equal "int8", reply["quantization"]
+        assert_kind_of String, reply["raw"]
+        assert_kind_of Float, reply["l2"]
+        assert_kind_of Float, reply["range"]
+      end
+    end
+
+    def test_vemb_raw_with_noquant
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element", quantization: :noquant)
+
+        reply = r.vemb("foo", "element", raw: true)
+        assert_equal "f32", reply["quantization"]
+        refute reply.key?("range")
+        # The blob holds the normalized vector as little-endian FP32.
+        normalized = reply["raw"].unpack("e*")
+        assert_equal 3, normalized.size
+        normalized.zip([0.1, 1.2, 0.5]) do |actual, expected|
+          assert_in_delta expected / reply["l2"], actual, 0.001
+        end
+      end
+    end
+
+    def test_vgetattr
+      target_version "8.0" do
+        attributes = { "size" => "large", "price" => 18.99 }
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element", attributes: attributes)
+        assert_equal attributes, r.vgetattr("foo", "element")
+      end
+    end
+
+    def test_vgetattr_raw
+      target_version "8.0" do
+        attributes = { "size" => "large" }
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element", attributes: attributes)
+
+        reply = r.vgetattr("foo", "element", raw: true)
+        assert_kind_of String, reply
+        assert_equal attributes, JSON.parse(reply)
+      end
+    end
+
+    def test_vgetattr_with_no_attributes
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element")
+        assert_nil r.vgetattr("foo", "element")
+      end
+    end
+
+    def test_vgetattr_with_missing_element_or_key
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element")
+        assert_nil r.vgetattr("foo", "missing")
+        assert_nil r.vgetattr("missing", "element")
+      end
+    end
+
+    def test_vinfo
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element")
+
+        info = r.vinfo("foo")
+        assert_kind_of Hash, info
+        assert_equal "int8", info["quant-type"]
+        assert_equal 3, info["vector-dim"]
+        assert_equal 1, info["size"]
+      end
+    end
+
+    def test_vinfo_with_noquant
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element", quantization: :noquant)
+        assert_equal "f32", r.vinfo("foo")["quant-type"]
+      end
+    end
+
+    def test_vinfo_with_missing_key
+      target_version "8.0" do
+        assert_nil r.vinfo("missing")
+      end
+    end
+
+    def test_vismember
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element")
+        assert_equal true, r.vismember("foo", "element")
+        assert_equal false, r.vismember("foo", "missing")
+      end
+    end
+
+    def test_vismember_with_missing_key
+      target_version "8.0" do
+        assert_equal false, r.vismember("missing", "element")
+      end
+    end
+
+    def test_vlinks
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "elem-1")
+        assert_equal true, r.vadd("foo", [0.2, 1.1, 0.4], "elem-2")
+        assert_equal true, r.vadd("foo", [0.3, 1.0, 0.3], "elem-3")
+
+        layers = r.vlinks("foo", "elem-1")
+        assert_kind_of Array, layers
+        layers.each { |layer| assert_kind_of Array, layer }
+        # Which layers an element occupies is probabilistic, so assert on the
+        # union of neighbors across layers.
+        assert_equal %w[elem-2 elem-3], layers.flatten.uniq.sort
+      end
+    end
+
+    def test_vlinks_with_scores
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "elem-1")
+        assert_equal true, r.vadd("foo", [0.2, 1.1, 0.4], "elem-2")
+        assert_equal true, r.vadd("foo", [0.3, 1.0, 0.3], "elem-3")
+
+        layers = r.vlinks("foo", "elem-1", with_scores: true)
+        layers.each { |layer| assert_kind_of Hash, layer }
+        neighbors = layers.reduce({}, :merge)
+        assert_equal %w[elem-2 elem-3], neighbors.keys.sort
+        neighbors.each_value { |score| assert_kind_of Float, score }
+      end
+    end
+
+    def test_vlinks_with_missing_element_or_key
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element")
+        assert_nil r.vlinks("foo", "missing")
+        assert_nil r.vlinks("missing", "element")
+      end
+    end
+
+    def test_vrandmember
+      target_version "8.0" do
+        elements = %w[elem-1 elem-2 elem-3]
+        elements.each_with_index do |element, i|
+          assert_equal true, r.vadd("foo", [i, 1.0, 0.5], element)
+        end
+
+        assert_includes elements, r.vrandmember("foo")
+      end
+    end
+
+    def test_vrandmember_with_positive_count
+      target_version "8.0" do
+        elements = %w[elem-1 elem-2 elem-3]
+        elements.each_with_index do |element, i|
+          assert_equal true, r.vadd("foo", [i, 1.0, 0.5], element)
+        end
+
+        sample = r.vrandmember("foo", 2)
+        assert_equal 2, sample.size
+        assert_equal sample.uniq, sample
+        sample.each { |element| assert_includes elements, element }
+
+        # A count larger than the set returns the whole set.
+        assert_equal elements, r.vrandmember("foo", 10).sort
+      end
+    end
+
+    def test_vrandmember_with_negative_count
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element")
+
+        sample = r.vrandmember("foo", -5)
+        assert_equal ["element"] * 5, sample
+      end
+    end
+
+    def test_vrandmember_with_missing_key
+      target_version "8.0" do
+        assert_nil r.vrandmember("missing")
+        assert_equal [], r.vrandmember("missing", 3)
+      end
+    end
+
+    def test_vrange
+      target_version "8.4" do
+        %w[elem-1 elem-2 elem-3].each_with_index do |element, i|
+          assert_equal true, r.vadd("foo", [i, 1.0, 0.5], element)
+        end
+
+        assert_equal %w[elem-1 elem-2 elem-3], r.vrange("foo", "-", "+")
+        assert_equal %w[elem-1 elem-2 elem-3], r.vrange("foo", "-", "+", -1)
+      end
+    end
+
+    def test_vrange_with_boundaries
+      target_version "8.4" do
+        %w[elem-1 elem-2 elem-3].each_with_index do |element, i|
+          assert_equal true, r.vadd("foo", [i, 1.0, 0.5], element)
+        end
+
+        assert_equal %w[elem-2 elem-3], r.vrange("foo", "[elem-2", "+")
+        assert_equal %w[elem-3], r.vrange("foo", "(elem-2", "+")
+        assert_equal %w[elem-1 elem-2], r.vrange("foo", "-", "(elem-3")
+      end
+    end
+
+    def test_vrange_with_count_iteration
+      target_version "8.4" do
+        %w[elem-1 elem-2 elem-3].each_with_index do |element, i|
+          assert_equal true, r.vadd("foo", [i, 1.0, 0.5], element)
+        end
+
+        page = r.vrange("foo", "-", "+", 2)
+        assert_equal %w[elem-1 elem-2], page
+        assert_equal %w[elem-3], r.vrange("foo", "(#{page.last}", "+", 2)
+      end
+    end
+
+    def test_vrange_with_missing_key
+      target_version "8.4" do
+        assert_equal [], r.vrange("missing", "-", "+")
+      end
+    end
+
+    def test_vrem
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "elem-1")
+        assert_equal true, r.vadd("foo", [0.2, 1.1, 0.4], "elem-2")
+
+        assert_equal true, r.vrem("foo", "elem-1")
+        assert_equal false, r.vismember("foo", "elem-1")
+        assert_equal 1, r.vcard("foo")
+        assert_equal false, r.vrem("foo", "elem-1")
+      end
+    end
+
+    def test_vrem_with_missing_element_or_key
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element")
+        assert_equal false, r.vrem("foo", "missing")
+        assert_equal false, r.vrem("missing", "element")
+      end
+    end
+
+    def test_vrem_last_element_deletes_the_key
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element")
+        assert_equal true, r.vrem("foo", "element")
+        assert_equal 0, r.vcard("foo")
+        assert_equal false, r.exists?("foo")
+      end
+    end
+
+    def test_vsetattr
+      target_version "8.0" do
+        attributes = { "type" => "fruit", "color" => "red" }
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element")
+        assert_equal true, r.vsetattr("foo", "element", attributes)
+        assert_equal attributes, r.vgetattr("foo", "element")
+      end
+    end
+
+    def test_vsetattr_overwrites_existing_attributes
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element", attributes: { "size" => "large" })
+        assert_equal true, r.vsetattr("foo", "element", { "size" => "small" })
+        assert_equal({ "size" => "small" }, r.vgetattr("foo", "element"))
+      end
+    end
+
+    def test_vsetattr_with_json_string
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element")
+        assert_equal true, r.vsetattr("foo", "element", '{"size": "large"}')
+        assert_equal({ "size" => "large" }, r.vgetattr("foo", "element"))
+      end
+    end
+
+    def test_vsetattr_deletes_attributes
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element", attributes: { "size" => "large" })
+        assert_equal true, r.vsetattr("foo", "element", nil)
+        assert_nil r.vgetattr("foo", "element")
+
+        assert_equal true, r.vsetattr("foo", "element", { "size" => "small" })
+        assert_equal true, r.vsetattr("foo", "element", "")
+        assert_nil r.vgetattr("foo", "element")
+      end
+    end
+
+    def test_vsetattr_with_missing_element_or_key
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element")
+        assert_equal false, r.vsetattr("foo", "missing", { "a" => 1 })
+        assert_equal false, r.vsetattr("missing", "element", { "a" => 1 })
+      end
+    end
+
+    def test_vsim
+      target_version "8.0" do
+        add_vsim_fixture
+        assert_equal %w[a b c], r.vsim("foo", element: "a")
+        assert_equal %w[a b c], r.vsim("foo", vector: [1.0, 0.0, 0.0])
+        assert_equal %w[a b c], r.vsim("foo", vector: [1.0, 0.0, 0.0].pack("e*"))
+      end
+    end
+
+    def test_vsim_with_scores
+      target_version "8.0" do
+        add_vsim_fixture
+
+        scores = r.vsim("foo", element: "a", with_scores: true)
+        assert_equal %w[a b c], scores.keys
+        assert_in_delta 1.0, scores["a"], 0.001
+        scores.each_value { |score| assert_kind_of Float, score }
+      end
+    end
+
+    def test_vsim_with_scores_and_attribs
+      target_version "8.0" do
+        add_vsim_fixture
+
+        results = r.vsim("foo", element: "a", with_scores: true, with_attribs: true)
+        assert_equal %w[a b c], results.keys
+        score, attribs = results["a"]
+        assert_in_delta 1.0, score, 0.001
+        assert_equal({ "n" => 1 }, JSON.parse(attribs))
+        assert_nil results["b"][1]
+      end
+    end
+
+    def test_vsim_with_attribs
+      target_version "8.0" do
+        add_vsim_fixture
+
+        results = r.vsim("foo", element: "a", with_attribs: true)
+        assert_equal({ "n" => 1 }, JSON.parse(results["a"]))
+        assert_nil results["b"]
+        assert_equal({ "n" => 3 }, JSON.parse(results["c"]))
+      end
+    end
+
+    def test_vsim_with_options
+      target_version "8.0" do
+        add_vsim_fixture
+        assert_equal %w[a b], r.vsim("foo", element: "a", count: 2)
+        assert_equal %w[a b c], r.vsim("foo", element: "a", truth: true, nothread: true, ef: 300)
+        # Only elements closer than the epsilon distance qualify.
+        assert_equal %w[a b], r.vsim("foo", element: "a", epsilon: 0.4)
+      end
+    end
+
+    def test_vsim_with_filter
+      target_version "8.0" do
+        add_vsim_fixture
+        assert_equal %w[c], r.vsim("foo", element: "a", filter: ".n == 3")
+        assert_equal %w[a c], r.vsim("foo", element: "a", filter: ".n >= 1", filter_ef: 100)
+      end
+    end
+
+    def test_vsim_requires_exactly_one_query_form
+      assert_raises(ArgumentError) { r.vsim("foo") }
+      assert_raises(ArgumentError) { r.vsim("foo", vector: [1.0], element: "a") }
+    end
+
+    def test_vsim_with_missing_key
+      target_version "8.0" do
+        assert_equal [], r.vsim("missing", vector: [1.0, 0.0, 0.0])
+        assert_equal({}, r.vsim("missing", vector: [1.0, 0.0, 0.0], with_scores: true))
+      end
+    end
+
+    def add_vsim_fixture
+      assert_equal true, r.vadd("foo", [1.0, 0.0, 0.0], "a", attributes: { "n" => 1 })
+      assert_equal true, r.vadd("foo", [0.9, 0.1, 0.0], "b")
+      assert_equal true, r.vadd("foo", [0.0, 1.0, 0.0], "c", attributes: { "n" => 3 })
+    end
+
+    def test_vadd_with_attributes
+      target_version "8.0" do
+        assert_equal true, r.vadd("foo", [0.1, 1.2, 0.5], "element", attributes: { "size" => "large" })
+        assert_equal true, r.vadd("bar", [0.1, 1.2, 0.5], "element", attributes: '{"size": "small"}')
+      end
+    end
+  end
+end

--- a/test/lint/vector_sets.rb
+++ b/test/lint/vector_sets.rb
@@ -430,26 +430,34 @@ module Lint
     end
 
     def test_vsim_with_scores_and_attribs
-      target_version "8.0" do
+      target_version "8.0.3" do
         add_vsim_fixture
 
         results = r.vsim("foo", element: "a", with_scores: true, with_attribs: true)
         assert_equal %w[a b c], results.keys
         score, attribs = results["a"]
         assert_in_delta 1.0, score, 0.001
-        assert_equal({ "n" => 1 }, JSON.parse(attribs))
+        assert_equal({ "n" => 1 }, attribs)
         assert_nil results["b"][1]
+
+        raw_results = r.vsim("foo", element: "a", with_scores: true, with_attribs: true, raw: true)
+        assert_equal({ "n" => 1 }, JSON.parse(raw_results["a"][1]))
+        assert_nil raw_results["b"][1]
       end
     end
 
     def test_vsim_with_attribs
-      target_version "8.0" do
+      target_version "8.0.3" do
         add_vsim_fixture
 
         results = r.vsim("foo", element: "a", with_attribs: true)
-        assert_equal({ "n" => 1 }, JSON.parse(results["a"]))
+        assert_equal({ "n" => 1 }, results["a"])
         assert_nil results["b"]
-        assert_equal({ "n" => 3 }, JSON.parse(results["c"]))
+        assert_equal({ "n" => 3 }, results["c"])
+
+        raw_results = r.vsim("foo", element: "a", with_attribs: true, raw: true)
+        assert_equal({ "n" => 1 }, JSON.parse(raw_results["a"]))
+        assert_nil raw_results["b"]
       end
     end
 

--- a/test/redis/commands_on_vector_sets_test.rb
+++ b/test/redis/commands_on_vector_sets_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestCommandsOnVectorSets < Minitest::Test
+  include Helper::Client
+  include Lint::VectorSets
+
+  def test_vadd_in_pipeline
+    target_version "8.0" do
+      first, second = r.pipelined do |pipe|
+        pipe.vadd("foo", [0.1, 1.2, 0.5], "element")
+        pipe.vadd("foo", [0.1, 1.2, 0.5], "element")
+      end
+
+      assert_equal true, first
+      assert_equal false, second
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for Vector Set commands family was introduced in Redis 8.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and reply-shaping only; no changes to existing command behavior beyond new shared conversion lambdas used by vector-set replies.
> 
> **Overview**
> Adds **client support for Redis 8.0+ vector set commands**, exposing Ruby methods for insert/update (`vadd`), similarity search (`vsim`), membership, removal, metadata (`vinfo`, `vdim`, `vcard`), embeddings (`vemb`), HNSW neighbors (`vlinks`), lex range scan (`vrange`), random sampling, and JSON element attributes (`vsetattr` / `vgetattr`).
> 
> The new `Commands::VectorSets` module builds RESP argument lists (numeric `VALUES`, FP32 blobs, quantization, filters, etc.) and normalizes replies across **RESP2 and RESP3** via shared helpers in `commands.rb` (`BoolifyBoolean`, `FloatifyArray`, score/embedding hashifiers). **`Redis::Distributed`** gains key-routed wrappers for the same API.
> 
> Coverage is a shared **`Lint::VectorSets`** suite exercised from standalone, distributed, and cluster tests, plus a pipeline test for boolean coercion on `vadd`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2bdabfb002dd3c7c672bd3494f0d93402b9ff90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->