### PR TITLE
Added missing Redis 7.0 commands API

### DIFF
--- a/cluster/test/commands_on_keys_test.rb
+++ b/cluster/test/commands_on_keys_test.rb
@@ -87,6 +87,14 @@ class TestClusterCommandsOnKeys < Minitest::Test
     assert_equal %w[1 2 3 4 5], redis.sort('mylist')
   end
 
+  def test_sort_ro
+    target_version "7.0.0" do
+      redis.rpush('mylist', %w[3 1 5 2 4])
+      assert_equal %w[1 2 3 4 5], redis.sort_ro('mylist')
+      assert_equal %w[5 4], redis.sort_ro('mylist', order: 'desc', limit: [0, 2])
+    end
+  end
+
   def test_touch
     set_some_keys
     assert_equal 1, redis.touch('key1')

--- a/lib/redis/commands/keys.rb
+++ b/lib/redis/commands/keys.rb
@@ -412,7 +412,54 @@ class Redis
       #   element specified in `:get`
       #   - when `:store` is specified, the number of elements in the stored result
       def sort(key, by: nil, limit: nil, get: nil, order: nil, store: nil)
-        args = [:sort, key]
+        _sort(:sort, key, by: by, limit: limit, get: get, order: order, store: store)
+      end
+
+      # Sort the elements in a list, set or sorted set without storing the result.
+      #
+      # Read-only variant of `sort`: it has no `STORE` option, so it is flagged read-only on the
+      # server and can be executed on read-only replicas (a cluster replica in `READONLY` mode
+      # redirects plain `SORT` to the master).
+      #
+      # @example Retrieve the first 2 elements from an alphabetically sorted "list"
+      #   redis.sort_ro("list", :order => "alpha", :limit => [0, 2])
+      #     # => ["a", "b"]
+      # @example Sort by an external key and fetch each element together with its weight
+      #   redis.sort_ro("list", :by => "weight_*", :get => ["#", "weight_*"])
+      #     # => [["c", "10"], ["b", "20"], ["a", "30"]]
+      #
+      # @param [String] key
+      # @param [Hash] options
+      #   - `:by => String`: use external key to sort elements by
+      #   - `:limit => [offset, count]`: skip `offset` elements, return a maximum
+      #   of `count` elements
+      #   - `:get => [String, Array<String>]`: single key or array of keys to
+      #   retrieve per element in the result
+      #   - `:order => String`: combination of `ASC`, `DESC` and optionally `ALPHA`
+      #
+      # @return [Array<String>, Array<Array<String>>]
+      #   - when `:get` is not specified, or holds a single element, an array of elements
+      #   - when `:get` is specified, and holds more than one element, an array of
+      #   elements where every element is an array with the result for every
+      #   element specified in `:get`
+      #
+      # @see #sort
+      def sort_ro(key, by: nil, limit: nil, get: nil, order: nil)
+        _sort(:sort_ro, key, by: by, limit: limit, get: get, order: order)
+      end
+
+      # Determine the type stored at key.
+      #
+      # @param [String] key
+      # @return [String] `string`, `list`, `set`, `zset`, `hash` or `none`
+      def type(key)
+        send_command([:type, key])
+      end
+
+      private
+
+      def _sort(command, key, by:, limit:, get:, order:, store: nil)
+        args = [command, key]
         args << "BY" << by if by
 
         if limit
@@ -436,16 +483,6 @@ class Redis
           end
         end
       end
-
-      # Determine the type stored at key.
-      #
-      # @param [String] key
-      # @return [String] `string`, `list`, `set`, `zset`, `hash` or `none`
-      def type(key)
-        send_command([:type, key])
-      end
-
-      private
 
       def _scan(command, cursor, args, match: nil, count: nil, type: nil, novalues: false, &block)
         # SSCAN/ZSCAN/HSCAN already prepend the key to +args+.

--- a/lib/redis/commands/sets.rb
+++ b/lib/redis/commands/sets.rb
@@ -164,6 +164,28 @@ class Redis
         send_command([:sinter].concat(keys))
       end
 
