### PR TITLE
Added support for missing HFE commands

### DIFF
--- a/lib/redis/commands/hashes.rb
+++ b/lib/redis/commands/hashes.rb
@@ -158,6 +158,105 @@ class Redis
         send_command([:hdel, key].concat(fields))
       end
 
+      # Get the value of one or more hash fields and delete them.
+      #
+      # @example
+      #   redis.hset("hash", "f1", "v1", "f2", "v2")
+      #   redis.hgetdel("hash", "f1", "f2") # => ["v1", "v2"]
+      #   redis.hgetdel("hash", "f1", "f3") # => [nil, nil]
+      #
+      # @param [String] key
+      # @param [Array<String>] fields
+      # @return [Array<String, nil>] the value of each requested field, `nil` for fields that
+      #   did not exist
+      def hgetdel(key, *fields)
+        fields.flatten!(1)
+        send_command([:hgetdel, key, 'FIELDS', fields.length, *fields])
+      end
+
+      # Get the value of one or more hash fields and optionally set their expiration. HGETEX is
+      # similar to HMGET, but is a write command with additional options. When no options are
+      # provided, HGETEX behaves like HMGET.
+      #
+      # @example
+      #   redis.hset("hash", "f1", "v1", "f2", "v2")
+      #   redis.hgetex("hash", "f1", "f2") # => ["v1", "v2"]
+      #   redis.hgetex("hash", "f1", ex: 60) # => ["v1"]
+      #
+      # @param [String] key
+      # @param [Array<String>] fields
+      # @param [Hash] options
+      #   - `:ex => Integer`: Set the specified expire time on the fields, in seconds.
+      #   - `:px => Integer`: Set the specified expire time on the fields, in milliseconds.
+      #   - `:exat => Integer`: Set the specified Unix time at which the fields will expire, in
+      #      seconds.
+      #   - `:pxat => Integer`: Set the specified Unix time at which the fields will expire, in
+      #      milliseconds.
+      #   - `:persist => true`: Remove the time to live associated with the fields.
+      # @return [Array<String, nil>] the value of each requested field, `nil` for fields that
+      #   did not exist
+      def hgetex(key, *fields, ex: nil, px: nil, exat: nil, pxat: nil, persist: false)
+        if [ex, px, exat, pxat, persist].count { |option| option } > 1
+          raise ArgumentError, "ex, px, exat, pxat, and persist are mutually exclusive"
+        end
+
+        fields.flatten!(1)
+        args = [:hgetex, key]
+        args << "EX" << Integer(ex) if ex
+        args << "PX" << Integer(px) if px
+        args << "EXAT" << Integer(exat) if exat
+        args << "PXAT" << Integer(pxat) if pxat
+        args << "PERSIST" if persist
+        args.concat(['FIELDS', fields.length, *fields])
+
+        send_command(args)
+      end
+
+      # Set the value of one or more hash fields, and optionally their expiration. Existing
+      # values for the given fields are overwritten, and any previous TTL on those fields is
+      # discarded unless `:keepttl` is given.
+      #
+      # @example
+      #   redis.hsetex("hash", "f1", "v1", "f2", "v2") # => 1
+      #   redis.hsetex("hash", { "f1" => "v1", "f2" => "v2" }, ex: 60) # => 1
+      #
+      # @param [String] key
+      # @param [Array<String> | Hash<String, String>] attrs array or hash of fields and values
+      # @param [Hash] options
+      #   - `:fnx => true`: Only set the fields if none of them already exist. Mutually
+      #      exclusive with `:fxx`.
+      #   - `:fxx => true`: Only set the fields if all of them already exist. Mutually
+      #      exclusive with `:fnx`.
+      #   - `:ex => Integer`: Set the specified expire time on the fields, in seconds.
+      #   - `:px => Integer`: Set the specified expire time on the fields, in milliseconds.
+      #   - `:exat => Integer`: Set the specified Unix time at which the fields will expire, in
+      #      seconds.
+      #   - `:pxat => Integer`: Set the specified Unix time at which the fields will expire, in
+      #      milliseconds.
+      #   - `:keepttl => true`: Retain the time to live already associated with the fields.
+      # @return [Integer] `1` if all the fields were set, `0` if none were set (e.g. the
+      #   `:fnx`/`:fxx` condition was not met)
+      def hsetex(key, *attrs, fnx: nil, fxx: nil, ex: nil, px: nil, exat: nil, pxat: nil, keepttl: false)
+        raise ArgumentError, "fnx and fxx are mutually exclusive" if fnx && fxx
+        if [ex, px, exat, pxat, keepttl].count { |option| option } > 1
+          raise ArgumentError, "ex, px, exat, pxat, and keepttl are mutually exclusive"
+        end
+
+        attrs = attrs.first.flatten if attrs.size == 1 && attrs.first.is_a?(Hash)
+
+        args = [:hsetex, key]
+        args << "FNX" if fnx
+        args << "FXX" if fxx
+        args << "EX" << Integer(ex) if ex
+        args << "PX" << Integer(px) if px
+        args << "EXAT" << Integer(exat) if exat
+        args << "PXAT" << Integer(pxat) if pxat
+        args << "KEEPTTL" if keepttl
+        args.concat(['FIELDS', attrs.length / 2, *attrs])
+
+        send_command(args)
+      end
+
       # Determine if a hash field exists.
       #
       # @param [String] key

