### PR TITLE
Added support for Redis functions (7.0)

### DIFF
--- a/cluster/test/commands_on_scripting_test.rb
+++ b/cluster/test/commands_on_scripting_test.rb
@@ -51,4 +51,71 @@ class TestClusterCommandsOnScripting < Minitest::Test
   def test_script_load
     assert_equal 'e0e1f9fabfc9d4800c877a703b823ac0578ff8db', redis.script(:load, 'return 1')
   end
+
+  FUNCTIONS_LIB = <<~LUA
+    #!lua name=mylib
+    local function myfunc(keys, args)
+      return { keys, args }
+    end
+    redis.register_function('myfunc', myfunc)
+    redis.register_function{function_name='myfunc_ro', callback=myfunc, flags={'no-writes'}}
+  LUA
+
+  def load_functions
+    redis.function(:flush)
+    redis.function(:load, FUNCTIONS_LIB)
+  end
+
+  def test_function_load_list_delete
+    target_version '7.0.0' do
+      redis.function(:flush)
+
+      # FUNCTION LOAD carries the all_shards/all_succeeded command tips, so the
+      # cluster client fans it out to every primary and returns a single reply.
+      assert_equal 'mylib', redis.function(:load, FUNCTIONS_LIB)
+      assert_equal 'mylib', redis.function(:load, FUNCTIONS_LIB, replace: true)
+
+      libraries = redis.function(:list)
+      assert_equal(['mylib'], libraries.map { |library| library['library_name'] })
+      assert_equal %w[myfunc myfunc_ro], libraries.first['functions'].map { |function| function['name'] }.sort
+
+      assert_equal 'OK', redis.function(:delete, 'mylib')
+      assert_equal [], redis.function(:list)
+    end
+  end
+
+  def test_function_stats
+    target_version '7.0.0' do
+      load_functions
+
+      stats = redis.function(:stats)
+      assert_nil stats['running_script']
+      assert stats['engines'].key?('LUA')
+    end
+  end
+
+  def test_fcall
+    target_version '7.0.0' do
+      load_functions
+
+      keys = %w[key1 key2]
+      assert_raises(Redis::CommandError, "CROSSSLOT Keys in request don't hash to the same slot") do
+        redis.fcall('myfunc', keys: keys, argv: %w[a1])
+      end
+
+      keys = %w[{key}1 {key}2]
+      assert_equal [keys, %w[a1]], redis.fcall('myfunc', keys: keys, argv: %w[a1])
+    end
+  end
+
+  def test_fcall_ro
+    target_version '7.0.0' do
+      load_functions
+
+      assert_equal [%w[{key}1], %w[a1]], redis.fcall_ro('myfunc_ro', keys: %w[{key}1], argv: %w[a1])
+
+      # myfunc is not registered with the no-writes flag.
+      assert_raises(Redis::CommandError) { redis.fcall_ro('myfunc', keys: %w[{key}1]) }
+    end
+  end
 end

--- a/lib/redis/commands.rb
+++ b/lib/redis/commands.rb
@@ -226,6 +226,34 @@ class Redis
       reply.map { |str| HashifyClusterNodeInfo.call(str) }
     }
 
+    # FUNCTION LIST: RESP2 replies with a flat [k, v, ...] array per library (and per
+    # function within it); RESP3 already returns maps. Converge on nested Hashes.
+    HashifyFunctionList = lambda { |reply|
+      reply.map do |library|
+        library = library.each_slice(2).to_h unless library.is_a?(Hash)
+        library["functions"] = library["functions"].map do |function|
+          function.is_a?(Hash) ? function : function.each_slice(2).to_h
+        end
+        library
+      end
+    }
+
+    # FUNCTION STATS: RESP2 replies with nested flat [k, v, ...] arrays; RESP3 with maps.
+    HashifyFunctionStats = lambda { |reply|
+      reply = reply.each_slice(2).to_h unless reply.is_a?(Hash)
+
+      running = reply["running_script"]
+      reply["running_script"] = running.each_slice(2).to_h if running.is_a?(Array)
+
+      engines = reply["engines"]
+      engines = engines.each_slice(2).to_h unless engines.is_a?(Hash)
+      reply["engines"] = engines.transform_values do |stats|
+        stats.is_a?(Hash) ? stats : stats.each_slice(2).to_h
+      end
+
+      reply
+    }
+
     Noop = ->(reply) { reply }
 
     # Sends a command to Redis and returns its reply.