+      # Get the number of members in the intersection of multiple sets.
+      #
+      # @example
+      #   redis.sadd("foo", ["s1", "s2", "s3"])
+      #   redis.sadd("bar", ["s2", "s3", "s4"])
+      #   redis.sintercard("foo", "bar")
+      #     # => 2
+      # @example Stop counting once the intersection reaches 1 member
+      #   redis.sintercard("foo", "bar", limit: 1)
+      #     # => 1
+      #
+      # @param [String, Array<String>] keys keys pointing to sets to intersect
+      # @param [Integer] limit stop counting once the intersection reaches `limit`
+      #   members (`0` means unlimited)
+      # @return [Integer] number of members in the intersection
+      def sintercard(*keys, limit: nil)
+        keys.flatten!(1)
+        args = [:sintercard, keys.size].concat(keys)
+        args << "LIMIT" << Integer(limit) if limit
+        send_command(args)
+      end
+
       # Intersect multiple sets and store the resulting set in a key.
       #
       # @param [String] destination destination key

--- a/lib/redis/commands/sorted_sets.rb
+++ b/lib/redis/commands/sorted_sets.rb
@@ -736,6 +736,28 @@ class Redis
       end
       ruby2_keywords(:zinter) if respond_to?(:ruby2_keywords, true)
 
+      # Get the number of members in the intersection of multiple sorted sets.
+      #
+      # @example
+      #   redis.zadd("zsetA", [[1, "v1"], [2, "v2"], [3, "v3"]])
+      #   redis.zadd("zsetB", [[1, "v2"], [2, "v3"], [3, "v4"]])
+      #   redis.zintercard("zsetA", "zsetB")
+      #     # => 2
+      # @example Stop counting once the intersection reaches 1 member
+      #   redis.zintercard("zsetA", "zsetB", limit: 1)
+      #     # => 1
+      #
+      # @param [String, Array<String>] keys one or more keys to intersect
+      # @param [Integer] limit stop counting once the intersection reaches `limit`
+      #   members (`0` means unlimited)
+      # @return [Integer] number of members in the intersection
+      def zintercard(*keys, limit: nil)
+        keys.flatten!(1)
+        args = [:zintercard, keys.size].concat(keys)
+        args << "LIMIT" << Integer(limit) if limit
+        send_command(args)
+      end
+
       # Intersect multiple sorted sets and store the resulting sorted set in a new
       # key.
       #

--- a/lib/redis/commands/strings.rb
+++ b/lib/redis/commands/strings.rb
@@ -395,6 +395,51 @@ class Redis
         send_command([:strlen, key])
       end
 
+      # Find the longest common subsequence of the strings stored at two keys.
+      #
+      # Matching characters need not be contiguous: the LCS of "foo" and "fao" is "fo".
+      # Runs in O(N*M) on the server, so keep the strings small.
+      #
+      # @example Get the subsequence
+      #   redis.mset("key1", "ohmytext", "key2", "mynewtext")
+      #   redis.lcs("key1", "key2")
+      #     # => "mytext"
+      # @example Get only its length
+      #   redis.lcs("key1", "key2", len: true)
+      #     # => 6
+      # @example Get the match positions, last match first
+      #   redis.lcs("key1", "key2", idx: true)
+      #     # => { "matches" => [[[4, 7], [5, 8]], [[2, 3], [0, 1]]], "len" => 6 }
+      # @example Only matches of at least 4 characters, each with its length
+      #   redis.lcs("key1", "key2", idx: true, minmatchlen: 4, withmatchlen: true)
+      #     # => { "matches" => [[[4, 7], [5, 8], 4]], "len" => 6 }
+      #
+      # @param [String] key1
+      # @param [String] key2
+      # @param [Hash] options
+      #   - `:len => true`: return the length of the subsequence instead of the subsequence
+      #   - `:idx => true`: return the match positions instead of the subsequence
+      #   - `:minmatchlen => Integer`: (`idx`) only report matches at least this long
+      #   - `:withmatchlen => true`: (`idx`) append each match's length to its entry
+      #
+      # @return [String, Integer, Hash]
+      #   - by default, the subsequence (`""` when there is none)
+      #   - with `:len`, its length
+      #   - with `:idx`, `{ "matches" => [[[start1, end1], [start2, end2], (len)], ...], "len" => Integer }`
+      def lcs(key1, key2, len: false, idx: false, minmatchlen: nil, withmatchlen: false)
+        args = [:lcs, key1, key2]
+        args << "LEN" if len
+        args << "IDX" if idx
+        args << "MINMATCHLEN" << Integer(minmatchlen) if minmatchlen
+        args << "WITHMATCHLEN" if withmatchlen
+
+        if idx
+          send_command(args, &Hashify)
+        else
+          send_command(args)
+        end
+      end
+
       private
 
       # INCREX bounds decide whether the increment is applied at all, so a

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -1652,11 +1652,12 @@ class Redis
       key[@tag, 1] if key.match?(@tag)
     end
 
