### PR TITLE
Fixed XAUTOCLAIM omit Deleted entry from reply

### DIFF
--- a/lib/redis/commands.rb
+++ b/lib/redis/commands.rb
@@ -219,19 +219,23 @@ class Redis
       end
     }
 
+    # XAUTOCLAIM: Redis 7.0 appends the ids of entries that were deleted from the stream and
+    # dropped from the PEL; 6.2 has no third element and reports them as nils inside entries.
     HashifyStreamAutoclaim = lambda { |reply|
       {
         'next' => reply[0],
         'entries' => reply[1].compact.map do |entry, values|
           [entry, values.each_slice(2)&.to_h]
-        end
+        end,
+        'deleted' => reply[2] || []
       }
     }
 
     HashifyStreamAutoclaimJustId = lambda { |reply|
       {
         'next' => reply[0],
-        'entries' => reply[1]
+        'entries' => reply[1],
+        'deleted' => reply[2] || []
       }
     }
 

--- a/lib/redis/commands/streams.rb
+++ b/lib/redis/commands/streams.rb
@@ -397,8 +397,12 @@ class Redis
       # @param justid        [Boolean]       whether to fetch just an array of entry ids or not.
       #                                      Does not increment retry count when true
       #
-      # @return [Hash{String => Hash}] the entries successfully claimed
-      # @return [Array<String>]        the entry ids successfully claimed if justid option is `true`
+      # @return [Hash] with the keys
+      #   * `'next'`    [String] the entry id to pass as `start` on the next call, `0-0` when done
+      #   * `'entries'` [Array<[String, Hash]>] the claimed entries as `[id, fields]` pairs, or just
+      #     the ids when `justid` is `true`
+      #   * `'deleted'` [Array<String>] ids that were deleted from the stream and dropped from the
+      #     PEL (Redis 7.0); always `[]` on Redis 6.2
       def xautoclaim(key, group, consumer, min_idle_time, start, count: nil, justid: false)
         args = [:xautoclaim, key, group, consumer, min_idle_time, start]
         if count

--- a/test/lint/streams.rb
+++ b/test/lint/streams.rb
@@ -981,6 +981,7 @@ module Lint
       assert_equal '0-0', actual['next']
       assert_equal %w(0-2 0-3), actual['entries'].map(&:first)
       assert_equal(%w(v2 v3), actual['entries'].map { |i| i.last['f'] })
+      assert_equal [], actual['deleted']
     end
 
     def test_xautoclaim_with_justid_option
@@ -1046,6 +1047,26 @@ module Lint
 
       assert_equal '0-0', actual['next']
       assert_equal [], actual['entries']
+      # 7.0 reports the ids it dropped from the PEL; 6.2 has no such reply element.
+      assert_equal(version >= '7.0.0' ? ['0-2'] : [], actual['deleted'])
+    end
+
+    def test_xautoclaim_with_deleted_entry_and_justid_option
+      omit_version('7.0.0')
+
+      redis.xadd('s1', { f: 'v1' }, id: '0-1')
+      redis.xgroup(:create, 's1', 'g1', '$')
+      redis.xadd('s1', { f: 'v2' }, id: '0-2')
+      redis.xadd('s1', { f: 'v3' }, id: '0-3')
+      redis.xreadgroup('g1', 'c1', 's1', '>')
+      redis.xdel('s1', '0-2')
+      sleep 0.01
+
+      actual = redis.xautoclaim('s1', 'g1', 'c2', 0, '0-0', justid: true)
+
+      assert_equal '0-0', actual['next']
+      assert_equal ['0-3'], actual['entries']
+      assert_equal ['0-2'], actual['deleted']
     end
 
     def test_xpending

--- a/test/redis/commands_on_streams_test.rb
+++ b/test/redis/commands_on_streams_test.rb
@@ -7,4 +7,29 @@ require "helper"
 class TestCommandsOnStreams < Minitest::Test
   include Helper::Client
   include Lint::Streams
+
+  # Redis 6.2 replies to XAUTOCLAIM with two elements; the third (deleted ids) arrived in 7.0.
+  def test_xautoclaim_tolerates_the_two_element_reply_of_redis_6_2
+    commands = { xautoclaim: ->(*_) { ['0-0', [['0-1', %w[f v1]], nil, ['0-3', %w[f v3]]]] } }
+
+    redis_mock(commands) do |redis|
+      actual = redis.xautoclaim('s1', 'g1', 'c1', 0, '0-0')
+
+      assert_equal '0-0', actual['next']
+      assert_equal [['0-1', { 'f' => 'v1' }], ['0-3', { 'f' => 'v3' }]], actual['entries']
+      assert_equal [], actual['deleted']
+    end
+  end
+
+  def test_xautoclaim_with_justid_tolerates_the_two_element_reply_of_redis_6_2
+    commands = { xautoclaim: ->(*_) { ['0-0', %w[0-1 0-3]] } }
+
+    redis_mock(commands) do |redis|
+      actual = redis.xautoclaim('s1', 'g1', 'c1', 0, '0-0', justid: true)
+
+      assert_equal '0-0', actual['next']
+      assert_equal %w[0-1 0-3], actual['entries']
+      assert_equal [], actual['deleted']
+    end
+  end
 end

--- a/test/support/redis_mock.rb
+++ b/test/support/redis_mock.rb
@@ -108,6 +108,9 @@ module RedisMock
         write_resp_value(session, key, protocol)
         write_resp_value(session, val, protocol)
       end
+    when nil
+      # A null element (RESP3 `_`, RESP2 null bulk), e.g. a deleted entry inside XAUTOCLAIM on 6.2.
+      session.write(protocol >= 3 ? "_\r\n" : "$-1\r\n")
     else
       str = value.to_s
       session.write("$#{str.bytesize}\r\n#{str}\r\n")


### PR DESCRIPTION
New deleted entry from XAUTOCLAIM reply was added as a part of Redis 7.0. Currently, parser omits it and does not add it into a reply structure

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive response field with a safe default on older Redis; limited to stream consumer-group parsing and tests.
> 
> **Overview**
> **`xautoclaim`** now includes a **`'deleted'`** key in its return hash: an array of stream entry ids Redis removed from the pending list because the messages were already deleted from the stream (Redis **7.0+**). On **6.2**, that key is always **`[]`** because the server reply has no third element.
> 
> The **`HashifyStreamAutoclaim`** / **`HashifyStreamAutoclaimJustId`** parsers map `reply[2]` into **`'deleted'`**, and **`xautoclaim`** docs describe the full **`next` / `entries` / `deleted`** shape. Integration and mock tests cover deleted-stream cases and two-element 6.2 replies; **`redis_mock`** encodes **`nil`** as RESP null so 6.2-style deleted slots in the entries list can be exercised in tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da735b97e8c5527ec1c2cc2ca5999165621db070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->