--- a/lib/redis/commands/scripting.rb
+++ b/lib/redis/commands/scripting.rb
@@ -97,6 +97,115 @@ class Redis
         _eval(:evalsha, args)
       end
 
+      # Manage Redis Functions libraries.
+      #
+      # @example Load a library
+      #   redis.function(:load, "#!lua name=mylib\n...")
+      #     # => "mylib"
+      # @example Replace an existing library
+      #   redis.function(:load, code, replace: true)
+      #     # => "mylib"
+      # @example List loaded libraries
+      #   redis.function(:list)
+      #     # => [{ "library_name" => "mylib", "engine" => "LUA", "functions" => [...] }]
+      # @example List one library including its source code
+      #   redis.function(:list, libraryname: "mylib", withcode: true)
+      # @example Delete a library
+      #   redis.function(:delete, "mylib")
+      #     # => "OK"
+      # @example Dump and restore all libraries
+      #   payload = redis.function(:dump)
+      #   redis.function(:restore, payload, policy: :replace)
+      #     # => "OK"
+      # @example Get engine and running-function statistics
+      #   redis.function(:stats)
+      #     # => { "running_script" => nil,
+      #     #      "engines" => { "LUA" => { "libraries_count" => 1, "functions_count" => 2 } } }
+      # @example Kill the currently running function
+      #   redis.function(:kill)
+      #     # => "OK"
+      #
+      # @param [String, Symbol] subcommand e.g. `load`, `delete`, `flush`, `list`, `dump`, `restore`, `stats`, `kill`
+      # @param [Array<String>] args depends on subcommand
+      # @param [Hash] options
+      #   - `:replace => true`: (`load`) overwrite an existing library of the same name
+      #   - `:libraryname => String`: (`list`) only list libraries matching this pattern
+      #   - `:withcode => true`: (`list`) include each library's source code in the reply
+      #   - `:policy => Symbol`: (`restore`) one of `:append` (default), `:flush`, `:replace`
+      # @return [String, Array<Hash>, Hash] depends on subcommand
+      #
+      # @see #fcall
+      # @see #fcall_ro
+      def function(subcommand, *args, **options)
+        subcommand = subcommand.to_s.downcase
+
+        case subcommand
+        when "load"
+          command = %i[function load]
+          command << "REPLACE" if options[:replace]
+          send_command(command + args)
+        when "list"
+          command = %i[function list]
+          command << "LIBRARYNAME" << options[:libraryname] if options[:libraryname]
+          command << "WITHCODE" if options[:withcode]
+          send_command(command, &HashifyFunctionList)
+        when "restore"
+          command = %i[function restore] + args
+          command << options[:policy].to_s.upcase if options[:policy]
+          send_command(command)
+        when "stats"
+          send_command(%i[function stats], &HashifyFunctionStats)
+        else
+          send_command([:function, subcommand] + args)
+        end
+      end
+
+      # Invoke a Redis Function loaded with FUNCTION LOAD.
+      #
+      # @example FCALL without keys nor arguments
+      #   redis.fcall("myfunc")
+      #     # => <depends on the function>
+      # @example FCALL with keys and arguments as array arguments
+      #   redis.fcall("myfunc", ["k1", "k2"], ["a1", "a2"])
+      #     # => <depends on the function>
+      # @example FCALL with keys and arguments in a hash argument
+      #   redis.fcall("myfunc", :keys => ["k1", "k2"], :argv => ["a1", "a2"])
+      #     # => <depends on the function>
+      #
+      # @param [Array<String>] keys optional array with keys to pass to the function
+      # @param [Array<String>] argv optional array with arguments to pass to the function
+      # @param [Hash] options
+      #   - `:keys => Array<String>`: optional array with keys to pass to the function
+      #   - `:argv => Array<String>`: optional array with arguments to pass to the function
+      # @return depends on the function
+      #
+      # @see #function
+      # @see #fcall_ro
+      def fcall(*args)
+        _eval(:fcall, args)
+      end
+
+      # Invoke a read-only Redis Function loaded with FUNCTION LOAD.
+      #
+      # The function must have been registered with the `no-writes` flag.
+      #
+      # @example FCALL_RO with a key
+      #   redis.fcall_ro("myfunc", ["k1"])
+      #     # => <depends on the function>
+      #
+      # @param [Array<String>] keys optional array with keys to pass to the function
+      # @param [Array<String>] argv optional array with arguments to pass to the function
+      # @param [Hash] options
+      #   - `:keys => Array<String>`: optional array with keys to pass to the function
+      #   - `:argv => Array<String>`: optional array with arguments to pass to the function
+      # @return depends on the function
+      #
+      # @see #function
+      # @see #fcall
+      def fcall_ro(*args)
+        _eval(:fcall_ro, args)
+      end
+
       private
 
       def _eval(cmd, args)