-    # Keys SORT/SORT_RO touch, for same-node routing. `GET #` denotes the sorted element
-    # itself rather than another key, so it takes no part in routing.
+    # Keys SORT/SORT_RO touch, for same-node routing. A BY/GET pattern without `*` never reads
+    # another key (`BY nosort` skips sorting, `GET #` yields the element itself), so it is
+    # left out.
     def sort_keys(key, options)
-      get = Array(options[:get]).reject { |pattern| pattern == "#" }
-      [key, options[:by], options[:store], *get].compact
+      patterns = [options[:by], *Array(options[:get])].compact.select { |pattern| pattern.to_s.include?("*") }
+      [key, options[:store], *patterns].compact
     end
 
     def ensure_same_node(command, keys)

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -266,6 +266,15 @@ class Redis
       end
     end
 
+    # Sort the elements in a list, set or sorted set without storing the result.
+    def sort_ro(key, **options)
+      keys = [key, options[:by], *Array(options[:get])].compact
+
+      ensure_same_node(:sort_ro, keys) do |node|
+        node.sort_ro(key, **options)
+      end
+    end
+
     # Determine the type stored at key.
     def type(key)
       node_for(key).type(key)
@@ -538,6 +547,13 @@ class Redis
     # Get the length of the value stored in a key.
     def strlen(key)
       node_for(key).strlen(key)
+    end
+
+    # Find the longest common subsequence of the strings stored at two keys.
+    def lcs(key1, key2, **options)
+      ensure_same_node(:lcs, [key1, key2]) do |node|
+        node.lcs(key1, key2, **options)
+      end
     end
 
     def [](key)
@@ -819,6 +835,14 @@ class Redis
       end
     end
 
+    # Get the number of members in the intersection of multiple sets.
+    def sintercard(*keys, limit: nil)
+      keys.flatten!(1)
+      ensure_same_node(:sintercard, keys) do |node|
+        node.sintercard(keys, limit: limit)
+      end
+    end
+
     # Intersect multiple sets and store the resulting set in a key.
     def sinterstore(destination, *keys)
       keys.flatten!(1)
@@ -963,6 +987,14 @@ class Redis
       keys.flatten!(1)
       ensure_same_node(:zinter, keys) do |node|
         node.zinter(keys, **options)
+      end
+    end
+
+    # Get the number of members in the intersection of multiple sorted sets.
+    def zintercard(*keys, limit: nil)
+      keys.flatten!(1)
+      ensure_same_node(:zintercard, keys) do |node|
+        node.zintercard(keys, limit: limit)
       end
     end
 

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -259,18 +259,14 @@ class Redis
 
     # Sort the elements in a list, set or sorted set.
     def sort(key, **options)