--- a/lib/redis/commands/hashes.rb
+++ b/lib/redis/commands/hashes.rb
@@ -243,6 +243,7 @@ class Redis
         end
 
         attrs = attrs.first.flatten if attrs.size == 1 && attrs.first.is_a?(Hash)
+        attrs.flatten!(1)
 
         args = [:hsetex, key]
         args << "FNX" if fnx

--- a/lib/redis/distributed.rb
+++ b/lib/redis/distributed.rb
@@ -1086,6 +1086,23 @@ class Redis
       node_for(key).hdel(key, fields)
     end
 
+    # Get the value of one or more hash fields and delete them.
+    def hgetdel(key, *fields)
+      fields.flatten!(1)
+      node_for(key).hgetdel(key, fields)
+    end
+
+    # Get the value of one or more hash fields and optionally set their expiration.
+    def hgetex(key, *fields, ex: nil, px: nil, exat: nil, pxat: nil, persist: false)
+      fields.flatten!(1)
+      node_for(key).hgetex(key, *fields, ex: ex, px: px, exat: exat, pxat: pxat, persist: persist)
+    end
+
+    # Set the value of one or more hash fields, and optionally their expiration.
+    def hsetex(key, *attrs, fnx: nil, fxx: nil, ex: nil, px: nil, exat: nil, pxat: nil, keepttl: false)
+      node_for(key).hsetex(key, *attrs, fnx: fnx, fxx: fxx, ex: ex, px: px, exat: exat, pxat: pxat, keepttl: keepttl)
+    end
+
     # Determine if a hash field exists.
     def hexists(key, field)
       node_for(key).hexists(key, field)

--- a/test/lint/hashes.rb
+++ b/test/lint/hashes.rb
@@ -68,6 +68,266 @@ module Lint
       assert_nil r.hget("foo", "f2")
     end
 