--- a/lib/redis/commands/scripting.rb
+++ b/lib/redis/commands/scripting.rb
@@ -145,7 +145,7 @@ class Redis
           command << "REPLACE" if options[:replace]
           send_command(command + args)
         when "list"
-          command = %i[function list]
+          command = %i[function list] + args
           command << "LIBRARYNAME" << options[:libraryname] if options[:libraryname]
           command << "WITHCODE" if options[:withcode]
           send_command(command, &HashifyFunctionList)

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -1357,8 +1357,33 @@ class Redis
     end
 
     # Manage Redis Functions libraries.
+    #
+    # Function libraries are server-global rather than per-database, so the fan-out runs
+    # once per physical server: ring nodes differing only by database would re-run
+    # mutations (e.g. FUNCTION LOAD) against the same server and fail on collision.
     def function(subcommand, *args, **options)
-      nodes.map { |node| node.function(subcommand, *args, **options) }
+      function_nodes = nodes.uniq { |node| [node._client.path, node._client.host, node._client.port] }
+
+      if subcommand.to_s.downcase == "kill"
+        # Only the node actually running a function replies OK; idle nodes raise NOTBUSY.
+        # Succeed when any node killed a function, mirroring the cluster client's
+        # one_succeeded fan-out semantics.
+        not_busy = nil
+        killed = function_nodes.filter_map do |node|
+          node.function(:kill)
+        rescue CommandError => e
+          raise unless e.message.start_with?("NOTBUSY")
+
+          not_busy = e
+          nil
+        end
+
+        raise not_busy if killed.empty? && not_busy
+
+        killed.first
+      else
+        function_nodes.map { |node| node.function(subcommand, *args, **options) }
+      end
     end
 
     # Add a new element into a vector set, or update its vector if it already exists.

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -1362,7 +1362,12 @@ class Redis
     # once per physical server: ring nodes differing only by database would re-run
     # mutations (e.g. FUNCTION LOAD) against the same server and fail on collision.
     def function(subcommand, *args, **options)
-      function_nodes = nodes.uniq { |node| [node._client.path, node._client.host, node._client.port] }
+      # Both RedisClient::Config and RedisClient::SentinelConfig expose the address;
+      # for a sentinel-backed node it is the currently resolved master.
+      function_nodes = nodes.uniq do |node|
+        config = node._client.config
+        [config.path, config.host, config.port]
+      end
 
       if subcommand.to_s.downcase == "kill"
         # Only the node actually running a function replies OK; idle nodes raise NOTBUSY.

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -1356,6 +1356,11 @@ class Redis
       on_each_node(:script, subcommand, *args)
     end
 
