### PR TITLE
Fixed Redis 7.2 reply shapes

### DIFF
--- a/lib/redis/commands.rb
+++ b/lib/redis/commands.rb
@@ -94,12 +94,16 @@ class Redis
       end
     }
 
+    # RESP2 carries doubles as bulk strings, including the non-finite ones Redis 7.2 normalizes
+    # to "inf", "-inf" and "nan"; RESP3 delivers native Floats, which pass through.
     Floatify = lambda { |value|
       case value
       when "inf"
         Float::INFINITY
       when "-inf"
         -Float::INFINITY
+      when "nan"
+        Float::NAN
       when String
         Float(value)
       else
@@ -115,7 +119,11 @@ class Redis
       value.first.is_a?(String) ? value.map(&Floatify) : value
     }
 
-    FloatifyPair = lambda { |(first, score)|
+    # A nil reply (e.g. ZRANK WITHSCORE on a missing member) stays nil instead of becoming [nil, nil].
+    FloatifyPair = lambda { |pair|
+      return if pair.nil?
+
+      first, score = pair
       [first, Floatify.call(score)]
     }
 

--- a/lib/redis/commands/sorted_sets.rb
+++ b/lib/redis/commands/sorted_sets.rb
@@ -463,9 +463,10 @@ class Redis
       # @param [String] key
       # @param [String] member
       #
-      # @return [Integer, [Integer, Float]]
+      # @return [Integer, [Integer, Float], nil]
       #   - when `:with_score` is not specified, an Integer
       #   - when `:with_score` is specified, a `[rank, score]` pair
+      #   - `nil` when the key or the member does not exist
       def zrank(key, member, withscore: false, with_score: withscore)
         args = [:zrank, key, member]
 
@@ -490,9 +491,10 @@ class Redis
       # @param [String] key
       # @param [String] member
       #
-      # @return [Integer, [Integer, Float]]
+      # @return [Integer, [Integer, Float], nil]
       #   - when `:with_score` is not specified, an Integer
       #   - when `:with_score` is specified, a `[rank, score]` pair
+      #   - `nil` when the key or the member does not exist
       def zrevrank(key, member, withscore: false, with_score: withscore)
         args = [:zrevrank, key, member]
 

--- a/test/lint/sorted_sets.rb
+++ b/test/lint/sorted_sets.rb
@@ -244,6 +244,27 @@ module Lint
       end
     end
 
+    def test_zrank_with_score_for_a_missing_member
+      target_version "7.2" do
+        r.zadd "foo", 1, "s1"
+
+        # Same nil as the plain form, not a [nil, nil] pair.
+        assert_nil r.zrank("foo", "nope")
+        assert_nil r.zrank("foo", "nope", with_score: true)
+        assert_nil r.zrank("missing", "s1", with_score: true)
+      end
+    end
+
+    def test_zrevrank_with_score_for_a_missing_member
+      target_version "7.2" do
+        r.zadd "foo", 1, "s1"
+
+        assert_nil r.zrevrank("foo", "nope")
+        assert_nil r.zrevrank("foo", "nope", with_score: true)
+        assert_nil r.zrevrank("missing", "s1", with_score: true)
+      end
+    end
+
     def test_zrange
       r.zadd "foo", 1, "s1"
       r.zadd "foo", 2, "s2"

--- a/test/redis/commands_on_sorted_sets_test.rb
+++ b/test/redis/commands_on_sorted_sets_test.rb
@@ -5,4 +5,44 @@ require "helper"
 class TestCommandsOnSortedSets < Minitest::Test
   include Helper::Client
   include Lint::SortedSets
+
+  # Core Redis never stores a NaN score, but Redis 7.2 normalizes any NaN a reply carries (Lua,
+  # modules) to a "nan" bulk string under RESP2 and a NaN double under RESP3. Both must reach the
+  # caller as Float::NAN instead of raising from Float("nan").
+  def nan_reply
+    PROTOCOL == 3 ? ",nan\r\n" : "$3\r\nnan\r\n"
+  end
+
+  def test_floatify_handles_nan
+    assert_predicate Redis::Commands::Floatify.call("nan"), :nan?
+    assert_predicate Redis::Commands::Floatify.call(Float::NAN), :nan?
+    assert_equal Float::INFINITY, Redis::Commands::Floatify.call("inf")
+  end
+
+  def test_zscore_with_a_nan_reply
+    redis_mock(zscore: ->(*_) { nan_reply }) do |redis|
+      assert_predicate redis.zscore("foo", "s1"), :nan?
+    end
+  end
+
+  def test_zincrby_with_a_nan_reply
+    redis_mock(zincrby: ->(*_) { nan_reply }) do |redis|
+      assert_predicate redis.zincrby("foo", 1, "s1"), :nan?
+    end
+  end
+
+  def test_zrange_with_scores_with_a_nan_reply
+    reply = if PROTOCOL == 3
+      "*1\r\n*2\r\n$2\r\ns1\r\n,nan\r\n"
+    else
+      "*2\r\n$2\r\ns1\r\n$3\r\nnan\r\n"
+    end
+
+    redis_mock(zrange: ->(*_) { reply }) do |redis|
+      member, score = redis.zrange("foo", 0, -1, with_scores: true).first
+
+      assert_equal "s1", member
+      assert_predicate score, :nan?
+    end
+  end
 end


### PR DESCRIPTION
- Floatify crashes on "nan". 7.2 normalizes any NaN in a reply to the literal nan (RESP2 bulk string). Floatify (lib/redis/commands.rb:83) handles "inf"/"-inf" but falls through to Float(value), and         
Float("nan") raises ArgumentError. Add a when "nan" then Float::NAN branch (RESP3 already delivers a native double, so only the RESP2 path is affected).                                                     

- zrank(..., withscore: true) for a missing member likely returns [nil, nil] instead of nil. FloatifyPair (commands.rb:96) destructures a nil reply into [nil, Floatify.call(nil)]. Worth a test under both    
protocols and a nil guard.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3d4d5e44a0383dec1d4fe1f6db1cbd680f8dfe5b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->