+    def test_hgetdel
+      target_version "8.0.0" do
+        r.hset("foo", "f1", "s1")
+
+        assert_equal ["s1"], r.hgetdel("foo", "f1")
+        assert_nil r.hget("foo", "f1")
+      end
+    end
+
+    def test_splat_hgetdel
+      target_version "8.0.0" do
+        r.hset("foo", "f1", "s1", "f2", "s2")
+
+        assert_equal ["s1", "s2"], r.hgetdel("foo", "f1", "f2")
+
+        assert_nil r.hget("foo", "f1")
+        assert_nil r.hget("foo", "f2")
+      end
+    end
+
+    def test_variadic_hgetdel
+      target_version "8.0.0" do
+        r.hset("foo", "f1", "s1", "f2", "s2")
+
+        assert_equal ["s1", "s2"], r.hgetdel("foo", ["f1", "f2"])
+
+        assert_nil r.hget("foo", "f1")
+        assert_nil r.hget("foo", "f2")
+      end
+    end
+
+    def test_hgetdel_with_a_missing_field
+      target_version "8.0.0" do
+        r.hset("foo", "f1", "s1")
+
+        assert_equal ["s1", nil], r.hgetdel("foo", "f1", "f2")
+        assert_nil r.hget("foo", "f1")
+      end
+    end
+
+    def test_hgetdel_removes_the_key_when_the_last_field_is_deleted
+      target_version "8.0.0" do
+        r.hset("foo", "f1", "s1")
+
+        r.hgetdel("foo", "f1")
+
+        assert_equal false, r.exists?("foo")
+      end
+    end
+
+    def test_hgetdel_on_a_missing_key
+      target_version "8.0.0" do
+        assert_equal [nil, nil], r.hgetdel("foo", "f1", "f2")
+        assert_equal false, r.exists?("foo")
+      end
+    end
+
+    def test_hgetdel_on_the_wrong_type
+      target_version "8.0.0" do
+        r.rpush("foo", "s1")
+
+        assert_raises(Redis::CommandError) do
+          r.hgetdel("foo", "f1")
+        end
+      end
+    end
+
+    def test_hgetex
+      target_version "8.0.0" do
+        r.hset("foo", "f1", "s1", "f2", "s2")
+
+        assert_equal ["s1", "s2"], r.hgetex("foo", "f1", "f2")
+        assert_equal [-1, -1], r.httl("foo", "f1", "f2")
+      end
+    end
+
+    def test_hgetex_with_a_missing_field
+      target_version "8.0.0" do
+        r.hset("foo", "f1", "s1")
+
+        assert_equal ["s1", nil], r.hgetex("foo", "f1", "f2")
+      end
+    end
+
+    def test_hgetex_on_a_missing_key
+      target_version "8.0.0" do
+        assert_equal [nil, nil], r.hgetex("foo", "f1", "f2")
+        assert_equal false, r.exists?("foo")
+      end
+    end
+
+    def test_hgetex_with_ex
+      target_version "8.0.0" do
+        r.hset("foo", "f1", "s1")
+
+        assert_equal ["s1"], r.hgetex("foo", "f1", ex: 4)
+        assert_in_range(1..4, r.httl("foo", "f1")[0])
+      end
+    end
+
+    def test_hgetex_with_px
+      target_version "8.0.0" do
+        r.hset("foo", "f1", "s1")
+
+        assert_equal ["s1"], r.hgetex("foo", "f1", px: 500)
+        assert_in_range(1..500, r.hpttl("foo", "f1")[0])
+      end
+    end
+
+    def test_hgetex_with_exat
+      target_version "8.0.0" do
+        r.hset("foo", "f1", "s1")
+
+        assert_equal ["s1"], r.hgetex("foo", "f1", exat: Time.now.to_i + 400)
+        assert_in_range(1..405, r.httl("foo", "f1")[0])
+      end
+    end
+
+    def test_hgetex_with_pxat
+      target_version "8.0.0" do
+        r.hset("foo", "f1", "s1")
+
+        now_ms = (Time.now.to_f * 1000).to_i
+        assert_equal ["s1"], r.hgetex("foo", "f1", pxat: now_ms + 400_000)
+        assert_in_range(1..405_000, r.hpttl("foo", "f1")[0])
+      end
+    end
+
+    def test_hgetex_with_persist
+      target_version "8.0.0" do
+        r.hset("foo", "f1", "s1")
+        r.hexpire("foo", 100, "f1")
+
+        assert_equal ["s1"], r.hgetex("foo", "f1", persist: true)
+        assert_equal [-1], r.httl("foo", "f1")
+      end
+    end
+
+    def test_hgetex_on_the_wrong_type
+      target_version "8.0.0" do
+        r.rpush("foo", "s1")
+
+        assert_raises(Redis::CommandError) do
+          r.hgetex("foo", "f1")
+        end
+      end
+    end
+
+    def test_hgetex_with_incompatible_expiration_options
+      target_version "8.0.0" do
+        assert_raises(ArgumentError) { r.hgetex("foo", "f1", ex: 60, px: 60_000) }
+        assert_raises(ArgumentError) { r.hgetex("foo", "f1", ex: 60, persist: true) }
+      end
+    end
+
+    def test_hsetex
+      target_version "8.0.0" do
+        assert_equal 1, r.hsetex("foo", "f1", "v1", "f2", "v2")
+
+        assert_equal "v1", r.hget("foo", "f1")
+        assert_equal "v2", r.hget("foo", "f2")
+        assert_equal [-1, -1], r.httl("foo", "f1", "f2")
+      end
+    end
+
+    def test_hsetex_with_a_hash
+      target_version "8.0.0" do
+        assert_equal 1, r.hsetex("foo", { "f1" => "v1", "f2" => "v2" })
+
+        assert_equal "v1", r.hget("foo", "f1")
+        assert_equal "v2", r.hget("foo", "f2")
+      end
+    end
+
+    def test_hsetex_with_ex
+      target_version "8.0.0" do
+        assert_equal 1, r.hsetex("foo", "f1", "v1", ex: 4)
+
+        assert_equal "v1", r.hget("foo", "f1")
+        assert_in_range(1..4, r.httl("foo", "f1")[0])
+      end
+    end
+
+    def test_hsetex_with_px
+      target_version "8.0.0" do
+        assert_equal 1, r.hsetex("foo", "f1", "v1", px: 500)
+
+        assert_in_range(1..500, r.hpttl("foo", "f1")[0])
+      end
+    end
+
+    def test_hsetex_with_exat
+      target_version "8.0.0" do
+        assert_equal 1, r.hsetex("foo", "f1", "v1", exat: Time.now.to_i + 400)
+
+        assert_in_range(1..405, r.httl("foo", "f1")[0])
+      end
+    end
+
+    def test_hsetex_with_pxat
+      target_version "8.0.0" do
+        now_ms = (Time.now.to_f * 1000).to_i
+        assert_equal 1, r.hsetex("foo", "f1", "v1", pxat: now_ms + 400_000)
+
+        assert_in_range(1..405_000, r.hpttl("foo", "f1")[0])
+      end
+    end
+
+    def test_hsetex_with_keepttl
+      target_version "8.0.0" do
+        r.hsetex("foo", "f1", "v1", ex: 100)
+
+        assert_equal 1, r.hsetex("foo", "f1", "v2", keepttl: true)
+
+        assert_equal "v2", r.hget("foo", "f1")
+        assert_in_range(1..100, r.httl("foo", "f1")[0])
+      end
+    end
+
+    def test_hsetex_with_fnx
+      target_version "8.0.0" do
+        assert_equal 1, r.hsetex("foo", "f1", "v1", fnx: true)
+        assert_equal "v1", r.hget("foo", "f1")
+
+        assert_equal 0, r.hsetex("foo", "f1", "v2", "f2", "v2", fnx: true)
+        assert_equal "v1", r.hget("foo", "f1")
+        assert_nil r.hget("foo", "f2")
+      end
+    end
+
+    def test_hsetex_with_fxx
+      target_version "8.0.0" do
+        assert_equal 0, r.hsetex("foo", "f1", "v1", fxx: true)
+        assert_nil r.hget("foo", "f1")
+
+        r.hset("foo", "f1", "v1")
+
+        assert_equal 1, r.hsetex("foo", "f1", "v2", fxx: true)
+        assert_equal "v2", r.hget("foo", "f1")
+      end
+    end
+
+    def test_hsetex_with_incompatible_options
+      target_version "8.0.0" do
+        assert_raises(ArgumentError) { r.hsetex("foo", "f1", "v1", ex: 60, keepttl: true) }
+        assert_raises(ArgumentError) { r.hsetex("foo", "f1", "v1", ex: 60, px: 60_000) }
+        assert_raises(ArgumentError) { r.hsetex("foo", "f1", "v1", fnx: true, fxx: true) }
+      end
+    end
+
+    def test_hsetex_on_the_wrong_type
+      target_version "8.0.0" do
+        r.rpush("foo", "s1")
+
+        assert_raises(Redis::CommandError) do
+          r.hsetex("foo", "f1", "v1")
+        end
+      end
+    end
+
     def test_hexists
       assert_equal false, r.hexists("foo", "f1")
 