+    # Manage Redis Functions libraries.
+    def function(subcommand, *args, **options)
+      nodes.map { |node| node.function(subcommand, *args, **options) }
+    end
+
     # Set one or more contiguous values starting at an index in an array.
     def arset(key, index, *values)
       node_for(key).arset(key, index, *values)
@@ -1487,6 +1492,16 @@ class Redis
     # Evaluate Lua script by its SHA.
     def evalsha(*args)
       _eval(:evalsha, args)
+    end
+
+    # Invoke a Redis Function.
+    def fcall(*args)
+      _eval(:fcall, args)
+    end
+
+    # Invoke a read-only Redis Function.
+    def fcall_ro(*args)
+      _eval(:fcall_ro, args)
     end
 
     def inspect

--- a/test/distributed/scripting_test.rb
+++ b/test/distributed/scripting_test.rb
@@ -113,6 +113,40 @@ class TestDistributedScripting < Minitest::Test
     end
   end
 
+  def test_function_runs_once_per_physical_server
+    target_version "7.0.0" do
+      # Two ring nodes on the same server (different databases): library mutations
+      # must run once per physical server or the second run fails on collision.
+      node_urls = ["redis://127.0.0.1:#{PORT}/14", "redis://127.0.0.1:#{PORT}/15"]
+      redis = Redis::Distributed.new(node_urls, timeout: TIMEOUT, driver: ENV["DRIVER"], protocol: PROTOCOL)
+
+      redis.function(:flush)
+      assert_equal ["mylib"], redis.function(:load, FUNCTIONS_LIB)
+      assert_equal ["OK"], redis.function(:delete, "mylib")
+    end
+  end
+
+  def test_function_kill_when_idle
+    target_version "7.0.0" do
+      error = assert_raises(Redis::CommandError) { r.function(:kill) }
+      assert_match(/NOTBUSY/, error.message)
+    end
+  end
+
+  def test_function_kill_tolerates_idle_nodes
+    idle = ->(*_) { "-NOTBUSY No scripts in execution right now." }
+    busy = ->(*_) { "+OK" }
+
+    RedisMock.start(function: idle) do |idle_port|
+      RedisMock.start(function: busy) do |busy_port|
+        node_urls = ["redis://127.0.0.1:#{idle_port}", "redis://127.0.0.1:#{busy_port}"]
+        redis = Redis::Distributed.new(node_urls, timeout: TIMEOUT, driver: ENV["DRIVER"], protocol: PROTOCOL)
+
+        assert_equal "OK", redis.function(:kill)
+      end
+    end
+  end
+
   def test_fcall
     target_version "7.0.0" do
       load_functions

--- a/test/distributed/scripting_test.rb
+++ b/test/distributed/scripting_test.rb
@@ -84,4 +84,62 @@ class TestDistributedScripting < Minitest::Test
     assert_equal ["k1"], r.evalsha(to_sha("return KEYS"), { keys: ["k1"] })
     assert_equal ["a1", "a2"], r.evalsha(to_sha("return ARGV"), { keys: ["k1"], argv: ["a1", "a2"] })
   end