-      keys = [key, options[:by], options[:store], *Array(options[:get])].compact
-
-      ensure_same_node(:sort, keys) do |node|
+      ensure_same_node(:sort, sort_keys(key, options)) do |node|
         node.sort(key, **options)
       end
     end
 
     # Sort the elements in a list, set or sorted set without storing the result.
     def sort_ro(key, **options)
-      keys = [key, options[:by], *Array(options[:get])].compact
-
-      ensure_same_node(:sort_ro, keys) do |node|
+      ensure_same_node(:sort_ro, sort_keys(key, options)) do |node|
         node.sort_ro(key, **options)
       end
     end
@@ -1654,6 +1650,13 @@ class Redis
     def key_tag(key)
       key = key.to_s
       key[@tag, 1] if key.match?(@tag)
+    end
+
+    # Keys SORT/SORT_RO touch, for same-node routing. `GET #` denotes the sorted element
+    # itself rather than another key, so it takes no part in routing.
+    def sort_keys(key, options)
+      get = Array(options[:get]).reject { |pattern| pattern == "#" }
+      [key, options[:by], options[:store], *get].compact
     end
 
     def ensure_same_node(command, keys)

--- a/test/distributed/commands_on_sets_test.rb
+++ b/test/distributed/commands_on_sets_test.rb
@@ -91,6 +91,12 @@ class TestDistributedCommandsOnSets < Minitest::Test
     end
   end
 
+  def test_sintercard_with_keys_on_different_nodes
+    assert_raises Redis::Distributed::CannotDistribute do
+      r.sintercard('foo', 'bar')
+    end
+  end
+
   def test_sscan
     r.sadd 'foo', 's1'
     r.sadd 'foo', 's2'

--- a/test/distributed/commands_on_sorted_sets_test.rb
+++ b/test/distributed/commands_on_sorted_sets_test.rb
@@ -14,6 +14,12 @@ class TestDistributedCommandsOnSortedSets < Minitest::Test
     assert_raises(Redis::Distributed::CannotDistribute) { super }
   end
 
+  def test_zintercard_with_keys_on_different_nodes
+    assert_raises(Redis::Distributed::CannotDistribute) do
+      r.zintercard('foo', 'bar')
+    end
+  end
+
   def test_zinter_with_aggregate
     assert_raises(Redis::Distributed::CannotDistribute) { super }
   end

--- a/test/distributed/commands_on_strings_test.rb
+++ b/test/distributed/commands_on_strings_test.rb
@@ -37,6 +37,12 @@ class TestDistributedCommandsOnStrings < Minitest::Test
     end
   end
 
+  def test_lcs_with_keys_on_different_nodes
+    assert_raises Redis::Distributed::CannotDistribute do
+      r.lcs("foo", "bar")
+    end
+  end
+
   def test_mset_mapped
     assert_raises Redis::Distributed::CannotDistribute do
       r.mapped_mset(foo: "s1", bar: "s2")

--- a/test/distributed/commands_requiring_clustering_test.rb
+++ b/test/distributed/commands_requiring_clustering_test.rb
@@ -211,6 +211,25 @@ class TestDistributedCommandsRequiringClustering < Minitest::Test
     end
   end
 
+  def test_sort_with_by_nosort_keeps_insertion_order
+    r.rpush("{qux}bar", "2")
+    r.rpush("{qux}bar", "1")
+
+    # A constant BY pattern skips sorting and reads no key, so it must not affect routing.
+    assert_equal %w[2 1], r.sort("{qux}bar", by: "nosort")
+    assert_equal %w[1 2], r.sort("{qux}bar")
+  end
+
+  def test_sort_ro_with_by_nosort_keeps_insertion_order
+    target_version "7.0.0" do
+      r.rpush("{qux}bar", "2")
+      r.rpush("{qux}bar", "1")
+
+      assert_equal %w[2 1], r.sort_ro("{qux}bar", by: "nosort")
+      assert_equal %w[1 2], r.sort_ro("{qux}bar")
+    end
+  end
+
   def test_bitop
     r.set("{qux}foo", "a")
     r.set("{qux}bar", "b")

