### PR TITLE
Added support for missing XSETID command + 7.0 specific arguments

### DIFF
--- a/lib/redis/commands/server.rb
+++ b/lib/redis/commands/server.rb
@@ -84,14 +84,26 @@ class Redis
 
       # Get information and statistics about the server.
       #
-      # @param [String, Symbol] cmd e.g. "commandstats"
-      # @return [Hash<String, String>]
-      def info(cmd = nil)
-        send_command([:info, cmd].compact) do |reply|
+      # @example Default sections
+      #   redis.info
+      # @example One section
+      #   redis.info(:commandstats)
+      #     # => { "get" => { "calls" => "2", ... }, ... }
+      # @example Several sections at once (Redis 7.0)
+      #   redis.info(:server, :clients)
+      #
+      # @param [Array<String, Symbol>] sections zero or more sections, e.g. `server`, `clients`,
+      #   `commandstats`, `all`, `everything`. Passing more than one section requires Redis 7.0.
+      # @return [Hash<String, String>] the parsed `INFO` output. When `commandstats` is the only
+      #   section, the reply is nested per command instead: `{ "get" => { "calls" => "2", ... } }`.
+      def info(*sections)
+        sections.flatten!(1)
+        sections.compact!
+        send_command([:info].concat(sections)) do |reply|
           if reply.is_a?(String)
             reply = HashifyInfo.call(reply)
 