+
+  FUNCTIONS_LIB = <<~LUA
+    #!lua name=mylib
+    local function myfunc(keys, args)
+      return { keys, args }
+    end
+    redis.register_function('myfunc', myfunc)
+  LUA
+
+  def load_functions
+    r.function(:flush)
+    r.function(:load, FUNCTIONS_LIB)
+  end
+
+  def test_function
+    target_version "7.0.0" do
+      r.function(:flush)
+
+      assert_equal ["mylib"], r.function(:load, FUNCTIONS_LIB)
+      assert_equal ["mylib"], r.function(:load, FUNCTIONS_LIB, replace: true)
+
+      libraries = r.function(:list).first
+      assert_equal(["mylib"], libraries.map { |library| library["library_name"] })
+
+      assert_equal ["OK"], r.function(:delete, "mylib")
+      assert_equal [[]], r.function(:list)
+    end
+  end
+
+  def test_fcall
+    target_version "7.0.0" do
+      load_functions
+
+      assert_raises(Redis::Distributed::CannotDistribute) do
+        r.fcall("myfunc")
+      end
+
+      assert_raises(Redis::Distributed::CannotDistribute) do
+        r.fcall("myfunc", ["k1", "k2"])
+      end
+
+      assert_equal [["k1"], ["a1"]], r.fcall("myfunc", ["k1"], ["a1"])
+      assert_equal [["k1"], ["a1"]], r.fcall("myfunc", { keys: ["k1"], argv: ["a1"] })
+    end
+  end
+
+  def test_fcall_ro
+    target_version "7.0.0" do
+      load_functions
+
+      assert_raises(Redis::Distributed::CannotDistribute) do
+        r.fcall_ro("myfunc")
+      end
+
+      # myfunc is not registered with the no-writes flag.
+      assert_raises(Redis::CommandError) { r.fcall_ro("myfunc", ["k1"]) }
+    end
+  end
 end

--- a/test/distributed/scripting_test.rb
+++ b/test/distributed/scripting_test.rb
@@ -126,6 +126,34 @@ class TestDistributedScripting < Minitest::Test
     end
   end
 
+  def test_function_dedups_sentinel_backed_nodes
+    target_version "7.0.0" do
+      # Sentinel-backed nodes resolve their address through SentinelConfig. Both mock
+      # sentinels point at the same standalone master, so mutations must run exactly once.
+      sentinel = lambda do |command, *_|
+        case command
+        when "get-master-addr-by-name" then ["127.0.0.1", PORT.to_s]
+        when "sentinels" then []
+        else raise "Unexpected sentinel command #{command}"
+        end
+      end
+
+      RedisMock.start(sentinel: sentinel) do |sentinel_a|
+        RedisMock.start(sentinel: sentinel) do |sentinel_b|
+          nodes = [
+            { name: "shard-a", sentinels: [{ host: "127.0.0.1", port: sentinel_a }], db: 14 },
+            { name: "shard-b", sentinels: [{ host: "127.0.0.1", port: sentinel_b }], db: 15 },
+          ]
+          redis = Redis::Distributed.new(nodes, timeout: TIMEOUT, driver: ENV["DRIVER"], protocol: PROTOCOL)
+
+          redis.function(:flush)
+          assert_equal ["mylib"], redis.function(:load, FUNCTIONS_LIB)
+          assert_equal ["OK"], redis.function(:delete, "mylib")
+        end
+      end
+    end
+  end
+
   def test_function_kill_when_idle
     target_version "7.0.0" do
       error = assert_raises(Redis::CommandError) { r.function(:kill) }

--- a/test/redis/scripting_test.rb
+++ b/test/redis/scripting_test.rb
@@ -121,6 +121,10 @@ class TestScripting < Minitest::Test
       reply = r.function(:list, libraryname: "mylib", withcode: true)
       assert_equal 1, reply.size
       assert_equal FUNCTIONS_LIB, reply.first["library_code"]
+
+      positional = r.function(:list, "LIBRARYNAME", "mylib", "WITHCODE")
+      assert_equal 1, positional.size
+      assert_equal FUNCTIONS_LIB, positional.first["library_code"]
     end
   end
 

--- a/test/redis/scripting_test.rb
+++ b/test/redis/scripting_test.rb
@@ -5,8 +5,22 @@ require "helper"
 class TestScripting < Minitest::Test
   include Helper::Client
 