--- a/test/distributed/commands_requiring_clustering_test.rb
+++ b/test/distributed/commands_requiring_clustering_test.rb
@@ -158,6 +158,34 @@ class TestDistributedCommandsRequiringClustering < Minitest::Test
     assert_equal ["s1", "s2"], r.lrange("{qux}baz", 0, -1)
   end
 
+  def test_sort_ro
+    target_version "7.0.0" do
+      r.set("{qux}foo:1", "s1")
+      r.set("{qux}foo:2", "s2")
+
+      r.rpush("{qux}bar", "1")
+      r.rpush("{qux}bar", "2")
+
+      assert_equal ["s1"], r.sort_ro("{qux}bar", get: "{qux}foo:*", limit: [0, 1])
+      assert_equal ["s2"], r.sort_ro("{qux}bar", get: "{qux}foo:*", limit: [0, 1], order: "desc alpha")
+    end
+  end
+
+  def test_sort_ro_with_an_array_of_gets
+    target_version "7.0.0" do
+      r.set("{qux}foo:1:a", "s1a")
+      r.set("{qux}foo:1:b", "s1b")
+
+      r.set("{qux}foo:2:a", "s2a")
+      r.set("{qux}foo:2:b", "s2b")
+
+      r.rpush("{qux}bar", "1")
+      r.rpush("{qux}bar", "2")
+
+      assert_equal [["s1a", "s1b"], ["s2a", "s2b"]], r.sort_ro("{qux}bar", get: ["{qux}foo:*:a", "{qux}foo:*:b"])
+    end
+  end
+
   def test_bitop
     r.set("{qux}foo", "a")
     r.set("{qux}bar", "b")

--- a/test/distributed/commands_requiring_clustering_test.rb
+++ b/test/distributed/commands_requiring_clustering_test.rb
@@ -186,6 +186,31 @@ class TestDistributedCommandsRequiringClustering < Minitest::Test
     end
   end
 
+  def test_sort_with_get_hash_returns_the_element_itself
+    r.set("{qux}foo:1", "s1")
+    r.set("{qux}foo:2", "s2")
+
+    r.rpush("{qux}bar", "1")
+    r.rpush("{qux}bar", "2")
+
+    # `GET #` is not a key and must not take part in same-node routing.
+    assert_equal %w[1 2], r.sort("{qux}bar", get: "#")
+    assert_equal [["1", "s1"], ["2", "s2"]], r.sort("{qux}bar", get: ["#", "{qux}foo:*"])
+  end
+
+  def test_sort_ro_with_get_hash_returns_the_element_itself
+    target_version "7.0.0" do
+      r.set("{qux}foo:1", "s1")
+      r.set("{qux}foo:2", "s2")
+
+      r.rpush("{qux}bar", "1")
+      r.rpush("{qux}bar", "2")
+
+      assert_equal %w[1 2], r.sort_ro("{qux}bar", get: "#")
+      assert_equal [["1", "s1"], ["2", "s2"]], r.sort_ro("{qux}bar", get: ["#", "{qux}foo:*"])
+    end
+  end
+
   def test_bitop
     r.set("{qux}foo", "a")
     r.set("{qux}bar", "b")

--- a/test/distributed/sorting_test.rb
+++ b/test/distributed/sorting_test.rb
@@ -16,4 +16,15 @@ class TestDistributedSorting < Minitest::Test
       r.sort("bar", get: "foo:*", limit: [0, 1])
     end
   end
+
+  def test_sort_ro
+    target_version "7.0.0" do
+      assert_raises(Redis::Distributed::CannotDistribute) do
+        r.set("foo:1", "s1")
+        r.rpush("bar", "1")
+
+        r.sort_ro("bar", get: "foo:*", limit: [0, 1])
+      end
+    end
+  end
 end

--- a/test/lint/sets.rb
+++ b/test/lint/sets.rb
@@ -405,6 +405,54 @@ module Lint
       end
     end
 