-            if cmd && cmd.to_s == "commandstats"
+            if sections.size == 1 && sections.first.to_s == "commandstats"
               # Extract nested hashes for INFO COMMANDSTATS
               reply = Hash[reply.map do |k, v|
                 v = v.split(",").map { |e| e.split("=") }
@@ -135,10 +147,35 @@ class Redis
       end
 
       # Synchronously save the dataset to disk and then shut down the server.
-      def shutdown
+      #
+      # @example Default: save if a save point is configured, then exit
+      #   redis.shutdown
+      #     # => nil
+      # @example Skip the RDB save and don't wait for lagging replicas (Redis 7.0)
+      #   redis.shutdown(save: false, now: true)
+      # @example Cancel an in-progress shutdown (Redis 7.0)
+      #   redis.shutdown(abort: true)
+      #     # => "OK"
+      #
+      # @param [Boolean, nil] save `true` forces an RDB save (`SAVE`), `false` skips it
+      #   (`NOSAVE`); `nil` leaves the decision to the server's save points
+      # @param [Boolean] now skip waiting for lagging replicas (Redis 7.0)
+      # @param [Boolean] force ignore errors that would normally prevent the shutdown, such as a
+      #   failed RDB or AOF write (Redis 7.0)
+      # @param [Boolean] abort cancel a shutdown that is waiting for replicas (Redis 7.0)
+      #
+      # @return [nil] when the server shut down (the connection is closed without a reply)
+      # @return [String] `OK` when `abort:` cancelled a pending shutdown
+      def shutdown(save: nil, now: false, force: false, abort: false)
+        args = [:shutdown]
+        args << (save ? "SAVE" : "NOSAVE") unless save.nil?
+        args << "NOW" if now
+        args << "FORCE" if force
+        args << "ABORT" if abort
+
         synchronize do |client|
           client.disable_reconnection do
-            client.call_v([:shutdown])
+            client.call_v(args)
           rescue ConnectionError
             # This means Redis has probably exited.
             nil

--- a/lib/redis/commands/streams.rb
+++ b/lib/redis/commands/streams.rb
@@ -219,19 +219,46 @@ class Redis
       #   redis.xgroup(:destroy, 'mystream', 'mygroup')
       # @example With `delconsumer` subcommand
       #   redis.xgroup(:delconsumer, 'mystream', 'mygroup', 'consumer1')
+      # @example With `create` subcommand and the group's entries-read counter (Redis 7.0)
+      #   redis.xgroup(:create, 'mystream', 'mygroup', '$', mkstream: true, entriesread: 10)
       #
-      # @param subcommand     [String] `create` `setid` `destroy` `delconsumer`
+      # @param subcommand     [String] `create` `setid` `destroy` `delconsumer` `createconsumer`
       # @param key            [String] the stream key
       # @param group          [String] the consumer group name
       # @param id_or_consumer [String]
       #   * the entry id or `$`, required if subcommand is `create` or `setid`
-      #   * the consumer name, required if subcommand is `delconsumer`
-      # @param mkstream [Boolean] whether to create an empty stream automatically or not
+      #   * the consumer name, required if subcommand is `delconsumer` or `createconsumer`
+      # @param mkstream    [Boolean] (`create`) create an empty stream automatically if it does not exist
+      # @param entriesread [Integer] (`create`, `setid`) the number of entries the group has read, used by
+      #   the server to compute the group's lag (Redis 7.0)
       #
       # @return [String] `OK` if subcommand is `create` or `setid`
-      # @return [Integer] effected count if subcommand is `destroy` or `delconsumer`
-      def xgroup(subcommand, key, group, id_or_consumer = nil, mkstream: false)
-        args = [:xgroup, subcommand, key, group, id_or_consumer, (mkstream ? 'MKSTREAM' : nil)].compact
+      # @return [Integer] effected count if subcommand is `destroy`, `delconsumer` or `createconsumer`
+      def xgroup(subcommand, key, group, id_or_consumer = nil, mkstream: false, entriesread: nil)
+        args = [:xgroup, subcommand, key, group, id_or_consumer].compact
+        args << 'MKSTREAM' if mkstream
+        args << 'ENTRIESREAD' << Integer(entriesread) if entriesread
+        send_command(args)
+      end
+
+      # Set the last entry id of the stream, and optionally its entries-added counter and
+      # maximal deleted entry id.
+      #
+      # @example Set the last id
+      #   redis.xsetid('mystream', '1526919030474-55')
+      # @example Also set the counters used for lag tracking (Redis 7.0)
+      #   redis.xsetid('mystream', '1526919030474-55', entriesadded: 100, maxdeletedid: '1526919030474-10')
+      #
+      # @param key          [String]  the stream key
+      # @param id           [String]  the new last entry id, must not be smaller than the current one
+      # @param entriesadded [Integer] the number of entries added to the stream over its lifetime (Redis 7.0)
+      # @param maxdeletedid [String]  the maximal entry id that was deleted from the stream (Redis 7.0)
+      #
+      # @return [String] `OK`
+      def xsetid(key, id, entriesadded: nil, maxdeletedid: nil)
+        args = [:xsetid, key, id]
+        args << 'ENTRIESADDED' << Integer(entriesadded) if entriesadded
+        args << 'MAXDELETEDID' << maxdeletedid if maxdeletedid
         send_command(args)
       end
 

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -100,8 +100,8 @@ class Redis
     end
 
     # Get information and statistics about the server.
-    def info(cmd = nil)
-      on_each_node :info, cmd
+    def info(*sections)
+      on_each_node :info, *sections
     end
 
     # Get the UNIX time stamp of the last successful save to disk.

--- a/test/distributed/remote_server_control_commands_test.rb
+++ b/test/distributed/remote_server_control_commands_test.rb
@@ -26,6 +26,16 @@ class TestDistributedRemoteServerControlCommands < Minitest::Test
     end
   end
 
+  def test_info_with_multiple_sections
+    target_version "7.0.0" do
+      r.info(:server, :clients).each do |info|
+        assert info.key?("redis_version")
+        assert info.key?("connected_clients")
+        assert !info.key?("used_memory")
+      end
+    end
+  end
+
   def test_info_commandstats
     r.nodes.each do |n|
       n.config(:resetstat)

--- a/test/lint/streams.rb
+++ b/test/lint/streams.rb
@@ -55,6 +55,34 @@ module Lint
       assert_raises(Redis::CommandError) { redis.xinfo(:consumers, 's1', nil) }
     end
 
+    def test_xsetid
+      redis.xadd('s1', { f: 'v1' }, id: '0-1')
+      redis.xadd('s1', { f: 'v2' }, id: '0-2')
+
+      assert_equal 'OK', redis.xsetid('s1', '0-5')
+      assert_equal '0-5', redis.xinfo(:stream, 's1')['last-generated-id']
+    end
+
+    def test_xsetid_with_entriesadded_and_maxdeletedid_options
+      target_version '7.0.0' do
+        redis.xadd('s1', { f: 'v1' }, id: '0-1')
+        redis.xadd('s1', { f: 'v2' }, id: '0-2')
+
+        assert_equal 'OK', redis.xsetid('s1', '0-5', entriesadded: 10, maxdeletedid: '0-3')
+
+        info = redis.xinfo(:stream, 's1')
+        assert_equal '0-5', info['last-generated-id']
+        assert_equal 10, info['entries-added']
+        assert_equal '0-3', info['max-deleted-entry-id']
+      end
+    end
+
+    def test_xsetid_with_id_smaller_than_the_last_entry
+      redis.xadd('s1', { f: 'v1' }, id: '0-5')
+
+      assert_raises(Redis::CommandError) { redis.xsetid('s1', '0-1') }
+    end
+
     def test_xadd_with_entry_as_splatted_params
       assert_match ENTRY_ID_FORMAT, redis.xadd('s1', { f1: 'v1', f2: 'v2' })
     end
@@ -598,6 +626,43 @@ module Lint
       redis.xadd('s1', { f: 'v' })
       redis.xgroup(:create, 's1', 'g1', '$')
       assert_equal 'OK', redis.xgroup(:setid, 's1', 'g1', '0')
+    end
+
+    def test_xgroup_with_create_subcommand_and_entriesread_option
+      target_version '7.0.0' do
+        redis.xadd('s1', { f: 'v1' }, id: '0-1')
+        redis.xadd('s1', { f: 'v2' }, id: '0-2')
+        redis.xadd('s1', { f: 'v3' }, id: '0-3')
+
+        assert_equal 'OK', redis.xgroup(:create, 's1', 'g1', '0-1', entriesread: 1)
+
+        group = redis.xinfo(:groups, 's1').first
+        assert_equal 1, group['entries-read']
+        assert_equal 2, group['lag']
+      end
+    end
+
+    def test_xgroup_with_create_subcommand_and_mkstream_and_entriesread_options
+      target_version '7.0.0' do
+        assert_equal 'OK', redis.xgroup(:create, 's2', 'g1', '$', mkstream: true, entriesread: 0)
+        assert_equal 0, redis.xinfo(:groups, 's2').first['entries-read']
+      end
+    end
+
+    def test_xgroup_with_setid_subcommand_and_entriesread_option
+      target_version '7.0.0' do
+        redis.xadd('s1', { f: 'v1' }, id: '0-1')
+        redis.xadd('s1', { f: 'v2' }, id: '0-2')
+        redis.xadd('s1', { f: 'v3' }, id: '0-3')
+        redis.xgroup(:create, 's1', 'g1', '$')
+
+        assert_equal 'OK', redis.xgroup(:setid, 's1', 'g1', '0-2', entriesread: 2)
+
+        group = redis.xinfo(:groups, 's1').first
+        assert_equal '0-2', group['last-delivered-id']
+        assert_equal 2, group['entries-read']
+        assert_equal 1, group['lag']
+      end
     end
 
     def test_xgroup_with_destroy_subcommand

--- a/test/redis/connection_handling_test.rb
+++ b/test/redis/connection_handling_test.rb
@@ -110,6 +110,38 @@ class TestConnectionHandling < Minitest::Test
     end
   end
 
+  def test_shutdown_with_options
+    received = nil
+    commands = {
+      shutdown: ->(*args) { received = args; :exit }
+    }
+
+    redis_mock(commands) do |redis|
+      assert_nil redis.shutdown(save: false, now: true, force: true)
+    end
+    assert_equal %w[NOSAVE NOW FORCE], received
+
+    redis_mock(commands) do |redis|
+      assert_nil redis.shutdown(save: true)
+    end
+    assert_equal %w[SAVE], received
+  end
+
+  def test_shutdown_with_abort
+    received = nil
+    commands = {
+      shutdown: ->(*args) { received = args; "+OK\r\n" },
+      ping: ->(*_) { "+PONG\r\n" }
+    }
+
+    redis_mock(commands) do |redis|
+      # ABORT cancels a pending shutdown and replies: the connection stays usable.
+      assert_equal "OK", redis.shutdown(abort: true)
+      assert_equal "PONG", redis.ping
+    end
+    assert_equal %w[ABORT], received
+  end
+
   def test_shutdown_with_error
     connections = 0
     commands = {

--- a/test/redis/remote_server_control_commands_test.rb
+++ b/test/redis/remote_server_control_commands_test.rb
@@ -33,6 +33,41 @@ class TestRemoteServerControlCommands < Minitest::Test
     assert_equal '2', result['get']['calls']
   end
 
+  def test_info_with_a_single_section
+    info = r.info(:server)
+
+    assert info.key?("redis_version")
+    assert !info.key?("connected_clients")
+  end
+
+  def test_info_with_nil_section_behaves_like_no_section
+    assert_equal r.info.keys, r.info(nil).keys
+  end
+
+  def test_info_with_multiple_sections
+    target_version "7.0.0" do
+      info = r.info(:server, :clients)
+
+      assert info.key?("redis_version")
+      assert info.key?("connected_clients")
+      assert !info.key?("used_memory")
+
+      # Values such as uptime change between calls, so compare the section layout only.
+      assert_equal info.keys, r.info(%i[server clients]).keys
+    end
+  end
+
+  def test_info_with_commandstats_and_another_section_is_not_nested
+    target_version "7.0.0" do
+      r.get("foo")
+
+      info = r.info(:server, :commandstats)
+
+      assert info.key?("redis_version")
+      assert info.key?("cmdstat_get")
+    end
+  end
+
   def test_monitor_redis
     log = []
 


### PR DESCRIPTION
- shutdown (lib/redis/commands/server.rb:138) takes no arguments — 7.0 syntax is SHUTDOWN [NOSAVE|SAVE] [NOW] [FORCE] [ABORT]. ABORT in particular is unusable today.                                          
- xgroup (streams.rb:233) — the rigid positional signature can't express the new ENTRIESREAD option on XGROUP CREATE and XGROUP SETID.                                                                         
- xsetid — no wrapper at all; 7.0 added ENTRIESADDED and MAXDELETEDID arguments.                                                                                                                              
- info (server.rb:89) accepts a single section; 7.0 allows INFO section [section ...].

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `shutdown` and `info` signature/behavior changes affect operational tooling; `shutdown` can still stop the server, and `info` multi-section requires Redis 7.0 on the server.
> 
> **Overview**
> Adds **Redis 7.0** client coverage for server control and stream metadata that was missing or too narrow before.
> 
> **`info`** now accepts zero or more section arguments (e.g. `redis.info(:server, :clients)`), with `Redis::Distributed#info` forwarding the same way. The nested per-command hash for **`commandstats`** is still applied only when that is the **sole** section, so mixed sections keep flat `cmdstat_*` keys.
> 
> **`shutdown`** gains keyword options that map to `SAVE`/`NOSAVE`, `NOW`, `FORCE`, and `ABORT` (including returning `"OK"` when aborting a pending shutdown). Calling `shutdown` with no arguments is unchanged.
> 
> On streams, **`xsetid`** is a new wrapper for setting the stream’s last ID plus optional **`entriesadded`** and **`maxdeletedid`**. **`xgroup`** adds an **`entriesread:`** option on create/setid and builds `MKSTREAM` / `ENTRIESREAD` arguments explicitly instead of a single compacted positional list.
> 
> Tests cover multi-section `info`, shutdown option wiring (including mocks), and the new stream APIs behind `target_version "7.0.0"` where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48ed58076ba16c9eb848e1835592fb575d574367. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->