+  FUNCTIONS_LIB = <<~LUA
+    #!lua name=mylib
+    local function myfunc(keys, args)
+      return { keys, args }
+    end
+    redis.register_function('myfunc', myfunc)
+    redis.register_function{function_name='myfunc_ro', callback=myfunc, flags={'no-writes'}}
+  LUA
+
   def to_sha(script)
     r.script(:load, script)
+  end
+
+  def load_functions
+    r.function(:flush)
+    r.function(:load, FUNCTIONS_LIB)
   end
 
   def test_script_exists
@@ -66,5 +80,161 @@ class TestScripting < Minitest::Test
     assert_equal 0, r.evalsha(to_sha("return #ARGV"), {})
     assert_equal ["k1", "k2"], r.evalsha(to_sha("return KEYS"), { keys: ["k1", "k2"] })
     assert_equal ["a1", "a2"], r.evalsha(to_sha("return ARGV"), { argv: ["a1", "a2"] })
+  end
+
+  def test_function_load
+    target_version "7.0.0" do
+      r.function(:flush)
+
+      assert_equal "mylib", r.function(:load, FUNCTIONS_LIB)
+      assert_raises(Redis::CommandError) { r.function(:load, FUNCTIONS_LIB) }
+      assert_equal "mylib", r.function(:load, FUNCTIONS_LIB, replace: true)
+    end
+  end
+
+  def test_function_list
+    target_version "7.0.0" do
+      load_functions
+
+      reply = r.function(:list)
+      assert_equal 1, reply.size
+
+      library = reply.first
+      assert_equal "mylib", library["library_name"]
+      assert_equal "LUA", library["engine"]
+      assert_nil library["library_code"]
+
+      functions = library["functions"].sort_by { |function| function["name"] }
+      assert_equal(%w[myfunc myfunc_ro], functions.map { |function| function["name"] })
+      assert_nil functions.first["description"]
+      assert_equal [], functions.first["flags"]
+      assert_equal ["no-writes"], functions.last["flags"]
+    end
+  end
+
+  def test_function_list_with_options
+    target_version "7.0.0" do
+      load_functions
+
+      assert_equal [], r.function(:list, libraryname: "nosuchlib")
+
+      reply = r.function(:list, libraryname: "mylib", withcode: true)
+      assert_equal 1, reply.size
+      assert_equal FUNCTIONS_LIB, reply.first["library_code"]
+    end
+  end
+
+  def test_function_delete
+    target_version "7.0.0" do
+      load_functions
+
+      assert_equal "OK", r.function(:delete, "mylib")
+      assert_equal [], r.function(:list)
+      assert_raises(Redis::CommandError) { r.function(:delete, "mylib") }
+    end
+  end
+
+  def test_function_flush
+    target_version "7.0.0" do
+      load_functions
+
+      assert_equal 1, r.function(:list).size
+      assert_equal "OK", r.function(:flush)
+      assert_equal [], r.function(:list)
+
+      r.function(:load, FUNCTIONS_LIB)
+      assert_equal "OK", r.function(:flush, "ASYNC")
+      assert_equal [], r.function(:list)
+    end
+  end
+
+  def test_function_dump_and_restore
+    target_version "7.0.0" do
+      load_functions
+
+      payload = r.function(:dump)
+      assert_kind_of String, payload
+
+      r.function(:flush)
+      assert_equal "OK", r.function(:restore, payload)
+      assert_equal(["mylib"], r.function(:list).map { |library| library["library_name"] })
+
+      # APPEND (the default policy) aborts on collision; REPLACE and FLUSH succeed.
+      assert_raises(Redis::CommandError) { r.function(:restore, payload) }
+      assert_equal "OK", r.function(:restore, payload, policy: :replace)
+      assert_equal "OK", r.function(:restore, payload, policy: :flush)
+    end
+  end
+
+  def test_function_stats
+    target_version "7.0.0" do
+      load_functions
+
+      stats = r.function(:stats)
+      assert_nil stats["running_script"]
+      assert stats["engines"].key?("LUA")
+      assert_kind_of Integer, stats["engines"]["LUA"]["libraries_count"]
+      assert_kind_of Integer, stats["engines"]["LUA"]["functions_count"]
+    end
+  end
+
+  def test_function_kill
+    target_version "7.0.0" do
+      error = assert_raises(Redis::CommandError) { r.function(:kill) }
+      assert_match(/NOTBUSY/, error.message)
+    end
+  end
+
+  def test_fcall
+    target_version "7.0.0" do
+      load_functions
+
+      assert_equal [[], []], r.fcall("myfunc")
+      assert_equal [["k1", "k2"], []], r.fcall("myfunc", ["k1", "k2"])
+      assert_equal [["k1"], ["a1", "a2"]], r.fcall("myfunc", ["k1"], ["a1", "a2"])
+    end
+  end
+
+  def test_fcall_with_options_hash
+    target_version "7.0.0" do
+      load_functions
+
+      assert_equal [[], []], r.fcall("myfunc", {})
+      assert_equal [["k1"], ["a1"]], r.fcall("myfunc", { keys: ["k1"], argv: ["a1"] })
+    end
+  end
+
+  def test_fcall_unknown_function
+    target_version "7.0.0" do
+      load_functions
+
+      assert_raises(Redis::CommandError) { r.fcall("nosuchfunc") }
+    end
+  end
+
+  def test_fcall_ro
+    target_version "7.0.0" do
+      load_functions
+
+      assert_equal [["k1"], ["a1"]], r.fcall_ro("myfunc_ro", ["k1"], ["a1"])
+      assert_equal [["k1"], ["a1"]], r.fcall_ro("myfunc_ro", { keys: ["k1"], argv: ["a1"] })
+
+      # myfunc is not registered with the no-writes flag.
+      assert_raises(Redis::CommandError) { r.fcall_ro("myfunc") }
+    end
+  end
+
+  def test_fcall_in_pipeline
+    target_version "7.0.0" do
+      load_functions
+
+      result = r.pipelined do |pipeline|
+        pipeline.fcall("myfunc", ["k1"], ["a1"])
+        pipeline.function(:list)
+      end
+
+      assert_equal [["k1"], ["a1"]], result.first
+      assert_equal(["mylib"], result.last.map { |library| library["library_name"] })
+    end
   end
 end