+    def test_sintercard
+      target_version('7.0.0') do
+        r.sadd('{1}foo', %w[s1 s2 s3 s4])
+        r.sadd('{1}bar', %w[s2 s3 s4 s5])
+        r.sadd('{1}baz', %w[s3 s4 s6])
+
+        assert_equal 3, r.sintercard('{1}foo', '{1}bar')
+        assert_equal 2, r.sintercard('{1}foo', '{1}bar', '{1}baz')
+      end
+    end
+
+    def test_sintercard_with_single_key
+      target_version('7.0.0') do
+        r.sadd('{1}foo', %w[s1 s2 s3])
+
+        assert_equal 3, r.sintercard('{1}foo')
+        assert_equal 0, r.sintercard('{1}nonexistent')
+      end
+    end
+
+    def test_sintercard_with_missing_key
+      target_version('7.0.0') do
+        r.sadd('{1}foo', %w[s1 s2 s3])
+
+        assert_equal 0, r.sintercard('{1}foo', '{1}nonexistent')
+      end
+    end
+
+    def test_variadic_sintercard_expand
+      target_version('7.0.0') do
+        r.sadd('{1}foo', %w[s1 s2 s3])
+        r.sadd('{1}bar', %w[s2 s3])
+
+        assert_equal 2, r.sintercard(['{1}foo', '{1}bar'])
+      end
+    end
+
+    def test_sintercard_with_limit
+      target_version('7.0.0') do
+        r.sadd('{1}foo', %w[s1 s2 s3 s4])
+        r.sadd('{1}bar', %w[s2 s3 s4])
+
+        assert_equal 1, r.sintercard('{1}foo', '{1}bar', limit: 1)
+        assert_equal 3, r.sintercard('{1}foo', '{1}bar', limit: 0)
+        assert_equal 3, r.sintercard('{1}foo', '{1}bar', limit: 10)
+      end
+    end
+
     def test_sscan
       r.sadd('foo', %w[1 2 3 foo foobar feelsgood])
       assert_equal %w[0 feelsgood foo foobar], r.sscan('foo', 0, match: 'f*').flatten.sort

--- a/test/lint/sorted_sets.rb
+++ b/test/lint/sorted_sets.rb
@@ -681,6 +681,54 @@ module Lint
       end
     end
 
+    def test_zintercard
+      target_version "7.0.0" do
+        r.zadd '{1}foo', [[1, 'm1'], [2, 'm2'], [3, 'm3'], [4, 'm4']]
+        r.zadd '{1}bar', [[1, 'm2'], [2, 'm3'], [3, 'm4'], [4, 'm5']]
+        r.zadd '{1}baz', [[1, 'm3'], [2, 'm4'], [3, 'm6']]
+
+        assert_equal 3, r.zintercard('{1}foo', '{1}bar')
+        assert_equal 2, r.zintercard('{1}foo', '{1}bar', '{1}baz')
+      end
+    end
+
+    def test_zintercard_with_single_key
+      target_version "7.0.0" do
+        r.zadd '{1}foo', [[1, 'm1'], [2, 'm2'], [3, 'm3']]
+
+        assert_equal 3, r.zintercard('{1}foo')
+        assert_equal 0, r.zintercard('{1}nonexistent')
+      end
+    end
+
+    def test_zintercard_with_missing_key
+      target_version "7.0.0" do
+        r.zadd '{1}foo', [[1, 'm1'], [2, 'm2'], [3, 'm3']]
+
+        assert_equal 0, r.zintercard('{1}foo', '{1}nonexistent')
+      end
+    end
+
+    def test_variadic_zintercard_expand
+      target_version "7.0.0" do
+        r.zadd '{1}foo', [[1, 'm1'], [2, 'm2'], [3, 'm3']]
+        r.zadd '{1}bar', [[1, 'm2'], [2, 'm3']]
+
+        assert_equal 2, r.zintercard(['{1}foo', '{1}bar'])
+      end
+    end
+
+    def test_zintercard_with_limit
+      target_version "7.0.0" do
+        r.zadd '{1}foo', [[1, 'm1'], [2, 'm2'], [3, 'm3'], [4, 'm4']]
+        r.zadd '{1}bar', [[1, 'm2'], [2, 'm3'], [3, 'm4']]
+
+        assert_equal 1, r.zintercard('{1}foo', '{1}bar', limit: 1)
+        assert_equal 3, r.zintercard('{1}foo', '{1}bar', limit: 0)
+        assert_equal 3, r.zintercard('{1}foo', '{1}bar', limit: 10)
+      end
+    end
+
     def test_zinter_with_count_aggregate
       target_version "8.8" do
         r.zadd '{1}foo', [[1, 'm1'], [2, 'm2'], [3, 'm3']]