--- a/test/lint/hashes.rb
+++ b/test/lint/hashes.rb
@@ -233,6 +233,15 @@ module Lint
       end
     end
 
+    def test_variadic_hsetex
+      target_version "8.0.0" do
+        assert_equal 1, r.hsetex("foo", ["f1", "v1", "f2", "v2"])
+
+        assert_equal "v1", r.hget("foo", "f1")
+        assert_equal "v2", r.hget("foo", "f2")
+      end
+    end
+
     def test_hsetex_with_a_hash
       target_version "8.0.0" do
         assert_equal 1, r.hsetex("foo", { "f1" => "v1", "f2" => "v2" })


### PR DESCRIPTION
Added support for missing HGETDEL/HGETEX/HSETEX commands

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive hash command wrappers with local argument validation; behavior depends on Redis 8.0 server support and can change field TTLs when expiry options are used.
> 
> **Overview**
> Adds Ruby client support for Redis **8.0** hash-field commands **`HGETDEL`**, **`HGETEX`**, and **`HSETEX`** on the main client and **`Redis::Distributed`**.
> 
> **`hgetdel`** returns values for the requested fields and removes them in one round trip, using the `FIELDS` count form like other hash-field APIs. **`hgetex`** reads fields and can optionally apply per-field expiry (`ex`/`px`/`exat`/`pxat`) or **`persist`**; incompatible expiry options are rejected in Ruby before sending. **`hsetex`** sets field/value pairs (array or hash, like **`hset`**) with optional **`fnx`**/**`fxx`** and the same expiry/ **`keepttl`** knobs, again with client-side mutual-exclusion checks.
> 
> Lint tests under **`target_version "8.0.0"`** cover splat/array fields, missing keys/fields, wrong types, TTL behavior, and **`ArgumentError`** cases for bad option combinations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50aed44c3b769f43aaf37a075ff2456fd7925fec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->