### PR DESCRIPTION
Starting from 7.0 Redis supports server-side script execution API called Redis Functions. Check the [official documentation](https://redis.io/docs/latest/develop/programmability/functions-intro/) for detailed explanation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New command surface and non-trivial distributed fan-out/kill semantics; behavior is gated to Redis 7.0+ and covered by tests but affects multi-node setups.
> 
> **Overview**
> Adds **Redis Functions** support (7.0+) alongside existing Lua scripting: `redis.function` for library lifecycle (load/replace, list, delete, flush, dump/restore with restore policies, stats, kill) and `redis.fcall` / `redis.fcall_ro` for invocation with the same keys/argv calling style as `eval`/`evalsha`.
> 
> **`FUNCTION LIST`** and **`FUNCTION STATS`** replies are normalized to nested hashes via new `HashifyFunctionList` and `HashifyFunctionStats`, so RESP2 flat arrays and RESP3 maps look the same in Ruby.
> 
> On **`Redis::Distributed`**, `function` fans out **once per physical server** (deduped by host/port/path, including sentinel-backed nodes) so server-global libraries are not loaded twice on different DBs; **`function(:kill)`** succeeds if any node returns OK and ignores idle nodes’ `NOTBUSY`. **`fcall`** / **`fcall_ro`** route like distributed `eval` (single key / same-slot keys only).
> 
> Coverage adds standalone, distributed, and cluster tests (CROSSSLOT, `no-writes` for `FCALL_RO`, pipelines).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff3723bd35dbb54ee33a20561007f3c243e61af8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->