--- a/test/lint/strings.rb
+++ b/test/lint/strings.rb
@@ -375,6 +375,54 @@ module Lint
       assert_equal "abcde", r.getrange("foo", 0, -1)
     end
 
+    def test_lcs
+      target_version "7.0.0" do
+        r.set("{1}foo", "ohmytext")
+        r.set("{1}bar", "mynewtext")
+
+        assert_equal "mytext", r.lcs("{1}foo", "{1}bar")
+      end
+    end
+
+    def test_lcs_with_len
+      target_version "7.0.0" do
+        r.set("{1}foo", "ohmytext")
+        r.set("{1}bar", "mynewtext")
+
+        assert_equal 6, r.lcs("{1}foo", "{1}bar", len: true)
+      end
+    end
+
+    def test_lcs_with_idx
+      target_version "7.0.0" do
+        r.set("{1}foo", "ohmytext")
+        r.set("{1}bar", "mynewtext")
+
+        expected = { "matches" => [[[4, 7], [5, 8]], [[2, 3], [0, 1]]], "len" => 6 }
+        assert_equal expected, r.lcs("{1}foo", "{1}bar", idx: true)
+      end
+    end
+
+    def test_lcs_with_idx_minmatchlen_and_withmatchlen
+      target_version "7.0.0" do
+        r.set("{1}foo", "ohmytext")
+        r.set("{1}bar", "mynewtext")
+
+        assert_equal({ "matches" => [[[4, 7], [5, 8]]], "len" => 6 },
+                     r.lcs("{1}foo", "{1}bar", idx: true, minmatchlen: 4))
+        assert_equal({ "matches" => [[[4, 7], [5, 8], 4]], "len" => 6 },
+                     r.lcs("{1}foo", "{1}bar", idx: true, minmatchlen: 4, withmatchlen: true))
+      end
+    end
+
+    def test_lcs_with_missing_keys
+      target_version "7.0.0" do
+        assert_equal "", r.lcs("{1}missing1", "{1}missing2")
+        assert_equal 0, r.lcs("{1}missing1", "{1}missing2", len: true)
+        assert_equal({ "matches" => [], "len" => 0 }, r.lcs("{1}missing1", "{1}missing2", idx: true))
+      end
+    end
+
     def test_setrange
       r.set("foo", "abcde")
 

--- a/test/redis/sorting_test.rb
+++ b/test/redis/sorting_test.rb
@@ -55,4 +55,81 @@ class TestSorting < Minitest::Test
     r.sort("bar", get: ["foo:*:a", "foo:*:b"], store: 'baz')
     assert_equal ["s1a", "s1b", "s2a", "s2b"], r.lrange("baz", 0, -1)
   end
+
+  def test_sort_ro
+    target_version "7.0.0" do
+      r.rpush("bar", %w[3 1 2])
+
+      assert_equal %w[1 2 3], r.sort_ro("bar")
+      assert_equal %w[3 2], r.sort_ro("bar", order: "desc", limit: [0, 2])
+    end
+  end
+
+  def test_sort_ro_with_get
+    target_version "7.0.0" do
+      r.set("foo:1", "s1")
+      r.set("foo:2", "s2")
+
+      r.rpush("bar", %w[1 2])
+
+      assert_equal ["s1"], r.sort_ro("bar", get: "foo:*", limit: [0, 1])
+      assert_equal ["s2"], r.sort_ro("bar", get: "foo:*", limit: [0, 1], order: "desc alpha")
+    end
+  end
+
+  def test_sort_ro_with_an_array_of_gets
+    target_version "7.0.0" do
+      r.set("foo:1:a", "s1a")
+      r.set("foo:1:b", "s1b")
+
+      r.set("foo:2:a", "s2a")
+      r.set("foo:2:b", "s2b")
+
+      r.rpush("bar", %w[1 2])
+
+      assert_equal [["s1a", "s1b"]], r.sort_ro("bar", get: ["foo:*:a", "foo:*:b"], limit: [0, 1])
+      assert_equal [["s2a", "s2b"]], r.sort_ro("bar", get: ["foo:*:a", "foo:*:b"], limit: [0, 1], order: "desc alpha")
+      assert_equal [["s1a", "s1b"], ["s2a", "s2b"]], r.sort_ro("bar", get: ["foo:*:a", "foo:*:b"])
+    end
+  end
+
+  def test_sort_ro_with_by
+    target_version "7.0.0" do
+      r.rpush("bar", %w[1 2 3])
+      r.set("weight_1", "30")
+      r.set("weight_2", "20")
+      r.set("weight_3", "10")
+
+      assert_equal %w[3 2 1], r.sort_ro("bar", by: "weight_*")
+      assert_equal [["3", "10"], ["2", "20"], ["1", "30"]], r.sort_ro("bar", by: "weight_*", get: ["#", "weight_*"])
+    end
+  end
+
+  def test_sort_ro_on_missing_key
+    target_version "7.0.0" do
+      assert_equal [], r.sort_ro("missing")
+    end
+  end
+
+  def test_sort_ro_has_no_store_option
+    assert_raises(ArgumentError) { r.sort_ro("bar", store: "baz") }
+  end
+
+  def test_sort_ro_in_pipeline
+    target_version "7.0.0" do
+      r.set("foo:1:a", "s1a")
+      r.set("foo:1:b", "s1b")
+      r.set("foo:2:a", "s2a")
+      r.set("foo:2:b", "s2b")
+      r.rpush("bar", %w[2 1])
+
+      plain, sliced = r.pipelined do |pipe|
+        pipe.sort_ro("bar")
+        pipe.sort_ro("bar", get: ["foo:*:a", "foo:*:b"])
+      end
+
+      assert_equal %w[1 2], plain
+      assert_equal [["s1a", "s1b"], ["s2a", "s2b"]], sliced
+    end
+  end
 end


### PR DESCRIPTION
Added support for following missing Redis 7.0 commands:
- SORT_RO
- SINTERCARD
- ZINTERCARD
- LCS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and test coverage with a targeted distributed routing fix for SORT; no auth or data-mutation behavior changes beyond new command bindings.
> 
> **Overview**
> Adds client support for four Redis 7.0 commands: **`sort_ro`** (read-only `SORT` without `STORE`), **`sintercard`** / **`zintercard`** (intersection cardinality with optional **`limit`**), and **`lcs`** (longest common subsequence with **`len`**, **`idx`**, and related flags).
> 
> **`sort`** and **`sort_ro`** now share a private **`_sort`** helper in `keys.rb`. On **`Redis::Distributed`**, same-node routing for sort commands uses a new **`sort_keys`** helper that only treats **`BY`/`GET` patterns containing `*`** (plus the list key and **`store`**) as extra keys—so **`GET #`** and **`BY nosort`** no longer incorrectly force cross-node **`CannotDistribute`** errors.
> 
> Distributed wrappers mirror the new commands and enforce same-node rules where multiple keys are involved. Lint, integration, cluster, and distributed tests cover the new APIs and the sort routing fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4abf4cfae90a303f14e31da6c75d7ac9977b1d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->